### PR TITLE
Use cozy-ui assets in project

### DIFF
--- a/stylus/index.js
+++ b/stylus/index.js
@@ -10,10 +10,14 @@
 'use strict'
 
 var path = require('path')
+var stylus = require('stylus')
 
 var plugin = function () {
   return function (style) {
     style.set('include css', true)
+    style.define('embed', stylus.url({
+      paths: [path.join(__dirname, '../assets')]
+    }))
     style.import(require.resolve('normalize.css'))
     style.import(path.join(__dirname, './index.styl'))
     return style


### PR DESCRIPTION
This PR brings an `embed` method that can be called to, well… embed assets in final CSS :). It uses and extended lookup path, so it first tries to load the assets relatively to the cozy-ui's _assets_ folder and then fallback to a relative way from the CSS.

You can pass it `utf8` as a second arg, so it'll uses a utf-8 encoding rather than a base64 (useful with SVG) for embeding.