### PR TITLE
Fix 'Path must be a string. Received undefined' embed ⟹ embedurl

### DIFF
--- a/stylus/ui-base/icons.styl
+++ b/stylus/ui-base/icons.styl
@@ -52,16 +52,16 @@ $icon-spinner-grey
     @extend $icon
     @extend $icon-centered
     @extend $spin-anim
-    background-image embed('../../assets/icons/spinner-grey.svg')
+    background-image embedurl('../../assets/icons/spinner-grey.svg')
 
 $icon-spinner-white
     @extend $icon
     @extend $icon-centered
     @extend $spin-anim
-    background-image embed('../../assets/icons/spinner-white.svg')
+    background-image embedurl('../../assets/icons/spinner-white.svg')
 
 $icon-spinner-small-blue
     @extend $icon
     @extend $icon-16
     @extend $spin-anim
-    background-image embed('../../assets/icons/spinner-blue.svg')
+    background-image embedurl('../../assets/icons/spinner-blue.svg')


### PR DESCRIPTION
I guess this is a typo and it seems to fix the error on `yarn run build` (which I did not get with `yarn run watch`, cannot know why) with an error like below (@kosssi faced earlier):

```
    ERROR in ./~/css-loader?importLoaders=1&modules!./~/postcss-loader!./~/stylus-loader!./src/styles/table.styl
    Module build failed: TypeError: /Users/enguerran/Development/Cozy/cozy-files-v3/src/styles/table.styl:82:1
       78| 
       79|     td.fil-content-file
       80|       left-padded(61px)
       81|       background-position em(16px) center
       82| 
    -------^
    
    Path must be a string. Received undefined
```

PS : I do not know stylus' syntax, so I may be wrong.

See https://github.com/cozy/cozy-ui/commit/43e9580d264aca15148cab95f5b51b867ba4643a and https://github.com/cozy/cozy-ui/commit/be098ea574ca07888a2a40688290d2b9cc924d12 for error introduction.