### PR TITLE
Better alerts

### DIFF
--- a/stylus/cozy-ui/defaults.styl
+++ b/stylus/cozy-ui/defaults.styl
@@ -58,6 +58,12 @@ body
     &.coz-btn--alert-error
         @extend $button--alert-error
 
+    &.coz-btn--alert-info
+        @extend $button--alert-info
+
+    &.coz-btn--alert-success
+        @extend $button--alert-success
+
 
 // FORMS
 @import '../ui-app/forms'

--- a/stylus/ui-app/alerts.styl
+++ b/stylus/ui-app/alerts.styl
@@ -19,7 +19,15 @@ $alerts
         left       0
         background white
         opacity    .6
-        transition opacity ease-out .3s
+        visibility visible
+        transition opacity .3s, visibility 0s ease-out
+
+        &.coz-overlay--hidden
+            opacity          0
+            visibility       hidden
+            transition       opacity .3s, visibility 0s ease-in
+            transition-delay 0s, .3s
+
 
     .coz-alert
         display          block
@@ -45,17 +53,20 @@ $alerts
         .coz-alert-title
             font-weight bold
 
-    .coz-alert--error
-        background-color pomegranate
-
-    &.coz-alerter--hidden
-        .coz-alert
+        &.coz-alert--hidden
             top                        -25%
             opacity                    0
             transition-timing-function ease-in
 
-        .coz-overlay
-            opacity 0
+    .coz-alert--error
+        background-color pomegranate
+
+    .coz-alert--success
+        background-color emerald
+
+    .coz-alert--info
+        background-color grey-12
+
 
     @media all and (min-width alert-width)
         .coz-alert

--- a/stylus/ui-app/alerts.styl
+++ b/stylus/ui-app/alerts.styl
@@ -25,8 +25,7 @@ $alerts
         &.coz-overlay--hidden
             opacity          0
             visibility       hidden
-            transition       opacity .3s, visibility 0s ease-in
-            transition-delay 0s, .3s
+            transition       opacity .3s 0s, visibility 0s ease-in .3s
 
 
     .coz-alert

--- a/stylus/ui-base/palette.styl
+++ b/stylus/ui-base/palette.styl
@@ -21,6 +21,7 @@ grey-08 = #32363F
 grey-09 = #D6D8Da
 grey-10 = #F5F6F7
 grey-11 = #95999D
+grey-12 = #5D6165
 
 // more of cozy UI
 // blue

--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -42,6 +42,31 @@ $button--alert-error
     &:hover
         color     darken(pomegranate, 25%)
 
+$button--alert-info
+    color               white
+    background-color    grey-11
+    border              none
+    font-weight         bold
+    margin              .5rem 0 0
+    padding             .5rem 1rem
+    height              auto
+    border-radius       em(3px)
+
+    &:hover
+        color     darken(white, 10%)
+
+$button--alert-success
+    color         emerald
+    border        none
+    font-weight   bold
+    margin        .5rem 0 0
+    padding       .5rem 1rem
+    height        auto
+    border-radius em(3px)
+
+    &:hover
+        color     darken(emerald, 25%)
+
 $buttons
     [role=button],
     button

--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -40,7 +40,7 @@ $button--alert-error
     border-radius em(3px)
 
     &:hover
-        color     darken(pomegranate, 25%)
+        color darken(pomegranate, 25%)
 
 $button--alert-info
     color               white
@@ -53,7 +53,7 @@ $button--alert-info
     border-radius       em(3px)
 
     &:hover
-        color     darken(white, 10%)
+        color darken(white, 10%)
 
 $button--alert-success
     color         emerald
@@ -65,7 +65,7 @@ $button--alert-success
     border-radius em(3px)
 
     &:hover
-        color     darken(emerald, 25%)
+        color darken(emerald, 25%)
 
 $buttons
     [role=button],


### PR DESCRIPTION
* __Class changes__: I didn't noticed but the previous class `.coz-alerter--hidden` was not compatible with a way to stack alerts (the hiding system worked by 'hiding' the alerter instead of just the alert). So I changed to use `.coz-alert--hidden` and `.coz-overlay--hidden` instead of `.coz-alerter--hidden`.
It's now compatible with a generic alerts system introduced in `cozy-settings` in this [PR](https://github.com/cozy/cozy-settings/pull/2/files#diff-6ff124af85549596cf89cf814b4de476)
* Improve overlay fadeout transition by using `visibility` property
* Add buttons classes for `info` (grey) and `success` (green) alert types.