### PR TITLE
Set viewport to [role=application]

### DIFF
--- a/stylus/cozy-ui/defaults.styl
+++ b/stylus/cozy-ui/defaults.styl
@@ -9,6 +9,12 @@
     @extend $hidden
 
 
+// LAYOUT
+[role=application]
+    width  100vw
+    height 100vh
+
+
 // BOXES
 @import '../ui-base/boxes'
 [aria-hidden=true]

--- a/stylus/ui-app/layouts.styl
+++ b/stylus/ui-app/layouts.styl
@@ -14,9 +14,10 @@ $content-center
 
 // NB: Not to be used on it's own. Use one of the others placeholders below (with drawer or sticky sidebar)
 $app-2panes
-    display flex
-    width   100vw
-    height  100vh
+    box-sizing border-box
+    display    flex
+    width      100%
+    height     100%
 
     main
     & > aside


### PR DESCRIPTION
This PR assumes that cozy apps always uses a `[role=application]` root element, and enforces it to be set to all viewport, rather than relying on the `$app-2panes` ruleset for this.