### PR TITLE
[fix] remove input css outline on focus

### DIFF
--- a/stylus/ui-app/forms.styl
+++ b/stylus/ui-app/forms.styl
@@ -72,6 +72,7 @@ $form-text
         &:focus
             border     1px solid dodger-blue
             background none
+            outline    0
         &:hover
             border 1px solid grey-11
         &.error


### PR DESCRIPTION
At least Chrome applies a default blue outline when focusing an input; this outlines covers the border color we define on hover, focus and error, making them all look the same. 
This PR removes the outline on focus.