### PR TITLE
[fix] Reduced alerter delay

### DIFF
--- a/react/Alerter/index.jsx
+++ b/react/Alerter/index.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 
 import styles from './index.styl'
 
-const DEFAULT_AUTOCLOSE_DELAY = 5000
+const DEFAULT_AUTOCLOSE_DELAY = 3500
 
 class Alerter extends Component {
 


### PR DESCRIPTION
As discussed with @jsilvestre, this PR reduces the alerter's default duration to 3.5 seconds.