### PR TITLE
[feat] Added mobile styles for alerts

### DIFF
--- a/react/Alerter/index.styl
+++ b/react/Alerter/index.styl
@@ -1,5 +1,6 @@
 @import '../../stylus/ui-base/fonts'
 @import '../../stylus/ui-base/palette'
+@import '../../stylus/ui-base/spacers'
 @import '../../stylus/ui-components/alerts'
 
 .coz-alerter

--- a/stylus/ui-app/layouts.styl
+++ b/stylus/ui-app/layouts.styl
@@ -43,6 +43,7 @@ $app-2panes-sticky
             left 0
             bottom 0
             width 100%
+            z-index 10
 
 // DRAWER layout
 // When you want the sidebar to act like a drawer

--- a/stylus/ui-components/alerts.styl
+++ b/stylus/ui-components/alerts.styl
@@ -20,7 +20,7 @@ $alerts
         background-color emerald
         box-shadow       0 em(6px) em(18px) 0 rgba(50, 54, 63, .23)
         box-sizing       border-box
-        padded(.8em, 1em)
+        padded           .8em, 1em
         color            white
         opacity          1
         transition       bottom .5s ease-out, top .5s ease-out, opacity .2s ease-out
@@ -50,14 +50,14 @@ $alerts
 
     @media all and (min-width alert-width)
         .coz-alert
-            top              em(16px)
-            bottom           auto
-            left             50%
-            margin-left      -(alert-width / 2)
-            max-width        alert-width
-            padded(1em, 1.5em)
-            width            100%
-            border-radius    em(10px)
+            top           em(16px)
+            bottom        auto
+            left          50%
+            margin-left   -(alert-width / 2)
+            max-width     alert-width
+            padded        1em, 1.5em
+            width         100%
+            border-radius em(10px)
 
             &.coz-alert--hidden
                 top -25%

--- a/stylus/ui-components/alerts.styl
+++ b/stylus/ui-components/alerts.styl
@@ -7,12 +7,9 @@
 
 $alerts
     alert-width = em(480px)
-    .coz-alerter
-        z-index 100
-
     .coz-alert
         display          block
-        z-index          100
+        z-index          5
         position         fixed
         bottom           50px
         left             0
@@ -50,6 +47,7 @@ $alerts
 
     @media all and (min-width alert-width)
         .coz-alert
+            z-index       100
             top           em(16px)
             bottom        auto
             left          50%

--- a/stylus/ui-components/alerts.styl
+++ b/stylus/ui-components/alerts.styl
@@ -10,39 +10,20 @@ $alerts
     .coz-alerter
         z-index 100
 
-    .coz-overlay
-        position   absolute
-        height     100%
-        width      100%
-        top        0
-        left       0
-        background white
-        opacity    .6
-        visibility visible
-        transition opacity .3s, visibility 0s ease-out
-
-        &.coz-overlay--hidden
-            opacity          0
-            visibility       hidden
-            transition       opacity .3s 0s, visibility 0s ease-in .3s
-
-
     .coz-alert
         display          block
         z-index          100
-        position         absolute
-        top              em(16px)
+        position         fixed
+        bottom           50px
         left             0
-        margin           0 em(16px)
-        border-radius    em(10px)
+        right            0
         background-color emerald
         box-shadow       0 em(6px) em(18px) 0 rgba(50, 54, 63, .23)
         box-sizing       border-box
-        padding          1em 1.5em
+        padded(.8em, 1em)
         color            white
         opacity          1
-
-        transition       top .5s ease-out, opacity .2s ease-out
+        transition       bottom .5s ease-out, top .5s ease-out, opacity .2s ease-out
         cursor           pointer
 
         p
@@ -53,7 +34,7 @@ $alerts
             font-weight bold
 
         &.coz-alert--hidden
-            top                        -25%
+            bottom                     -25%
             opacity                    0
             transition-timing-function ease-in
 
@@ -69,7 +50,14 @@ $alerts
 
     @media all and (min-width alert-width)
         .coz-alert
-            left        50%
-            max-width   alert-width
-            margin-left -(alert-width/2)
-            width       100%
+            top              em(16px)
+            bottom           auto
+            left             50%
+            margin-left      -(alert-width / 2)
+            max-width        alert-width
+            padded(1em, 1.5em)
+            width            100%
+            border-radius    em(10px)
+
+            &.coz-alert--hidden
+                top -25%


### PR DESCRIPTION
Update the alerter style to work on mobile.

The `coz-overlay` class is removed because it is never actually used.

Just a head's up, when this PR is merged I'm going to need a new published version of cozy-ui :-)