### PR TITLE
Labels in pop overs

### DIFF
--- a/stylus/ui-components/popover.styl
+++ b/stylus/ui-components/popover.styl
@@ -27,6 +27,7 @@ $popover
         border-top  1px solid grey-09
 
     a
+    [role=button]
         display          block
         padding          em(8px) em(32px) em(8px) em(42px)
         color            grey-08

--- a/stylus/ui-components/popover.styl
+++ b/stylus/ui-components/popover.styl
@@ -27,6 +27,7 @@ $popover
         border-top  1px solid grey-09
 
     a
+    button
     [role=button]
         display          block
         padding          em(8px) em(32px) em(8px) em(42px)


### PR DESCRIPTION
Some elements in popover menus are not links, they are buttons, but they all look the same.