### PR TITLE
[fix] Font family issue

### DIFF
--- a/stylus/cozy-ui/defaults.styl
+++ b/stylus/cozy-ui/defaults.styl
@@ -22,6 +22,12 @@ body
     font 1em/1.5
     @extend $font-labor
 
+button
+input
+optgroup
+select
+textarea
+    @extend $font-labor
 
 // UTILS
 @import '../ui-base/mixins'


### PR DESCRIPTION
This is a proposed fix for #54 (sorry, it bothers me every time I see it, and I see it a lot :D).
Normalize.css only defines `font-family` on 4 occasions, two of which are legitimate, one is the body that we already override, and the last one is the situation that I override in this PR.