### PR TITLE
[fix] Arrange sidebar height and selectionbar bottom offset on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Avoid hover effect on disabled buttons
+- Improve sidebar height on mobile, to be equal to selection bottom offset
 
 ### Added
 - Class .coz-link--upload to use for an upload button in a menu

--- a/stylus/ui-app/sidebar.styl
+++ b/stylus/ui-app/sidebar.styl
@@ -10,4 +10,4 @@ $sidebar
         @media (max-width: (1023/basefont)rem)
             border-top   1px solid grey-09
             border-left  none
-            height       em(50px, 16px)
+            height       em(48px, 16px)

--- a/stylus/ui-app/sidebar.styl
+++ b/stylus/ui-app/sidebar.styl
@@ -10,3 +10,4 @@ $sidebar
         @media (max-width: (1023/basefont)rem)
             border-top   1px solid grey-09
             border-left  none
+            height       em(50px, 16px)

--- a/stylus/ui-components/selectionbar.styl
+++ b/stylus/ui-components/selectionbar.styl
@@ -75,7 +75,7 @@ $selectionbar
     @media (max-width: (1023/basefont)rem)
         .coz-selectionbar
             top              auto
-            bottom           em(50px)
+            bottom           em(50px, 16px)
             justify-content  flex-start
             height           em(48px)
             padding-left     1em

--- a/stylus/ui-components/selectionbar.styl
+++ b/stylus/ui-components/selectionbar.styl
@@ -77,7 +77,7 @@ $selectionbar
             top              auto
             bottom           em(48px, 16px)
             justify-content  flex-start
-            height           em(48px)
+            height           em(48px, 16px)
             padding-left     1em
             padding-right    1em
 

--- a/stylus/ui-components/selectionbar.styl
+++ b/stylus/ui-components/selectionbar.styl
@@ -75,7 +75,7 @@ $selectionbar
     @media (max-width: (1023/basefont)rem)
         .coz-selectionbar
             top              auto
-            bottom           em(50px, 16px)
+            bottom           em(48px, 16px)
             justify-content  flex-start
             height           em(48px)
             padding-left     1em


### PR DESCRIPTION
There was an issue on photo in mobile mode, a little gap between selection bar and side bar. This commit fixes the problem.