### PR TITLE
[fix] Layout height

### DIFF
--- a/stylus/ui-app/layouts.styl
+++ b/stylus/ui-app/layouts.styl
@@ -53,7 +53,6 @@ $app-2panes
 $app-2panes-sticky
     @extend     $app-2panes
     flex        0 0 100%
-    height      auto
     align-items stretch
 
     main,


### PR DESCRIPTION
In every browser, Files was looking like this:
![image](https://cloud.githubusercontent.com/assets/776764/23729624/4a5c84ac-0463-11e7-9e87-6d1abf4fd53e.png)

Removing `height: auto` solves the issue on Firefox, Chrome, and also Safari (except it show a vertical scrollbar).