### PR TITLE
Fix/microfix

### DIFF
--- a/stylus/ui-app/layouts.styl
+++ b/stylus/ui-app/layouts.styl
@@ -41,6 +41,7 @@ $app-2panes
 
     main,
     main > [role=contentinfo]
+        position        relative
         display         flex
         flex-direction  column
         flex            1 1 auto

--- a/stylus/ui-base/icons.styl
+++ b/stylus/ui-base/icons.styl
@@ -22,20 +22,20 @@ $icon
 \*------------------------------------*/
 
 $icon-12
-    width   em(12px, basefont)
-    height  em(12px, basefont)
+    width   .75rem // 12px
+    height  .75rem
 
 $icon-16
-    width   em(16px, basefont)
-    height  em(16px, basefont)
+    width   1rem // 16px
+    height  1rem
 
 $icon-24
-    width   em(24px, basefont)
-    height  em(24px, basefont)
+    width   1.5rem // 24px
+    height  1.5rem
 
 $icon-36
-    width   em(36px, basefont)
-    height  em(36px, basefont)
+    width   2.25rem // 36px
+    height  2.25rem
 
 
 /*------------------------------------*\


### PR DESCRIPTION
- Add a position relative on [role=contentinfo] so we can position elements absolutely in it such as the loading spinner
- Change $icon-n placeholders' width & height with rem instead of em so it doesn't grow with the font-size of the parent. They should be fixed on their sizes.