### PR TITLE
Add Empty component style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-- none yet
+- Empty component style
 
 ### Removed
 - none yet

--- a/stylus/ui-components/empty.styl
+++ b/stylus/ui-components/empty.styl
@@ -22,7 +22,7 @@ $empty
         margin          em(33px) auto 0
         line-height     1.3
         color           grey-08
-        letter-spacing  -0.2px
+        letter-spacing  -.2px
     p
         margin-top   em(5px)
         color        grey-11

--- a/stylus/ui-components/empty.styl
+++ b/stylus/ui-components/empty.styl
@@ -1,0 +1,38 @@
+$empty
+    display          flex
+    flex-direction   column
+    justify-content  center
+    flex             1 0 auto
+    align-self       center
+    padding          1em 0
+    text-align       center
+
+    &:before
+        content              ''
+        display              block
+        margin               0 auto
+        width                em(160px)
+        height               em(140px)
+        background-position  center center
+        background-repeat    no-repeat
+        background-size      contain
+
+    h2
+        font-size(24px)
+        margin          em(33px) auto 0
+        line-height     1.3
+        color           grey-08
+        letter-spacing  -0.2px
+    p
+        margin-top   em(5px)
+        color        grey-11
+        line-height  1.5
+
+    @media (max-width: (1023/basefont)rem)
+        &:before
+            width   em(120px)
+            height  em(105px)
+        h2
+            margin  em(33px) 1.5em 0
+        p
+            margin  em(5px) 1.5em 0


### PR DESCRIPTION
As there was a similar empty view on Files, Photos and now Settings apps, I added it as a shared component. 
You then just need to specify the path to the icon you want in a `background-image` on the `:before`  when you extend it in your app.