### PR TITLE
[fix] Overlay position to absolute to fixed

### DIFF
--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -12,7 +12,7 @@ $modals
 
     .coz-overlay
         z-index     $modal-index
-        position    absolute
+        position    fixed
         top         0
         left        0
         height      100%


### PR DESCRIPTION
Because of the `position: relative` on [role=contentinfo] the overlay wasn't taking all the viewport.