### PR TITLE
fix: remove white background-color from more button

### DIFF
--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -116,6 +116,7 @@ $link--upload
 
 $button--more
     width                em(46px)
+    background-color     transparent
     background-image     embedurl('../assets/icons/ui/icon-dots.svg')
     background-position  center center
     background-repeat    no-repeat


### PR DESCRIPTION
Removed white background from "more button" as it is mostly used in parents with already a white background and can cause some inconvenience in some case

Basically, the more button doesn't have a white background by default anymore.