### PR TITLE
feat: add ModalContent component

### DIFF
--- a/react/Modal/Content.jsx
+++ b/react/Modal/Content.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import styles from './styles.styl'
+
+const ModalContent = ({children}) =>
+  (<div className={styles['coz-modal-content']}>
+    {children}
+  </div>)
+
+export default ModalContent


### PR DESCRIPTION
Using this component helped me to avoid repeating CSS code from `.coz-modal-content`.

For example I have not been able to retrieve padding properties from `.coz-modal-content` class, like this :

```jsx
<Modal>
  <div className='{styles['coz-modal-content']}'>
     My content
  </div>
</Modal>
```
But now with this component I can do :

```jsx
<Modal>
  <ModalContent>
     My content
  </ModalContent>
</Modal>
```
And I got the correct padding, it works like a charm.

I think we could do the same for example the modal sections used in cozy-photos.

After discussing with @GoOz, to make CozyUI usable, I think we need to aim a "two flavor Cozy UI" :
 * One usable as a bootstrap CSS framework
 * Another one based on React Components libraries, usable as it, based on the CSS framework part.

This PR tries to make a first step for the React Components lib.