### PR TITLE
fix(button): missing import

### DIFF
--- a/react/Button.jsx
+++ b/react/Button.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import cx from 'classnames'
 
 export default function (props) {


### PR DESCRIPTION
The production build breaks since React was not imported.

It is a bit problematic that the linter does not catch this problem.

If the linter cannot be configured to detect this, maybe the ProvidePlugin could be used ?

```
new webpack.ProvidePlugin({ React: 'preact-compat' })
```