### PR TITLE
fix: there is no button.primary style :lipstick:

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -78,7 +78,7 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   primaryType: 'secondary',
-  secondaryType: 'primary',
+  secondaryType: 'regular',
   withCross: true
 }
 


### PR DESCRIPTION
I though I already fix that, but it seems to be back.

`s/primary/regular/` to fit button's classes.