### PR TITLE
chore: export styles so that external components can use it

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import styles from './styles.styl'
+import Content from './Content'
 
 const ModalTitle = ({ title }) =>
   (
@@ -82,5 +83,5 @@ Modal.defaultProps = {
   withCross: true
 }
 
-export { styles }
+export { Content }
 export default Modal

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -82,4 +82,5 @@ Modal.defaultProps = {
   withCross: true
 }
 
+export { styles }
 export default Modal


### PR DESCRIPTION
To be able to get styles['coz-modal-content'] from external components.

import Modal, { styles as modalStyles } from 'cozy-ui/react/Modal'
