### PR TITLE
feat: Avoid overflowing for modal

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -83,16 +83,17 @@ class Modal extends Component {
     const { children, title, withCross } = this.props
     return (
       <div className={styles['coz-modal-container']}>
-        <div
-          onClick={withCross && this.handleOutsideClick}
-          className={styles['coz-overlay']}
-        >
-          <div className={styles['coz-modal']}>
-            {title && <ModalTitle {...this.props} />}
-            <ModalCross {...this.props} />
-            <ModalDescription {...this.props} />
-            { children }
-            <ModalButtons {...this.props} />
+        <div className={styles['coz-overlay']}>
+          <div
+            className={styles['coz-modal-wrapper']}
+            onClick={withCross && this.handleOutsideClick}>
+            <div className={styles['coz-modal']}>
+              {title && <ModalTitle {...this.props} />}
+              <ModalCross {...this.props} />
+              <ModalDescription {...this.props} />
+              { children }
+              <ModalButtons {...this.props} />
+            </div>
           </div>
         </div>
       </div>

--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -27,12 +27,20 @@ $modals
             transition  opacity .3s 0s, visibility 0s ease-in .3s
 
 
-    .coz-modal
+    .coz-modal-wrapper
         position          fixed
-        top               50%
-        left              50%
-        display           block
+        top               0
+        left              0
         box-sizing        border-box
+        width             100vw
+        height            100vh
+        overflow-y        scroll
+        display           flex
+        padding           (16/basefont)em
+
+    .coz-modal
+        position          relative
+        margin            auto
         border-radius     em(8px)
         max-width         90%
         height            auto
@@ -41,8 +49,6 @@ $modals
         padding           1.5em 0
         background-color  white
         color             grey-08
-        transform         translateX(-50%) translateY(-50%)
-
         .coz-modal-content
             padding 0 1.5em
 


### PR DESCRIPTION
Must be merged this afternoon.

Modal now stick to top when the viewport height is too tiny.

![capture d ecran 2017-05-29 a 14 46 56](https://cloud.githubusercontent.com/assets/776764/26550360/af107b2e-447d-11e7-8b16-838822db0b7b.png)

Requesting review from @GoOz at least for information.

I think that this PR should not trigger regression but I prefer to request reviews for the most people using the modal component as possible.