### PR TITLE
feat: remove vertical paddings in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ## [3.0.0-beta29] - 2017-XX-XX
+### Changed
+- Modal now has no padding by default. Padding are added in children or using `ModalContent` or `ModalSection` components.
 
 ### Fixed
 - Remove hover style on `[disabled]` and `[aria-disabled=true]` attribute for buttons: `$button--danger`, `$button--danger-outline` and `$button--highlight`
@@ -32,6 +34,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add a new icon variable: `$icon-spinner-red`
 - Add white spinner on buttons `$button--danger` and `$button--highlight` with `[aria-busy=true]` attribute
 - Add red spinner on `$button--danger-outline` with `[aria-busy=true]` attribute
+
+### Deprecated
+- The use of `Content` component in modals is deprecated and replaced by `ModalContent`.
 
 ## [3.0.0-beta28] - 2017-05-29
 

--- a/react/Modal/Content.jsx
+++ b/react/Modal/Content.jsx
@@ -2,9 +2,13 @@ import React from 'react'
 
 import styles from './styles.styl'
 
-const ModalContent = ({children}) =>
-  (<div className={styles['coz-modal-content']}>
-    {children}
-  </div>)
+const ModalContent = ({children}) => {
+  console.warn && console.warn('`Content` component is deprecated and will be removed soon, please use `ModalContent` instead.')
+  return (
+    <div className={styles['coz-modal-content']}>
+      {children}
+    </div>
+  )
+}
 
 export default ModalContent

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -3,13 +3,13 @@ import classNames from 'classnames'
 import Content from './Content'
 import styles from './styles.styl'
 
-const ModalContent = ({children}) =>
-  (<div className={styles['coz-modal-content']}>
+const ModalContent = ({children, className}) =>
+  (<div className={className ? classNames(styles['coz-modal-content'], className) : styles['coz-modal-content']}>
     {children}
   </div>)
 
-const ModalSection = ({children}) =>
-  (<div className={styles['coz-modal-section']}>
+const ModalSection = ({children, className}) =>
+  (<div className={className ? classNames(styles['coz-modal-section'], className) : styles['coz-modal-section']}>
     {children}
   </div>)
 

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -88,8 +88,8 @@ class Modal extends Component {
             className={styles['coz-modal-wrapper']}
             onClick={withCross && this.handleOutsideClick}>
             <div className={styles['coz-modal']}>
-              {title && <ModalTitle {...this.props} />}
               <ModalCross {...this.props} />
+              {title && <ModalTitle {...this.props} />}
               <ModalDescription {...this.props} />
               { children }
               <ModalButtons {...this.props} />

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -4,12 +4,12 @@ import Content from './Content'
 import styles from './styles.styl'
 
 const ModalContent = ({children, className}) =>
-  (<div className={className ? classNames(styles['coz-modal-content'], className) : styles['coz-modal-content']}>
+  (<div className={classNames(styles['coz-modal-content'], className)}>
     {children}
   </div>)
 
 const ModalSection = ({children, className}) =>
-  (<div className={className ? classNames(styles['coz-modal-section'], className) : styles['coz-modal-section']}>
+  (<div className={classNames(styles['coz-modal-section'], className)}>
     {children}
   </div>)
 

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -8,6 +8,11 @@ const ModalContent = ({children}) =>
     {children}
   </div>)
 
+const ModalSection = ({children}) =>
+  (<div className={styles['coz-modal-section']}>
+    {children}
+  </div>)
+
 const ModalTitle = ({ title }) =>
   (
     <h2 className={styles['coz-modal-title']}>{title}</h2>
@@ -126,4 +131,5 @@ Modal.defaultProps = {
 export { ModalContent }
  // deprecated, for retro-compatibilty only.
 export { Content }
+export { ModalSection }
 export default Modal

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -1,8 +1,12 @@
 import React, { Component } from 'react'
 import classNames from 'classnames'
-
-import styles from './styles.styl'
 import Content from './Content'
+import styles from './styles.styl'
+
+const ModalContent = ({children}) =>
+  (<div className={styles['coz-modal-content']}>
+    {children}
+  </div>)
 
 const ModalTitle = ({ title }) =>
   (
@@ -119,5 +123,7 @@ Modal.defaultProps = {
   withCross: true
 }
 
+export { ModalContent }
+ // deprecated, for retro-compatibilty only.
 export { Content }
 export default Modal

--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -44,9 +44,6 @@ $modals
         border-radius     em(8px)
         max-width         90%
         height            auto
-        // Padding is set by inner element,
-        // to be able to get horizontal separators.
-        padding           1.5em 0
         background-color  white
         color             grey-08
 
@@ -59,6 +56,13 @@ $modals
 
         .coz-modal-section
             border-top 1px solid grey-09
+
+        .coz-modal-content,
+        .coz-modal-section
+            &:first-of-type
+                padding-top    1.5em
+            &:last-of-type
+                padding-bottom 1.5em
 
         .coz-modal-title
             margin       .33em 0 1em

--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -67,8 +67,12 @@ $modals
         .coz-modal-title
             margin       .33em 0 1em
             // font is 1.5em
-            padding      0 1em
+            padding      1em 1em 0
             font-weight  bold
+
+            & + .coz-modal-content:first-of-type,
+            & + .coz-modal-section:first-of-type
+                padding-top 0
 
         .coz-btn-modal-close
             position         absolute

--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -51,7 +51,9 @@ $modals
         // overflow settings as overflowing here may
         // hide the border-radius
         overflow          hidden
-        .coz-modal-content
+
+        .coz-modal-content,
+        .coz-modal-section
             padding 0 1.5em
 
         .coz-modal-section


### PR DESCRIPTION
The goal is to avoid default vertical paddings and let <ModalContent> component add them.