### PR TITLE
Improve danger, danger-outline and hightline buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Security
 - none yet
 
+## [3.0.0-beta29] - 2017-XX-XX
+
+### Fixed
+- Remove hover style on `[disabled]` and `[aria-disabled=true]` attribute for buttons: `$button--danger`, `$button--danger-outline` and `$button--highlight`
+
+### Added
+- Add a new icon variable: `$icon-spinner-red`
+- Add white spinner on buttons `$button--danger` and `$button--highlight` with `[aria-busy=true]` attribute
+- Add red spinner on `$button--danger-outline` with `[aria-busy=true]` attribute
 
 ## [3.0.0-beta28] - 2017-05-29
 

--- a/assets/icons/ui/spinner-red.svg
+++ b/assets/icons/ui/spinner-red.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='12' height='12' fill='#F52D2D'>
+  <path opacity='.25' d='M16 0a16 16 0 0 0 0 32 16 16 0 0 0 0-32m0 4a12 12 0 0 1 0 24 12 12 0 0 1 0-24'/>
+  <path d='M16 0a16 16 0 0 1 16 16h-4a12 12 0 0 0-12-12z'/>
+</svg>

--- a/stylus/ui-base/icons.styl
+++ b/stylus/ui-base/icons.styl
@@ -72,3 +72,8 @@ $icon-spinner-blue
     @extend           $icon
     @extend           $spin-anim
     background-image  embedurl('../../assets/icons/ui/spinner-blue.svg')
+
+$icon-spinner-red
+    @extend           $icon
+    @extend           $spin-anim
+    background-image  embedurl('../../assets/icons/ui/spinner-red.svg')

--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -74,10 +74,14 @@ $button--danger
     color             white
 
     &:active
-    &:hover
+    &:not([disabled]):not([aria-disabled=true]):hover
     &:focus
         border-color      monza
         background-color  monza
+
+    &[aria-busy=true]
+        &::after
+            @extend  $icon-spinner-white
 
 $button--danger-outline
     background-color  white
@@ -85,9 +89,13 @@ $button--danger-outline
     border            1px solid your-pink
 
     &:active
-    &:hover
+    &:not([disabled]):not([aria-disabled=true]):hover
     &:focus
         background-color  your-pink
+
+    &[aria-busy=true]
+        &::after
+            @extend  $icon-spinner-red
 
 $button--highlight
     border-color      emerald
@@ -95,10 +103,14 @@ $button--highlight
     color             white
 
     &:active
-    &:hover
+    &:not([disabled]):not([aria-disabled=true]):hover
     &:focus
         border-color      malachite
         background-color  malachite
+
+    &[aria-busy=true]
+        &::after
+            @extend  $icon-spinner-white
 
 $button--share
     padding-left         em(44px, 16px)


### PR DESCRIPTION
### Fixed
- Remove hover style on `[disabled]` and `[aria-disabled=true]` attribute for buttons: `$button--danger`, `$button--danger-outline` and `$button--highlight`

### Added
- Add a new icon variable: `$icon-spinner-red`
- Add white spinner on buttons `$button--danger` and `$button--highlight` with `[aria-busy=true]` attribute
- Add red spinner on `$button--danger-outline` with `[aria-busy=true]` attribute