### PR TITLE
fix: overflow on .coz-modal

### DIFF
--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -49,6 +49,11 @@ $modals
         padding           1.5em 0
         background-color  white
         color             grey-08
+
+        // The content of the modal should manage its
+        // overflow settings as overflowing here may
+        // hide the border-radius
+        overflow          hidden
         .coz-modal-content
             padding 0 1.5em
 


### PR DESCRIPTION
The modal should not let its content overflow on its border-radius.

Before
![image](https://cloud.githubusercontent.com/assets/465582/26576371/f9bda498-4528-11e7-8a0a-be35f66f99db.png)

After
![image](https://cloud.githubusercontent.com/assets/465582/26576393/09b1214a-4529-11e7-93a2-bf1e62263cb2.png)
