### PR TITLE
fix: no hard-coded height for buttons

### DIFF
--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -16,7 +16,6 @@ $button
     margin           0 .25em
     border           1px solid white
     border-radius    2px
-    height           em(40px, 14px)
     padding          em(13px, 14px) em(15px, 14px) em(11px, 14px)
     background       transparent
     vertical-align   top

--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -16,6 +16,7 @@ $button
     margin           0 .25em
     border           1px solid white
     border-radius    2px
+    min-height       em(40px, 14px)
     padding          em(13px, 14px) em(15px, 14px) em(11px, 14px)
     background       transparent
     vertical-align   top


### PR DESCRIPTION
I am currently working on the responsive version of the EDF app.

The height of the button is hard-coded here
https://github.com/cozy/cozy-ui/blob/632a397076b2794953b26e5918457f68db17d7f1/stylus/ui-components/button.styl#L19

I think we can rely on the text setting the height of the button.

Problem
![image](https://cloud.githubusercontent.com/assets/465582/26636175/30d87108-461c-11e7-9db4-c7df6671a417.png)

Solution
![image](https://cloud.githubusercontent.com/assets/465582/26636200/44885aa6-461c-11e7-96b0-99ebf7fd592b.png)

