### PR TITLE
feat: font smoothing 💄

### DIFF
--- a/stylus/cozy-ui/defaults.styl
+++ b/stylus/cozy-ui/defaults.styl
@@ -20,6 +20,8 @@
 
 body
     font 1em/1.5
+    -moz-osx-font-smoothing grayscale
+    -webkit-font-smoothing antialiased
     @extend $font-labor
 
 // Overrides Normalize.css default style

--- a/stylus/ui-base/fonts.styl
+++ b/stylus/ui-base/fonts.styl
@@ -20,7 +20,6 @@ $font-title
 $font-labor
     font-family  Lato, sans-serif
 
-
 // Contextual fonts store, based on the selector checksum hash
 basefonts = {}
 


### PR DESCRIPTION
Fixes https://github.com/cozy/cozy-ui/issues/127

![2017-06-01 10_10_38](https://cloud.githubusercontent.com/assets/465582/26670633/a5499f94-46b2-11e7-9caf-c33e2cbb6104.gif)

To be clear : when the font is bolder (and ugly), font-smoothing is not active.
