### PR TITLE
feat: Add I18n component :construction_worker:

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "babel-preset-env": "^1.1.8",
     "babel-preset-react": "^6.22.0",
     "css-loader": "^0.26.1",
+    "date-fns": "^1.28.5",
+    "node-polyglot": "^2.2.2",
     "npm-run-all": "^4.0.1",
     "postcss-loader": "^1.2.2",
     "preact": "^7.1.0",

--- a/react/I18n/format.js
+++ b/react/I18n/format.js
@@ -1,0 +1,16 @@
+import format from 'date-fns/format'
+import { DEFAULT_LANG } from '.'
+
+export const initFormat = (lang, defaultLang = DEFAULT_LANG) => {
+  const locales = {
+    [defaultLang]: require(`date-fns/locale/${defaultLang}/index`)
+  }
+  if (lang && lang !== defaultLang) {
+    try {
+        locales[lang] = require(`date-fns/locale/${lang}/index`)
+    } catch (e) {
+      console.warn(`The "${lang}" locale isn't supported by date-fns`)
+    }
+  }
+  return (date, formatStr) => format(date, formatStr, { locale: locales[lang] })
+}

--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -1,0 +1,66 @@
+/**
+ * preact plugin that provides an I18n helper using a Higher Order Component.
+ */
+
+'use strict'
+
+import React, { Component } from 'react'
+
+import { initTranslation } from './translation'
+import { initFormat } from './format'
+
+export const DEFAULT_LANG = 'en'
+
+// Provider root component
+export class I18n extends Component {
+  constructor (props) {
+    super(props)
+    this.init(this.props)
+  }
+
+  init (props) {
+    const { lang, dictRequire, context, defaultLang } = props
+
+    this.translation = initTranslation(lang, dictRequire, context, defaultLang)
+    this.format = initFormat(lang, defaultLang)
+  }
+
+  getChildContext () {
+    return {
+      t: this.translation.t.bind(this.translation),
+      f: this.format
+    }
+  }
+
+  componentWillReceiveProps (newProps) {
+    if (newProps.locale !== this.props.locale) {
+      this.init(newProps)
+    }
+  }
+
+  render () {
+    return (this.props.children && this.props.children[0]) || null
+  }
+}
+
+I18n.propTypes = {
+  lang: React.PropTypes.string.isRequired,      // current language.
+  dictRequire: React.PropTypes.func.isRequired, // A callback to load locales.
+  context: React.PropTypes.string,              // current context.
+  defaultLang: React.PropTypes.string           // default language. By default is 'en'
+}
+
+I18n.childContextTypes = {
+  t: React.PropTypes.func,
+  f: React.PropTypes.func
+}
+
+// higher order decorator for components that need `t` and/or `f`
+export const translate = () => {
+  return (WrappedComponent) => {
+    const _translate = (props, context) => (
+      <WrappedComponent {...props} t={context.t} f={context.f} />
+    )
+    return _translate
+  }
+}

--- a/react/I18n/translation.js
+++ b/react/I18n/translation.js
@@ -1,0 +1,30 @@
+import Polyglot from 'node-polyglot'
+import { DEFAULT_LANG } from '.'
+
+export let _polyglot
+
+export const initTranslation = (lang, dictRequire, context, defaultLang = DEFAULT_LANG) => {
+  _polyglot = new Polyglot({
+    phrases: dictRequire(defaultLang),
+    locale: defaultLang
+  })
+
+  // Load global locales
+  if (lang && lang !== defaultLang) {
+    try {
+      const dict = dictRequire(lang)
+      _polyglot.extend(dict)
+      _polyglot.locale(lang)
+    } catch (e) {
+      console.warn(`The dict phrases for "${lang}" can't be loaded`)
+    }
+  }
+
+  // Load context locales
+  if (context) {
+    const dict = dictRequire(lang, context)
+    _polyglot.extend(dict)
+  }
+
+  return _polyglot
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,6 +1303,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.28.5:
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -1498,7 +1502,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.4.3:
+es-abstract@^1.4.3, es-abstract@^1.5.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
   dependencies:
@@ -1802,6 +1806,12 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+for-each@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+  dependencies:
+    is-function "~1.0.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -2200,6 +2210,10 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-function@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -2694,6 +2708,15 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
+
+node-polyglot@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.2.2.tgz#1a3f76d7392f836ea0823836ede817e6ea6ec26c"
+  dependencies:
+    for-each "^0.3.2"
+    has "^1.0.1"
+    string.prototype.trim "^1.1.2"
+    warning "^3.0.0"
 
 node-pre-gyp@^0.6.29:
   version "0.6.33"
@@ -3863,6 +3886,14 @@ string.prototype.padend@^3.0.0:
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
 
+string.prototype.trim@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -4150,6 +4181,12 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.2.0:
   version "1.3.1"


### PR DESCRIPTION
With `cozy-ui/react/I18n` you can:
- import a I18n component : `import { I18n } from 'cozy-ui/react/I18n'`
- import default lang of cozy : `import { DEFAULT_LANG } from 'cozy-ui/react/I18n'` is `en`
- import translate décorator : `import { translate } from 'cozy-ui/react/I18n'`

## I18n component

A small example to use I18n component:

    <I18n lang={lang} dictRequire={(lang) => require(`./locales/${lang}`)}>

With context:

    const dictRequire = (lang, context) => context
      ? require(`./contexts/${context}/locales/${lang}`)
      : require(`./locales/${lang}`)
    ...
    <I18n context={context} lang={lang} dictRequire={dictRequire}>

With defaultLang:

    <I18n defaultLang='fr' lang={lang} dictRequire={(lang) => require(`./locales/${lang}`)}>

## Polyglot

In mobile context you can require directly polyglot with `import { _polyglot } from 'cozy-ui/react/I18n/translation')`