### PR TITLE
feat: Add SelectionBar component :shell:

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { translate } from '../I18n'
+import classNames from 'classnames'
+
+import styles from './styles.styl'
+import { getSelectedIds, hideSelectionBar } from '.'
+
+/*
+
+If you want use SelectionBar component, you must have `actions` parameter, like :
+
+actions = {
+  trash: {
+    action: selections => dispatch(trashFiles(selections)))
+  },
+  rename: {
+    action: selections => dispatch(startRenamingAsync(selected[0])),
+    displayCondition: selections => selections.length === 1
+  }
+}
+
+*/
+
+const SelectionBar = ({ t, actions, selected, hideSelectionBar }) => {
+  const selectedCount = selected.length
+  const actionNames = Object.keys(actions).filter(actionName => {
+    const action = actions[actionName]
+    return action.displayCondition === undefined || action.displayCondition(selected)
+  })
+  return (
+    <div className={styles['coz-selectionbar']} role='toolbar'>
+      <span className={styles['coz-selectionbar-count']}>
+        {selectedCount}
+        <span> {t('SelectionBar.selected_count', { smart_count: selectedCount })}</span>
+      </span>
+      <span className={styles['coz-selectionbar-separator']} />
+      {actionNames.map(actionName => (
+        <button
+          className={styles['coz-action-' + actionName.toLowerCase()]}
+          disabled={selectedCount < 1}
+          onClick={() => actions[actionName].action(selected)}
+        >
+          {t('SelectionBar.' + actionName)}
+        </button>
+      ))}
+      <button className={styles['coz-action-close']} onClick={hideSelectionBar}>
+        {t('SelectionBar.close')}
+      </button>
+    </div>
+  )
+}
+
+SelectionBar.propTypes = {
+  t: React.PropTypes.func.isRequired,               // translate action name.
+  actions: React.PropTypes.object.isRequired,       // An object with actions
+  selected: React.PropTypes.array.isRequired,       // selected items id.
+  hideSelectionBar: React.PropTypes.func.isRequired // function to close SelectionBar.
+}
+
+export default translate()(SelectionBar)

--- a/react/SelectionBar/styles.styl
+++ b/react/SelectionBar/styles.styl
@@ -1,0 +1,8 @@
+@import '../../stylus/ui-base/fonts'
+@import '../../stylus/ui-base/palette'
+@import '../../stylus/ui-base/spacers'
+@import '../../stylus/ui-components/button'
+@import '../../stylus/ui-components/selectionbar'
+
+[role=application]
+  @extend $selectionbar


### PR DESCRIPTION
This is the SelectionBar on Cozy Drive:

<img width="1280" alt="capture d ecran 2017-06-08 a 15 17 35" src="https://user-images.githubusercontent.com/1135513/26930464-c93bbd5a-4c5d-11e7-853e-493d3011dc88.png">

This is the SelectionBar on Cozy Drive mobile:

<img width="288" alt="capture d ecran 2017-06-08 a 15 18 07" src="https://user-images.githubusercontent.com/1135513/26930504-e43b6740-4c5d-11e7-8b9a-71c13a3a4d66.png">

With `cozy-ui/react/SelectionBar` you can:

```javascript
// import component
import { SelectionBar } from 'cozy-ui/react/SelectionBar'

// use component
<SelectionBar t={t} selected={seleted} actions={actions} hideSelectionBar={hideSelectionBar} />

// define actions
const mapDispatchToProps = dispatch => ({
  actions: {
    download: {
      action: selections => dispatch(downloadSelection(selections))
    },
    rename: {
      action: selections => dispatch(startRenamingAsync(selections[0])),
      displayCondition: selections => selections.length === 1
    },
    yourOwnAction: {
      action: selections => dispatch(yourOwnAction(selections),
    },
    ...
  }
})
```