### PR TITLE
CC-13 | Fix keyframes w/ css modules

### DIFF
--- a/stylus/ui-base/animations.styl
+++ b/stylus/ui-base/animations.styl
@@ -2,7 +2,7 @@
   Animations
 \*------------------------------------*/
 
-@keyframes spin
+@keyframes :global(spin)
     from
         transform rotate(0deg)
     to


### PR DESCRIPTION
This PR fixes the keyframes name scope, so they aren't mangled in output CSS