### PR TITLE
fix: closing cross size in selection bar

### DIFF
--- a/stylus/ui-components/selectionbar.styl
+++ b/stylus/ui-components/selectionbar.styl
@@ -76,12 +76,13 @@ $selectionbar
             display none
 
         .coz-action-close
-            position     absolute
-            top          50%
-            right        0
-            background-image   embedurl('../assets/icons/ui/icon-cross-white.svg')
-            text-indent  -9999px
-            transform    translateY(-50%)
+            position          absolute
+            top               50%
+            right             0
+            background-image  embedurl('../assets/icons/ui/icon-cross-white.svg')
+            background-size   1em 1em
+            text-indent       -9999px
+            transform         translateY(-50%)
 
         .coz-action-download:disabled
         .coz-action-trash:disabled


### PR DESCRIPTION
The new cross is bigger than the old one so I forced its size when in background of the closing button in the selection bar.