### PR TITLE
Add Spinner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-
+- <Spinner /> component with several options like color, size, Box-model…
 - `<Icon />` component to use cozy-ui icons easily à la [FontAwesome](http://fontawesome.io/). `Icon`s can be styled with CSS.
 
 ```jsx

--- a/react/Spinner/index.jsx
+++ b/react/Spinner/index.jsx
@@ -4,13 +4,6 @@ import classNames from 'classnames'
 
 import styles from './styles'
 
-// === Component Options ===
-// loadingType = message type from locale [string] (default: '')
-// middle      = Component is centered both vertically & horizontally [bool] (default: false)
-// noMargin    = Component has no margin [bool] (default: false)
-// color       = Color of the spinner (available colors: blue, grey, white, red) [string] (default: 'blue')
-// size        = Size of the spinner (available sizes: tiny, small, medium, large, xlarge, xxlarge) [string] (default: 'medium')
-
 export const Spinner = ({ t, loadingType, middle, noMargin, color, size }) => {
   return (
     <div

--- a/react/Spinner/index.jsx
+++ b/react/Spinner/index.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { translate } from '../helpers/I18n'
+import classNames from 'classnames'
+
+import styles from './styles'
+
+export const Spinner = ({ t, loadingType, middle, center, noMargin, color, size }) => {
+  return (
+    <div
+      className={classNames(
+        styles['coz-spinner'], {
+          [styles['coz-spinner--middle']]: middle,
+          [styles['coz-spinner--center']]: center,
+          [styles['coz-spinner--no-margin']]: noMargin,
+          [styles[`coz-spinner--${color}`]]: color,
+          [styles[`coz-spinner--${size}`]]: size
+        }
+      )}
+    >
+      {loadingType && <p>{t(`loading.${loadingType}`)}</p>}
+    </div>
+  )
+}
+
+export default translate()(Spinner)

--- a/react/Spinner/index.jsx
+++ b/react/Spinner/index.jsx
@@ -4,13 +4,19 @@ import classNames from 'classnames'
 
 import styles from './styles'
 
-export const Spinner = ({ t, loadingType, middle, center, noMargin, color, size }) => {
+// === Component Options ===
+// loadingType = message type from locale [string] (default: '')
+// middle      = Component is centered both vertically & horizontally [bool] (default: false)
+// noMargin    = Component has no margin [bool] (default: false)
+// color       = Color of the spinner (available colors: blue, grey, white, red) [string] (default: 'blue')
+// size        = Size of the spinner (available sizes: tiny, small, medium, large, xlarge, xxlarge) [string] (default: 'medium')
+
+export const Spinner = ({ t, loadingType, middle, noMargin, color, size }) => {
   return (
     <div
       className={classNames(
         styles['coz-spinner'], {
           [styles['coz-spinner--middle']]: middle,
-          [styles['coz-spinner--center']]: center,
           [styles['coz-spinner--no-margin']]: noMargin,
           [styles[`coz-spinner--${color}`]]: color,
           [styles[`coz-spinner--${size}`]]: size

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -1,0 +1,60 @@
+@import '../../stylus/ui-base/palette'
+@import '../../stylus/ui-base/icons'
+
+.coz-spinner
+    display inline-block
+
+    &:before
+        content ''
+
+    p
+        margin-top  em(15px)
+        color       grey-11
+        line-height 1.5
+
+// === Modifiers ===
+
+// Box-model
+.coz-spinner--middle
+    position   absolute
+    top        50%
+    left       50%
+    transform  translateX(-50%) translateY(-50%)
+
+.coz-spinner--center:before
+    display     block
+    margin      0 auto
+    text-align  center
+
+
+// Colors
+.coz-spinner--blue:before
+    @extend $icon-spinner-blue
+
+.coz-spinner--grey:before
+    @extend $icon-spinner-grey
+
+.coz-spinner--white:before
+    @extend $icon-spinner-white
+
+.coz-spinner--red:before
+    @extend $icon-spinner-red
+
+// Sizes
+.coz-spinner--tiny:before
+    @extend $icon-8
+
+.coz-spinner--small:before
+    @extend $icon-12
+
+.coz-spinner--medium:before
+    @extend $icon-16
+
+.coz-spinner--large:before
+    @extend $icon-24
+
+.coz-spinner--xlarge:before
+    @extend $icon-36
+
+.coz-spinner--xxlarge:before
+    @extend $icon-80

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -3,9 +3,13 @@
 
 .coz-spinner
     display inline-block
+    margin 0 .5rem
 
     &:before
         content ''
+        // Default setup
+        @extend $icon-spinner-blue
+        @extend $icon-16
 
     p
         margin-top  em(15px)
@@ -20,12 +24,14 @@
     top        50%
     left       50%
     transform  translateX(-50%) translateY(-50%)
-
-.coz-spinner--center:before
-    display     block
-    margin      0 auto
     text-align  center
 
+    &:before
+        display     block
+        margin      0 auto
+
+.coz-spinner--nomargin
+    margin 0
 
 // Colors
 .coz-spinner--blue:before

--- a/stylus/ui-base/icons.styl
+++ b/stylus/ui-base/icons.styl
@@ -21,6 +21,10 @@ $icon
   Icon's sizes
 \*------------------------------------*/
 
+$icon-8
+    width   .5rem // 8px
+    height  .5rem
+
 $icon-12
     width   .75rem // 12px
     height  .75rem
@@ -36,6 +40,10 @@ $icon-24
 $icon-36
     width   2.25rem // 36px
     height  2.25rem
+
+$icon-80
+    width   5rem // 80px
+    height  5rem
 
 
 /*------------------------------------*\


### PR DESCRIPTION
Added a spinner component because it's used everywhere but never in a same way.
Available options so far:
- colors (default blue)
- size (default 1em (16px))
- noMargin — removes the default left and right margins
- middle — center the whole component both vertically & horizontally like it's used when loading a content view
- loadingType — if you want a message below the Spinner (to be consistent with locales files obviously)