### PR TITLE
fix: alert position on mobile

### DIFF
--- a/stylus/ui-components/alerts.styl
+++ b/stylus/ui-components/alerts.styl
@@ -13,7 +13,7 @@ $alerts
         z-index           $alert-index-mobile
         top               auto
         right             0
-        bottom            em(50px)
+        bottom            em(48px, 16px)
         left              0
         display           block
         box-sizing        border-box


### PR DESCRIPTION
wrong em calculation