### PR TITLE
feat: enable share button on small devices

### DIFF
--- a/stylus/ui-components/selectionbar.styl
+++ b/stylus/ui-components/selectionbar.styl
@@ -105,7 +105,6 @@ $selectionbar
             padding-right    1em
 
             .coz-selectionbar-count span
-            .coz-action-share
             .coz-action-moveto
                 display none
 


### PR DESCRIPTION
We will need to deploy another _-betaXX_ version to let cozy-drive be able to share one file.

See https://github.com/cozy/cozy-drive/pull/322 and https://github.com/cozy/cozy-drive/pull/307