### PR TITLE
fix: remove overflow hidden on modal

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -88,14 +88,14 @@ class Modal extends Component {
   }
 
   render () {
-    const { children, title, withCross } = this.props
+    const { children, title, withCross, overflowHidden } = this.props
     return (
       <div className={styles['coz-modal-container']}>
         <div className={styles['coz-overlay']}>
           <div
             className={styles['coz-modal-wrapper']}
             onClick={withCross && this.handleOutsideClick}>
-            <div className={styles['coz-modal']}>
+            <div className={classNames(styles['coz-modal'], { [styles['coz-modal--fullbleed']]: overflowHidden })}>
               <ModalCross {...this.props} />
               {title && <ModalTitle {...this.props} />}
               <ModalDescription {...this.props} />
@@ -118,13 +118,15 @@ Modal.propTypes = {
   primaryType: React.PropTypes.string,
   primaryText: React.PropTypes.string,
   primaryAction: React.PropTypes.func,
-  withCross: React.PropTypes.bool
+  withCross: React.PropTypes.bool,
+  overflowHidden: React.PropTypes.bool
 }
 
 Modal.defaultProps = {
   primaryType: 'secondary',
   secondaryType: 'regular',
-  withCross: true
+  withCross: true,
+  overflowHidden: false
 }
 
 export { ModalContent }

--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -48,10 +48,6 @@ $modals
         height            auto
         background-color  white
         color             charcoal-grey
-        // The content of the modal should manage its
-        // overflow settings as overflowing here may
-        // hide the border-radius
-        overflow          hidden
 
         .coz-modal-content:first-child
         .coz-btn-modal-close + .coz-modal-content

--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -92,6 +92,8 @@ $modals
             opacity                     0
             transition-timing-function  ease-in
 
+    .coz-modal--fullbleed
+        overflow hidden
 
     @media (max-width (modal-width + 2em))
         .coz-modal


### PR DESCRIPTION
@ptbrowne I tried to find another solution but I couldn't… :/
`overflow: hidden` is too restrictive for every use case. We'll have to find something else for PDF display.