### PR TITLE
fix: overflow error on html

### DIFF
--- a/stylus/cozy-ui/defaults.styl
+++ b/stylus/cozy-ui/defaults.styl
@@ -63,6 +63,9 @@ textarea
 // LAYOUT
 html
   height  100%
+  // Necessary not to have broken layout on iOS
+  // https://github.com/cozy/cozy-ui/issues/161
+  overflow hidden
 
 body
   display         flex


### PR DESCRIPTION
Fixing #161 

After : 

![bug-ios-scroll-fixed](https://user-images.githubusercontent.com/465582/29771228-0a8d6fa4-8bf3-11e7-857f-e8aa2e59177b.gif)

The Drive text staying fixed as we scroll is another bug.