### PR TITLE
Exports react components

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -129,6 +129,9 @@ Modal.defaultProps = {
   overflowHidden: false
 }
 
-export { ModalContent }
-export { ModalSection }
+export {
+  ModalContent,
+  ModalSection,
+  ModalButtons
+}
 export default Modal

--- a/react/index.js
+++ b/react/index.js
@@ -1,0 +1,29 @@
+import Alerter from './Alerter'
+import I18n, { translate } from './I18n'
+import Icon from './Icon'
+import Modal, { ModalContent, ModalSection, ModalButtons } from './Modal'
+import SelectionBar from './SelectionBar'
+import Spinner from './Spinner'
+import {Tabs, TabPanels, TabPanel, TabList, Tab} from './Tabs'
+import Toggle from './Toggle'
+import Button from './Button'
+
+export {
+  Alerter,
+  Button,
+  I18n,
+  translate,
+  Icon,
+  Modal,
+  SelectionBar,
+  Spinner,
+  Tabs,
+  TabPanels,
+  TabPanel,
+  TabList,
+  Tab,
+  Toggle,
+  ModalContent,
+  ModalSection,
+  ModalButtons
+}


### PR DESCRIPTION
Makes things like : 

```jsx
import { Modal, Icon, Toggle } from 'cozy-ui/react' 
```

possible.

Added documentation also. Fixes https://github.com/cozy/cozy-ui/issues/163