### PR TITLE
feat: ability for TabPanel to be forced activated

### DIFF
--- a/react/Tabs/index.jsx
+++ b/react/Tabs/index.jsx
@@ -29,16 +29,18 @@ export const TabList = function ({ children, activeTab, changeTab, className }) 
   }</div>
 }
 
-export const TabPanel = function ({ children, activeTab, name, changeTab, className }) {
-  return activeTab === name ? <div className={classnames(styles['coz-tab-panel'], className)}>{
+export const TabPanel = function ({ children, active, changeTab, className }) {
+  return active ? <div className={classnames(styles['coz-tab-panel'], className)}>{
     children
   }</div> : null
 }
 
 export const TabPanels = function ({ children, activeTab, name, changeTab, className }) {
-  const extra = { activeTab, changeTab }
   return <div className={classnames(styles['coz-tab-panels'], className)}>{
-    React.Children.map(children, child => React.cloneElement(child, extra))
+    React.Children.map(children, child => React.cloneElement(child, {
+      active: child.props.active || activeTab == child.props.name,
+      changeTab
+    }))
   }</div>
 }
 

--- a/react/Tabs/index.jsx
+++ b/react/Tabs/index.jsx
@@ -2,21 +2,36 @@ import React, { Component } from 'react'
 import styles from './styles.styl'
 import classnames from 'classnames'
 
-export const Tab = function ({ name, children, className, active, activeClass, changeTab }) {
-  const activeStyle = {
-    [styles['coz-tab--active']]: active
+export class Tab extends Component {
+  constructor (props) {
+    super(props)
+    this.onClick = this.onClick.bind(this)
   }
-  if (activeClass) {
-    activeStyle[activeClass] = active
+
+  render ({ name, children, className, active, activeClass, changeTab, onClick }) {
+    const activeStyle = {
+      [styles['coz-tab--active']]: active
+    }
+    if (activeClass) {
+      activeStyle[activeClass] = active
+    }
+    return <div
+      className={classnames(
+        styles['coz-tab'],
+        className,
+        activeStyle)}
+      onClick={this.onClick}>{
+      children
+    }</div>
   }
-  return <div
-    className={classnames(
-      styles['coz-tab'],
-      className,
-      activeStyle)}
-    onClick={() => changeTab(name)}>{
-    children
-  }</div>
+
+  onClick () {
+    const { changeTab, name, onClick } = this.props
+    changeTab(name)
+    if (onClick) {
+      onClick()
+    }
+  }
 }
 
 export const TabList = function ({ children, activeTab, changeTab, className }) {


### PR DESCRIPTION
## `active` prop on `<TabPanel />` can be passed and won't be overwritten

Sometimes you do not want the `<TabPanel />` active parameter to be controlled by the parent `<TabList />`. You want to force it.

Example in https://gitlab.cozycloud.cc/labs/cozy-bank/blob/master/src/ducks/settings/Settings.jsx

There are 3 tabs but only 1 panel since the children is passed from the routes so we know this panel will be the only one active

## `onClick` on `<Tab/>`

You want to provide an onClick handler. Example: you can change route after click on Tab