### PR TITLE
fix: make default coz-btn more consistent with other button styles

### DIFF
--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -21,6 +21,7 @@ $button
     background       transparent
     vertical-align   top
     text-align       center
+    color            white
     font-size        14px /* [1] */
     line-height      1
     text-transform   uppercase
@@ -32,11 +33,15 @@ $button
         opacity  .5
         cursor   not-allowed
 
+    &:active
+    &:not([disabled]):not([aria-disabled=true]):hover
+    &:focus
+        background-color  white
+        color             black
+
     &[aria-busy=true]
         &::after
-            @extend    $icon-16
-            position   relative
-            top        em(-1px)
+            @extend  $icon-spinner-white
 
 
 $button--regular

--- a/stylus/ui-components/button.styl
+++ b/stylus/ui-components/button.styl
@@ -36,8 +36,7 @@ $button
     &:active
     &:not([disabled]):not([aria-disabled=true]):hover
     &:focus
-        background-color  white
-        color             black
+        background-color  science-blue
 
     &[aria-busy=true]
         &::after
@@ -194,6 +193,11 @@ $button--close
     background-image     embedurl('../assets/icons/ui/icon-cross.svg')
     background-position  center center
     background-repeat    no-repeat
+
+    &:active
+    &:not([disabled]):not([aria-disabled=true]):hover
+    &:focus
+        background-color     transparent
 
 
 /*------------------------------------*\


### PR DESCRIPTION
Made the default `.coz-btn` class more consistent with the other button variants so now we can use it on its own.
Basically it's a transparent button with white border & text, and I added behavior for some pseudo-classes (It was already transparent with white borders, I just added the text color).

I'm pretty sure none of all the Drive & Photos' buttons use only the default class but @y-lohse if you could take a quick look in case I missed something, that would be nice of you.

Same for @CPatchane & @ptbrowne, I (almost) never worked on platformers or gangstas projects, could you assure me that this PR won't break anything on your side?