### PR TITLE
Fix bug : cannot use loader if full name is not specified

### DIFF
--- a/loaders/strip-fill-loader.js
+++ b/loaders/strip-fill-loader.js
@@ -13,8 +13,5 @@ module.exports = function (source) {
     .replace('fill="#FFFFFF"', '')
     .replace('fill=\'#FFF\'', '')
     .replace('fill=\'#FFFFFF\'', '')
-  if (replaced.length !== source.length) {
-    this.emitWarning('Deprecation warning: you have a fill attribute in your SVG icon file')
-  }
   return replaced
 }

--- a/src/icons.jsx
+++ b/src/icons.jsx
@@ -3,7 +3,7 @@ const normalize = function (k) {
 }
 
 const importIcons = function () {
-  const ctx = require.context('!!svg-sprite?name=[name]_[hash]!../loaders/strip-fill-loader!../assets/icons/ui', true, /icon-/)
+  const ctx = require.context('!!svg-sprite-loader?name=[name]_[hash]!../loaders/strip-fill-loader!../assets/icons/ui', true, /icon-/)
   const keys = ctx.keys()
     .filter(x => x.indexOf('./icon-') === 0)
     .filter(x => x.indexOf('-white') === -1)


### PR DESCRIPTION
- Use `svg-sprite-loader`
- Remove warning that nobody reads