### PR TITLE
fix: mobile modal centered

### DIFF
--- a/stylus/ui-components/modals.styl
+++ b/stylus/ui-components/modals.styl
@@ -41,7 +41,7 @@ $modals
 
     .coz-modal
         position          relative
-        margin            5vh auto auto
+        margin            auto
         border-radius     em(8px)
         max-width         90%
         min-width         modal-width


### PR DESCRIPTION
Modal on mobile are now vertically centered.