### PR TITLE
fix: nav layout on mobile with several items

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -95,14 +95,13 @@
     .c-nav-link
         display              block
         height               auto
-        min-width            em(100px, 10px)
-        padding              em(29px, 10px) 0 0
         text-align           center
         color                slate-grey
         font-size            10px
         line-height          1
         background-position  center top
         background-size      em(24px, 10px)
+        flex                 0 0 2.5em
 
         .active // deprecated
         .is-active


### PR DESCRIPTION
Nav items had a way too big min-width so I removed it along with useless padding and used flex-basis instead. Now you can have 5 items easily.