### PR TITLE
Make date-fns a dependency instead of a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-preset-react": "^6.22.0",
     "copyfiles": "^1.2.0",
     "css-loader": "^0.28.4",
-    "date-fns": "^1.28.5",
     "extract-text-webpack-plugin": "^3.0.0",
     "git-directory-deploy": "^1.5.1",
     "kss": "^3.0.0-beta.18",
@@ -64,6 +63,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "date-fns": "^1.28.5",
     "md5": "^2.2.0",
     "normalize.css": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "standard": "^10.0.2",
     "style-loader": "^0.18.2",
     "stylint": "^1.5.9",
-    "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "svg-sprite-loader": "^3.2.5",
     "webpack": "^3.5.6"
@@ -65,7 +64,8 @@
     "classnames": "^2.2.5",
     "date-fns": "^1.28.5",
     "md5": "^2.2.0",
-    "normalize.css": "^7.0.0"
+    "normalize.css": "^7.0.0",
+    "stylus": "^0.54.5"
   },
   "peerDependencies": {
     "piwik-react-router": "^0.8.2"


### PR DESCRIPTION
Since it's necessary for I18n component usage, it's could be better to have it directly in cozy-ui.
It avoid to add it in the app without directly using it (confusing).