### PR TITLE
Fix/v4 improvments

### DIFF
--- a/react/Alerter/index.jsx
+++ b/react/Alerter/index.jsx
@@ -132,7 +132,7 @@ class Alert extends Component {
       >
         <p>{message}</p>
         {buttonText &&
-          <button onClick={buttonAction} className={classNames('coz-btn', `coz-btn--alert-${type}`)}>
+          <button onClick={buttonAction} className={classNames(styles['coz-btn'], styles[`coz-btn--alert-${type}`])}>
             {buttonText}
           </button>
         }

--- a/react/Alerter/styles.styl
+++ b/react/Alerter/styles.styl
@@ -3,4 +3,17 @@
 @require '../../stylus/components/alerts'
 
 .coz-alerter
-  @extends $alerts
+    @extends $alerts
+
+.coz-btn
+    @extends .c-btn
+
+.coz-btn--alert-error
+    @extends .c-btn-alert--error
+
+.coz-btn--alert-info
+    @extends .c-btn-alert--info
+
+.coz-btn--alert-success
+    @extends .c-btn-alert--success
+

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -22,7 +22,7 @@ const ModalCross = ({ withCross, secondaryAction, secondaryText }) =>
   withCross &&
   (
     <button
-      className={classNames('coz-btn', 'coz-btn--close', styles['coz-btn-modal-close'])}
+      className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'])}
       onClick={secondaryAction}
       >
       <span className='coz-hidden'>{secondaryText}</span>
@@ -44,12 +44,12 @@ const ModalButtons = ({ secondaryText, secondaryAction, secondaryType, primaryTe
     (
       <div className={classNames(styles['coz-modal-content'], styles['coz-modal-buttons'])}>
         { displaySecondary &&
-          <button className={classNames('coz-btn', 'coz-btn--' + secondaryType)} onClick={secondaryAction}>
+          <button className={classNames(styles['coz-btn'], styles['coz-btn--' + secondaryType])} onClick={secondaryAction}>
             {secondaryText}
           </button>
         }
         { displayPrimary &&
-          <button className={classNames('coz-btn', 'coz-btn--' + primaryType)} onClick={primaryAction}>
+          <button className={classNames(styles['coz-btn'], styles['coz-btn--' + primaryType])} onClick={primaryAction}>
             {primaryText}
           </button>
         }

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -4,4 +4,16 @@
 @require '../../stylus/components/modals'
 
 .coz-modal-container
-  @extends $modals
+    @extends $modals
+
+.coz-btn
+    @extends .c-btn
+
+.coz-btn--regular
+    @extends .c-btn--regular
+
+.coz-btn--secondary
+    @extends .c-btn--secondary
+
+.coz-btn--close
+    @extends .c-btn--close

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -1,4 +1,5 @@
 @require '../settings/z-index'
+@require '../components/button'
 /*!
  * NOTIFICATIONS
  * =============

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -17,21 +17,6 @@ select,
 textarea
     @extend $font-labor
 
-// UTILS
-@require '../utilities/display'
-@require '../utilities/text'
-:global(.coz-error)
-    @extend .u-error
-
-:global(.coz-hidden)
-    @extend .u-hidden
-
-:global(.coz-desktop)
-    @extend .u-hide--mob
-
-:global(.coz-mobile)
-    @extend .u-hide--desk
-
 // LAYOUT
 html
   height  100%
@@ -54,71 +39,10 @@ body
     overflow-x  hidden
     overflow-y  auto
 
-
 // COLORS
 body
     background-color white
     color            black
-
-
-// BUTTONS
-@require '../components/button'
-:global(.coz-btn)
-    @extend $button
-
-:global(.coz-btn--regular)
-    @extend $button--regular
-
-:global(.coz-btn--secondary)
-    @extend $button--secondary
-
-:global(.coz-btn--danger)
-    @extend $button--danger
-
-:global(.coz-btn--danger-outline)
-    @extend $button--danger-outline
-
-:global(.coz-btn--highlight)
-    @extend $button--highlight
-
-:global(.coz-btn--share)
-    @extend $button--share
-
-:global(.coz-btn--upload)
-    @extend $button--upload
-
-:global(.coz-btn--download)
-    @extend $button--download
-
-:global(.coz-btn--delete)
-    @extend $button--delete
-
-:global(.coz-btn--more)
-    @extend $button--more
-
-:global(.coz-btn--close)
-    @extend $button--close
-
-:global(.coz-btn--extra)
-    @extend $button--extra
-
-:global(.coz-btn--extra-white)
-    @extend $button--extra-white
-
-:global(.coz-btn-alert--error)
-    @extend $button-alert--error
-
-:global(.coz-btn-alert--info)
-    @extend $button-alert--info
-
-:global(.coz-btn-alert--success)
-    @extend $button-alert--success
-
-
-// LINKS
-:global(.coz-link--upload)
-    @extend $link--upload
-
 
 // FORMS
 @require '../components/forms'


### PR DESCRIPTION
Massive clean up here.

I removed all the `:global` intructions from UI to make it agnostic, as much as possible at least. 
You can use or not CSS-modules on your app but you'll have to `@extend` the  previous global classes, such as `.coz-btn`, and make them global yourself in you app if you want to. 

Besides that there's 2 micro bugfix about buttons and the nav on mobile.