### PR TITLE
 🚑  Fix the annoying double tap on nav links on iPad 

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -109,3 +109,11 @@
             box-shadow   none
             font-weight  normal
             color        charcoal-grey
+
+// Prevent double tap on tablets
+@media not all and (pointer: fine)
+    .coz-nav-item:hover::before
+        content none
+
+    .c-nav-link:hover
+        color slate-grey


### PR DESCRIPTION
So I used the MQ parameter `pointer:fine` and `not` which means that ~~every~~ **any** device with**out** an accurate pointing device, such as a mouse, trackpad or pen, should**n't** show an hover effect in this case.
Pretty efficient on iPad & other tablets.