### PR TITLE
🚑 Fix alert's padding

### DIFF
--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -20,7 +20,7 @@ $alerts
         box-sizing        border-box
         box-shadow        0 em(6px) em(18px) 0 rgba(50, 54, 63, .23)
         background-color  emerald
-        padding           .8em, 1em
+        padding           .8em 1em
         color             white
         opacity           1
         transition        bottom .5s ease-out, top .5s ease-out, opacity .2s ease-out
@@ -57,7 +57,7 @@ $alerts
             left          50%
             margin-left   -(alert-width / 2)
             max-width     alert-width
-            padding       1em, 1.5em
+            padding       1em 1.5em
             width         100%
             border-radius em(10px)
 


### PR DESCRIPTION
The removal of `padded` mixin didn't go well. I missed two commas that invalidated `padding`'s syntax and so didn't apply any padding on alerts.