### PR TITLE
feat: use placeholders instead of .classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Removed
-- none yet
+- Removed deprecated classes `.coz-sidebar`, `coz-error`, `coz-error--warning`, `coz-hidden`, `coz-desktop`, `coz-mobile`
 
 ### Deprecated
 - none yet

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:doc:react": "styleguidist build --config docs/styleguide.config.js",
     "deploy:doc": "git-directory-deploy --directory build/ --branch gh-pages",
     "prebuild:css:app": "mkdir -p build/styleguide",
-    "build:css:app": "stylus --include stylus -o build/styleguide/app.css stylus/cozy-ui/index.styl",
+    "build:css:app": "stylus --include stylus -o build/styleguide/app.css stylus/cozy-ui/build.styl",
     "clean:doc:kss": "rm -rf build/styleguide",
     "prebuild:doc:kss": "run-s clean:doc:kss build:css:app",
     "build:doc:kss": "kss --destination build/styleguide --title 'Cozy-UI Styleguide' --source stylus --builder node_modules/michelangelo/kss_styleguide/custom-template --homepage styleguide.md --css app.css"

--- a/react/Alerter/styles.styl
+++ b/react/Alerter/styles.styl
@@ -3,17 +3,17 @@
 @require '../../stylus/components/alerts'
 
 .coz-alerter
-    @extends $alerts
+    @extend $alerts
 
 .coz-btn
-    @extends .c-btn
+    @extend $button
 
 .coz-btn--alert-error
-    @extends .c-btn-alert--error
+    @extend $button-alert--error
 
 .coz-btn--alert-info
-    @extends .c-btn-alert--info
+    @extend $button-alert--info
 
 .coz-btn--alert-success
-    @extends .c-btn-alert--success
+    @extend $button-alert--success
 

--- a/react/Button/styles.styl
+++ b/react/Button/styles.styl
@@ -3,19 +3,19 @@
 @require '../../stylus/components/button'
 
 .coz-btn
-    @extends .c-btn
+    @extend $button
 
 .coz-btn--regular
-    @extends .c-btn--regular
+    @extend $button--regular
 
 .coz-btn--secondary
-    @extends .c-btn--secondary
+    @extend $button--secondary
 
 .coz-btn--danger
-    @extend .c-btn--danger
+    @extend $button--danger
 
 .coz-btn--danger-outline
-    @extend .c-btn--danger-outline
+    @extend $button--danger-outline
 
 .coz-btn--highlight
-    @extend .c-btn--highlight
+    @extend $button--highlight

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -5,40 +5,40 @@
 @require '../../stylus/components/modals'
 
 .coz-modal-container
-    @extends $modals
+    @extend $modals
 
 .coz-btn
-    @extends .c-btn
+    @extend $button
 
 .coz-btn--regular
-    @extends .c-btn--regular
+    @extend $button--regular
 
 .coz-btn--secondary
-    @extends .c-btn--secondary
+    @extend $button--secondary
 
 .coz-btn--danger
-    @extend .c-btn--danger
+    @extend $button--danger
 
 .coz-btn--danger-outline
-    @extend .c-btn--danger-outline
+    @extend $button--danger-outline
 
 .coz-btn--highlight
-    @extend .c-btn--highlight
+    @extend $button--highlight
 
 .coz-btn--share
-    @extend .c-btn--share
+    @extend $button--share
 
 .coz-btn--upload
-    @extend .c-btn--upload
+    @extend $button--upload
 
 .coz-btn--download
-    @extend .c-btn--download
+    @extend $button--download
 
 .coz-btn--delete
-    @extend .c-btn--delete
+    @extend $button--delete
 
 .coz-btn--close
-    @extends .c-btn--close
+    @extends $button--close
 
 .coz-hidden
-    @extends .u-visuallyhidden
+    @extends $visuallyHidden

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -41,4 +41,4 @@
     @extends $button--close
 
 .coz-hidden
-    @extends $visuallyHidden
+    @extends $visuallyhidden

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -10,29 +10,8 @@
  * 1. `font-size` calls the font-size function in ui-components/fonts.styl
       and replaces px value by an em value. Don't be scared by this. :)
  */
-/*
- Buttons
 
- Buttons in different flavour
-
- Markup:
- <div class="u-p-1" style=" background-color: darkgrey">
-     <button class="c-btn {{modifier_class}}">Click me, I'm a button!</button>
-     <a hre="#" class="c-btn {{modifier_class}}">Click me, I'm a link!</a>
- </div>
-
- .c-btn--regular - Regular
- .c-btn--secondary - Regular alternative
- .c-btn--danger - Danger
- .c-btn--danger-outline - Danger outlined
- .c-btn--highlight - Highlighted button to catch the eye
-
- Weight: -1
-
- Styleguide Components.buttons
-*/
-$button // deprecated
-.c-btn
+$button
     box-sizing       border-box
     display          inline-block
     margin           0 .25em
@@ -71,8 +50,7 @@ $button // deprecated
             top        em(-1px)
 
 
-$button--regular // deprecated
-.c-btn--regular
+$button--regular
     border-color      dodger-blue
     background-color  dodger-blue
     color             white
@@ -90,8 +68,7 @@ $button--regular // deprecated
         &::after
             @extend  $icon-spinner-white
 
-$button--secondary // deprecated
-.c-btn--secondary
+$button--secondary
     background-color  white
     color             black
     border            1px solid silver
@@ -108,8 +85,7 @@ $button--secondary // deprecated
         &::after
             @extend  $icon-spinner-blue
 
-$button--danger // deprecated
-.c-btn--danger
+$button--danger
     border-color      pomegranate
     background-color  pomegranate
     color             white
@@ -127,8 +103,7 @@ $button--danger // deprecated
         &::after
             @extend  $icon-spinner-white
 
-$button--danger-outline // deprecated
-.c-btn--danger-outline
+$button--danger-outline
     background-color  white
     color             pomegranate
     border            1px solid your-pink
@@ -145,8 +120,7 @@ $button--danger-outline // deprecated
         &::after
             @extend  $icon-spinner-red
 
-$button--highlight // deprecated
-.c-btn--highlight
+$button--highlight
     border-color      emerald
     background-color  emerald
     color             white
@@ -164,50 +138,25 @@ $button--highlight // deprecated
         &::after
             @extend  $icon-spinner-white
 
-/*
- Buttons with icons
-
- Those buttons can inherit any flavour of buttons described above.
-
- For this example, we use `.c-btn--regular` but choose the one you want.
-
- Markup:
- <div class="u-p-1" style=" background-color: darkgrey">
-     <button class="c-btn c-btn--regular {{modifier_class}}">Click me, I'm a button!</button>
-     <a hre="#" class="c-btn c-btn--regular {{modifier_class}}">Click me, I'm a link!</a>
- </div>
-
- .c-btn--share - Share
- .c-btn--send - Send
- .c-btn--download - Download
- .c-btn--upload - Upload
- .c-btn--delete - Delete
-
- Styleguide Components.buttons.icons
-*/
-$button--share // deprecated
-.c-btn--share
+$button--share
     padding-left         em(44px, 16px)
     background-image     embedurl('../assets/icons/ui/icon-share-grey08.svg')
     background-position  em(17px, 16px) center
     background-repeat    no-repeat
 
-$button--send // deprecated
-.c-btn--send
+$button--send
     padding-left         em(44px, 16px)
     background-image     embedurl('../assets/icons/ui/icon-paperplane.svg')
     background-position  em(17px, 16px) center
     background-repeat    no-repeat
 
-$button--download // deprecated
-.c-btn--download
+$button--download
     padding-left         em(44px, 16px)
     background-image     embedurl('../assets/icons/ui/icon-download.svg')
     background-position  em(17px, 16px) center
     background-repeat    no-repeat
 
-$button--upload // deprecated
-.c-btn--upload
+$button--upload
     padding-left         em(44px, 16px)
     background-image     embedurl('../assets/icons/ui/icon-upload.svg')
     background-position  em(17px, 16px) center
@@ -221,8 +170,7 @@ $button--upload // deprecated
     input
         cursor pointer
 
-$button--delete // deprecated
-.c-btn--delete
+$button--delete
     padding-left         em(44px, 16px)
     background-image     embedurl('../assets/icons/ui/icon-delete.svg')
     background-position  em(17px, 16px) center
@@ -231,63 +179,24 @@ $button--delete // deprecated
     input
         cursor pointer
 
-/*
- Buttons link shaped with icons
-
- Buttons that look like links, with icons
-
- Markup:
- <div class="u-p-1" style=" background-color: darkgrey">
-     <button class="{{modifier_class}}">Click me, I'm a button!</button>
-     <a hre="#" class="{{modifier_class}}">Click me, I'm a link!</a>
- </div>
-
- .c-link--upload - Upload
- .c-link--delete - Delete
-
- Styleguide Components.buttons.link
-*/
-$link--upload // deprecated
-.c-link--upload
+$link--upload
     background-image     embedurl('../assets/icons/ui/icon-upload-grey08.svg')
     background-position  em(16px) center
     background-repeat    no-repeat
 
-$link--delete // deprecated
-.c-link--delete
+$link--delete
     background-image     embedurl('../assets/icons/ui/icon-delete-grey08.svg')
     background-position  em(16px) center
     background-repeat    no-repeat
 
-/*
-
-/*
- Button More
-
- Button to display more information
-
- Markup:
- <div class="u-p-1" style=" background-color: darkgrey">
-    <button class="c-btn {{modifier_class}}"><span class="u-hidden">Click me, I'm a button!</span></button>
-    <a hre="#" class="c-btn {{modifier_class}}"><span class="u-hidden">Click me, I'm a link!</span></a>
- </div>
-
- .c-btn--more - Classic more button
- .c-btn-extra - Extra button, much like More button but lighter, without border
- .c-btn-extra--white - Extra button with white icon
-
- Styleguide Components.buttons.more
-*/
-$button--more // deprecated
-.c-btn--more
+$button--more
     width                em(46px)
     background-color     transparent
     background-image     embedurl('../assets/icons/ui/icon-dots.svg')
     background-position  center center
     background-repeat    no-repeat
 
-$button--extra // deprecated
-.c-btn-extra
+$button-extra
     width       em(46px)
     border      0
     background  embedurl('../assets/icons/ui/icon-dots.svg') center center no-repeat
@@ -298,9 +207,8 @@ $button--extra // deprecated
     &:focus
         background-color  transparent
 
-$button--extra-white // deprecated
-.c-btn-extra--white
-    @extend .c-btn-extra
+$button-extra--white
+    @extend $button-extra
     background-image  embedurl('../assets/icons/ui/icon-dots-white.svg')
 
     &:active
@@ -308,8 +216,7 @@ $button--extra-white // deprecated
     &:focus
         background-color  transparent
 
-$button--close // deprecated
-.c-btn--close
+$button--close
     border               0
     width                em(46px)
     background-image     embedurl('../assets/icons/ui/icon-cross.svg')
@@ -321,31 +228,7 @@ $button--close // deprecated
     &:focus
         background-color  transparent
 
-
-/*------------------------------------*\
-  Alert's specific buttons
-\*------------------------------------*/
-/*
- Alert's buttons
-
- Buttons that look like links, with icons
-
- Markup:
- <div class="u-p-1">
-     <button class="c-btn--alert {{modifier_class}} u-m-1">Click me, I'm a button!</button>
-     <a hre="#" class="c-btn--alert {{modifier_class}} u-m-1">Click me, I'm a link!</a>
- </div>
-
- .c-btn-alert--error - Error button
- .c-btn-alert--info - Information button
- .c-btn-alert--success - Success button
-
- Weight: 10
-
- Styleguide Components.buttons.alert
-*/
-$button-alert // deprecated
-.c-btn-alert
+$button-alert
     margin       .5rem 0 0
     border       0
     height       auto
@@ -354,9 +237,8 @@ $button-alert // deprecated
     font-weight  bold
     font-size 1em
 
-$button-alert--error // deprecated
-.c-btn-alert--error
-    @extend .c-btn-alert
+$button-alert--error
+    @extend $button-alert
     color   pomegranate
 
     &:visited
@@ -367,9 +249,8 @@ $button-alert--error // deprecated
     &:focus
         color  darken(pomegranate, 25%)
 
-$button-alert--info // deprecated
-.c-btn-alert--info
-    @extend           .c-btn-alert
+$button-alert--info
+    @extend           $button-alert
     background-color  cool-grey
     color             white
 
@@ -381,9 +262,8 @@ $button-alert--info // deprecated
     &:focus
         color  darken(white, 10%)
 
-$button-alert--success // deprecated
-.c-btn-alert--success
-    @extend .c-btn-alert
+$button-alert--success
+    @extend $button-alert
     color   emerald
 
     &:visited
@@ -394,30 +274,9 @@ $button-alert--success // deprecated
     &:focus
         color darken(emerald, 25%)
 
-/*------------------------------------*\
-  Special buttons
-\*------------------------------------*/
-/*
- Special buttons
-
- Special link that look like buttons (<a> only)
-
- Markup:
- <div class="u-p-1" style="background-color: darkgrey; width: 50%;">
-     <a hre="#" class="{{modifier_class}} u-mb-1">Click me, I'm a link!</a>
- </div>
-
- .c-btn-client - Button to download Cozy client app
- .c-btn-client-mobile - Button to download Cozy client app on mobile
-
- Weight: 20
-
- Styleguide Components.buttons.special
-*/
-$button-client // deprecated
-.c-btn-client
-    @extend .c-btn
-    @extend .c-btn--secondary
+$button-client
+    @extend $button
+    @extend $button--secondary
     display           flex
     justify-content   center
     align-items       center
@@ -445,9 +304,8 @@ $button-client // deprecated
     span
         flex  0 1 auto
 
-$button-client-mobile // deprecated
-.c-btn-client-mobile
-    @extend .c-btn-client
+$button-client-mobile
+    @extend $button-client
     display          flex
     justify-content  flex-start
     background-color dodger-blue

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -6,7 +6,7 @@
 \*------------------------------------*/
 
 $nav
-    margin     em(24px) 0
+    margin     1.5rem 0
     padding    0
     list-style none
     padding-right 10%
@@ -14,16 +14,16 @@ $nav
     +medium-screen()
         display          flex
         justify-content  space-around
-        margin           em(5px) 0 em(4px)
+        margin           .3125rem 0 .25rem
         padding-right    0
 
 $nav-item
     position        relative
     z-index         $app-index
-    height          3em
+    height          3rem
     display         flex
     align-items     center
-    padding-right   .5em
+    padding-right   .5rem
 
     &:hover::before
         content        ''
@@ -39,7 +39,7 @@ $nav-item
     +medium-screen()
         height        auto
         display       block
-        flex          0 0 2.5em
+        flex          0 0 2.5rem
         padding-right 0
         &:hover::before
             content  none
@@ -51,7 +51,7 @@ $nav-item
 
 $nav-link
     display              flex
-    padding-left         em(50px)
+    padding-left         3.125rem
     line-height          1.5
     text-decoration      none
     color                slate-grey
@@ -59,7 +59,7 @@ $nav-link
     align-items          center
     flex                 1
     background-repeat    no-repeat
-    background-position  em(24px) center
+    background-position  1.5rem center
 
     &:visited
         color  slate-grey
@@ -75,13 +75,13 @@ $nav-link
     +medium-screen()
         display              block
         height               auto
-        padding              em(29px, 10px) 0 0
+        padding              1.8125rem 0 0
         text-align           center
         color                slate-grey
         font-size            10px
         line-height          1
         background-position  center top
-        background-size      em(24px, 10px)
+        background-size      1.5rem
 
         &.active // deprecated
         &.is-active

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -5,36 +5,19 @@
   Navigation
 \*------------------------------------*/
 
-/*
-    Navigation
-
-    Navigation component that displays a list of item link to other pages
-
-    Markup:
-    <nav style="width: 220px">
-        <ul class="c-nav">
-            <li class="c-nav-item">
-                <a class="c-nav-link is-active" href="#">Link 1</a>
-            </li>
-            <li class="c-nav-item">
-                <a class="c-nav-link" href="#">Link 2</a>
-            </li>
-            <li class="c-nav-item">
-                <a class="c-nav-link" href="#">Link 3</a>
-            </li>
-        </ul>
-    </nav>
-
-    Styleguide Components.nav
-*/
-
-.c-nav
+$nav
     margin     em(24px) 0
     padding    0
     list-style none
     padding-right 10%
 
-.c-nav-item
+    +medium-screen()
+        display          flex
+        justify-content  space-around
+        margin           em(5px) 0 em(4px)
+        padding-right    0
+
+$nav-item
     position        relative
     z-index         $app-index
     height          3em
@@ -53,7 +36,20 @@
         bottom 0
         background     silver
 
-.c-nav-link
+    +medium-screen()
+        height        auto
+        display       block
+        flex          0 0 2.5em
+        padding-right 0
+        &:hover::before
+            content  none
+
+    // Prevent double tap on tablets
+    @media not all and (pointer: fine)
+        &:hover::before
+            content none
+
+$nav-link
     display              flex
     padding-left         em(50px)
     line-height          1.5
@@ -76,23 +72,7 @@
         box-shadow   inset 4px 0 0 0 dodger-blue
         font-weight  bold
 
-
-+medium-screen()
-    .c-nav
-        display          flex
-        justify-content  space-around
-        margin           em(5px) 0 em(4px)
-        padding-right    0
-
-    .c-nav-item
-        height        auto
-        display       block
-        flex          0 0 2.5em
-        padding-right 0
-        &:hover::before
-            content  none
-
-    .c-nav-link
+    +medium-screen()
         display              block
         height               auto
         padding              em(29px, 10px) 0 0
@@ -110,10 +90,7 @@
             font-weight  normal
             color        charcoal-grey
 
-// Prevent double tap on tablets
-@media not all and (pointer: fine)
-    .coz-nav-item:hover::before
-        content none
-
-    .c-nav-link:hover
-        color slate-grey
+    // Prevent double tap on tablets
+    @media not all and (pointer: fine)
+        &:hover
+            color slate-grey

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1,0 +1,628 @@
+/*------------------------------------*\
+  CSS classes for those who want the
+  full library loaded kinda like
+  Bootstrap.
+\*------------------------------------*/
+
+/*------------------------------------*\
+  Required dependencies
+\*------------------------------------*/
+@require '../settings/*'
+@require '../tools/*'
+@require '../generic/animations'
+@require '../../node_modules/normalize.css/normalize.css'
+@require '../elements/*'
+@require '../objects/*'
+@require '../components/button'
+@require '../utilities/*'
+
+/*------------------------------------*\
+  Objects
+\*------------------------------------*/
+
+// Layout
+.o-layout--2panes
+    @extend $app-2panes-sticky
+
+// Sidebar
+.o-sidebar
+    @extend $sidebar
+
+/*------------------------------------*\
+  Components
+\*------------------------------------*/
+/*
+ Buttons
+
+ Buttons in different flavour
+
+ Markup:
+ <div class="u-p-1" style=" background-color: darkgrey">
+     <button class="c-btn {{modifier_class}}">Click me, I'm a button!</button>
+     <a hre="#" class="c-btn {{modifier_class}}">Click me, I'm a link!</a>
+ </div>
+
+ .c-btn--regular - Regular
+ .c-btn--secondary - Regular alternative
+ .c-btn--danger - Danger
+ .c-btn--danger-outline - Danger outlined
+ .c-btn--highlight - Highlighted button to catch the eye
+
+ Weight: -1
+
+ Styleguide Components.buttons
+*/
+.c-btn
+    @extend $button
+
+.c-btn--regular
+    @extend $button--regular
+
+.c-btn--secondary
+    @extend $button--secondary
+
+.c-btn--danger
+    @extend $button--danger
+
+.c-btn--danger-outline
+    @extend $button--danger-outline
+
+.c-btn--highlight
+    @extend $button--highlight
+
+/*
+ Buttons with icons
+
+ Those buttons can inherit any flavour of buttons described above.
+
+ For this example, we use `.c-btn--regular` but choose the one you want.
+
+ Markup:
+ <div class="u-p-1" style=" background-color: darkgrey">
+     <button class="c-btn c-btn--regular {{modifier_class}}">Click me, I'm a button!</button>
+     <a hre="#" class="c-btn c-btn--regular {{modifier_class}}">Click me, I'm a link!</a>
+ </div>
+
+ .c-btn--share - Share
+ .c-btn--send - Send
+ .c-btn--download - Download
+ .c-btn--upload - Upload
+ .c-btn--delete - Delete
+
+ Styleguide Components.buttons.icons
+*/
+.c-btn--share
+    @extend $button--share
+
+.c-btn--send
+    @extend $button--send
+
+.c-btn--download
+    @extend $button--download
+
+.c-btn--upload
+    @extend $button--upload
+
+.c-btn--delete
+    @extend $button--delete
+
+/*
+ Buttons link shaped with icons
+
+ Buttons that look like links, with icons
+
+ Markup:
+ <div class="u-p-1" style=" background-color: darkgrey">
+     <button class="{{modifier_class}}">Click me, I'm a button!</button>
+     <a hre="#" class="{{modifier_class}}">Click me, I'm a link!</a>
+ </div>
+
+ .c-link--upload - Upload
+ .c-link--delete - Delete
+
+ Styleguide Components.buttons.link
+*/
+.c-link--upload
+    @extend $link--upload
+
+.c-link--delete
+    @extend $link--delete
+
+/*
+ Button More
+
+ Button to display more information
+
+ Markup:
+ <div class="u-p-1" style=" background-color: darkgrey">
+    <button class="c-btn {{modifier_class}}"><span class="u-visuallyhidden">Click me, I'm a button!</span></button>
+    <a hre="#" class="c-btn {{modifier_class}}"><span class="u-visuallyhidden">Click me, I'm a link!</span></a>
+ </div>
+
+ .c-btn--more - Classic more button
+ .c-btn-extra - Extra button, much like More button but lighter, without border
+ .c-btn-extra--white - Extra button with white icon
+
+ Styleguide Components.buttons.more
+*/
+.c-btn--more
+    @extend $button--more
+
+.c-btn-extra
+    @extend $button-extra
+
+.c-btn-extra--white
+    @extend $button-extra--white
+
+.c-btn--close
+    @extend $button--close
+
+/*------------------------------------*\
+  Alert's specific buttons
+\*------------------------------------*/
+/*
+ Alert's buttons
+
+ Buttons that look like links, with icons
+
+ Markup:
+ <div class="u-p-1">
+     <button class="c-btn--alert {{modifier_class}} u-m-1">Click me, I'm a button!</button>
+     <a hre="#" class="c-btn--alert {{modifier_class}} u-m-1">Click me, I'm a link!</a>
+ </div>
+
+ .c-btn-alert--error - Error button
+ .c-btn-alert--info - Information button
+ .c-btn-alert--success - Success button
+
+ Weight: 10
+
+ Styleguide Components.buttons.alert
+*/
+.c-btn-alert
+    @extend $button-alert
+
+.c-btn-alert--error
+    @extend $button-alert--error
+
+.c-btn-alert--info
+    @extend $button-alert--info
+
+.c-btn-alert--success
+    @extend $button-alert--success
+
+/*------------------------------------*\
+  Special buttons
+\*------------------------------------*/
+/*
+ Special buttons
+
+ Special link that look like buttons (<a> only)
+
+ Markup:
+ <div class="u-p-1" style="background-color: darkgrey; width: 50%;">
+     <a hre="#" class="{{modifier_class}} u-mb-1">Click me, I'm a link!</a>
+ </div>
+
+ .c-btn-client - Button to download Cozy client app
+ .c-btn-client-mobile - Button to download Cozy client app on mobile
+
+ Weight: 20
+
+ Styleguide Components.buttons.special
+*/
+.c-btn-client
+    @extend $button-client
+
+.c-btn-client-mobile
+    @extend $button-client-mobile
+
+/*
+    Navigation
+
+    Navigation component that displays a list of item link to other pages
+
+    Markup:
+    <nav style="width: 220px">
+        <ul class="c-nav">
+            <li class="c-nav-item">
+                <a class="c-nav-link is-active" href="#">Link 1</a>
+            </li>
+            <li class="c-nav-item">
+                <a class="c-nav-link" href="#">Link 2</a>
+            </li>
+            <li class="c-nav-item">
+                <a class="c-nav-link" href="#">Link 3</a>
+            </li>
+        </ul>
+    </nav>
+
+    Styleguide Components.nav
+*/
+.c-nav
+    $nav
+
+.c-nav-item
+    $nav-item
+
+.c-nav-link
+    $nav-link
+
+/*------------------------------------*\
+  Utilities
+\*------------------------------------*/
+/*
+    Utilities
+
+    Ready-to-use utility classes
+
+    Weight: -4
+
+    Styleguide utilities
+*/
+
+/*
+    Display
+
+    Utilities that change the box model of an element or its visibility.
+
+    Styleguide utilities.display
+*/
+
+/*
+    Visibility
+
+    Utilities that show or hide an element for a giving viewport size.
+
+    Markup:
+    <p class="{{modifier_class}}">I'm visible! 🎉</p>
+
+    .u-hidden - Element is visually hidden but still readable by screen-readers
+    .u-hide - Element is totally hidden (even for screen readers)
+    .u-hide--desk - Element is hidden on desktop (>768px)
+    .u-hide--mob - Element is hidden on mobile (<1023px)
+
+    Styleguide utilities.visibility
+*/
+.u-visuallyhidden
+    @extend $visuallyHidden
+
+.u-hide
+    @extend $hide
+
+.u-hide--mob
+    @extend $hide--mob
+
+.u-hide--desk
+    @extend $hide--desk
+
+/*
+    Text
+
+    Utilities that mess only with with wild texts.
+
+    Styleguide utilities.text
+*/
+
+/*
+    Error
+
+    Utilities that give text some semantic color in case of error.
+
+    Markup: <p class="{{modifier_class}}">Somehow you messed up somewhere.</p>
+
+    .u-error - simple error text
+
+    Styleguide utilities.text.error
+*/
+
+/*
+    Error with warning icon
+
+    Utilities that give text some semantic color in case of important error.
+
+    Markup: <p class="u-error {{modifier_class}}">You really missed, badly.</p>
+
+    .u-error--warning - error with warning icon
+
+    Styleguide utilities.text.errorWarn
+*/
+
+.u-error
+    @extend $error
+
+.u-error--warning
+    @extend $error-warning
+
+/*
+ Valid
+
+ Utilities that give text some semantic color in case of success.
+
+ Markup: <p class="{{modifier_class}}">Yay, you did it!</p>
+
+ .u-valid - simple valid text
+
+ Styleguide utilities.text.valid
+*/
+.u-valid
+    @extend $valid
+
+/*
+ Warning
+
+ Utilities that give text some semantic color in case of warning.
+
+ Markup: <p class="{{modifier_class}}">Ok, something went wrong but it's not that bad.</p>
+
+ .u-warn - simple warning text
+
+ Styleguide utilities.text.warn
+*/
+.u-warn
+    @extend $warn
+
+/*
+    Margins
+
+    Classes to add margins on top, bottom, right, left or all of them based on
+    default font-size (16px)
+
+    .u-m-half - Margins on all sides with half a line (8px)
+    .u-m-1 - Margins on all sides with 1 line (16px)
+    .u-m-1-half - Margins on all sides with 1 line an a half (24px)
+    .u-m-2 - Margins on all sides with 2 lines (32px)
+    .u-m-2-half - Margins on all sides with 1 line an a half (40px)
+    .u-m-3 - Margins on all sides with 2 lines (48px)
+    .u-mt-half - Margin Top with half a line (8px)
+    .u-mt-1 - Margin Top with 1 line (16px)
+    .u-mt-1-half - Margin Top with 1 line an a half (24px)
+    .u-mt-2 - Margin Top with 2 lines (32px)
+    .u-mt-2-half - Margin Top with 1 line an a half (40px)
+    .u-mt-3 - Margin Top with 2 lines (48px)
+    .u-mb-half - Margin Bottom with half a line (8px)
+    .u-mb-1 - Margin Bottom with 1 line (16px)
+    .u-mb-1-half - Margin Bottom with 1 line an a half (24px)
+    .u-mb-2 - Margin Bottom with 2 lines (32px)
+    .u-mb-2-half - Margin Bottom with 1 line an a half (40px)
+    .u-mb-3 - Margin Bottom with 2 lines (48px)
+    .u-ml-half - Margin Left with half a line (8px)
+    .u-ml-1 - Margin Left with 1 line (16px)
+    .u-ml-1-half - Margin Left with 1 line an a half (24px)
+    .u-ml-2 - Margin Left with 2 lines (32px)
+    .u-ml-2-half - Margin Left with 1 line an a half (40px)
+    .u-ml-3 - Margin Left with 2 lines (48px)
+    .u-mr-half - Margin Right with half a line (8px)
+    .u-mr-1 - Margin Right with 1 line (16px)
+    .u-mr-1-half - Margin Right with 1 line an a half (24px)
+    .u-mr-2 - Margin Right with 2 lines (32px)
+    .u-mr-2-half - Margin Right with 1 line an a half (40px)
+    .u-mr-3 - Margin Right with 2 lines (48px)
+
+    Markup:
+    <div style="background-color:dimgrey; border: 1px solid black;"><div style="padding:.5rem; background-color:gainsboro;" class="{{modifier_class}}">🎶 Gimme some margin 🎵 </div></div>
+
+    Styleguide utilities.margins
+*/
+.u-m-half
+    @extend $m-half
+
+.u-m-1
+    @extend $m-1
+
+.u-m-1-half
+    @extend $m-1-half
+
+.u-m-2
+    @extend $m-2
+
+.u-m-2-half
+    @extend $m-2-half
+
+.u-m-3
+    @extend $m-3
+
+.u-mt-half
+    @extend $mt-half
+
+.u-mt-1
+    @extend $mt-1
+
+.u-mt-1-half
+    @extend $mt-1-half
+
+.u-mt-2
+    @extend $mt-2
+
+.u-mt-2-half
+    @extend $mt-2-half
+
+.u-mt-3
+    @extend $mt-3
+
+.u-mb-half
+    @extend $mb-half
+
+.u-mb-1
+    @extend $mb-1
+
+.u-mb-1-half
+    @extend $mb-1-half
+
+.u-mb-2
+    @extend $mb-2
+
+.u-mb-2-half
+    @extend $mb-2-half
+
+.u-mb-3
+    @extend $mb-3
+
+.u-ml-half
+    @extend $ml-half
+
+.u-ml-1
+    @extend $ml-1
+
+.u-ml-1-half
+    @extend $ml-1-half
+
+.u-ml-2
+    @extend $ml-2
+
+.u-ml-2-half
+    @extend $ml-2-half
+
+.u-ml-3
+    @extend $ml-3
+
+.u-mr-half
+    @extend $mr-half
+
+.u-mr-1
+    @extend $mr-1
+
+.u-mr-1-half
+    @extend $mr-1-half
+
+.u-mr-2
+    @extend $mr-2
+
+.u-mr-2-half
+    @extend $mr-2-half
+
+.u-mr-3
+    @extend $mr-3
+
+/*
+    Paddings
+
+    Classes to add paddings on top, bottom, right, left or all of them based on
+    default font-size (16px)
+
+    .u-p-half - Paddings on all sides with half a line (8px)
+    .u-p-1 - Paddings on all sides with 1 line (16px)
+    .u-p-1-half - Paddings on all sides with 1 line an a half (24px)
+    .u-p-2 - Paddings on all sides with 2 lines (32px)
+    .u-p-2-half - Paddings on all sides with 1 line an a half (40px)
+    .u-p-3 - Paddings on all sides with 2 lines (48px)
+    .u-pt-half - Padding Top with half a line (8px)
+    .u-pt-1 - Padding Top with 1 line (16px)
+    .u-pt-1-half - Padding Top with 1 line an a half (24px)
+    .u-pt-2 - Padding Top with 2 lines (32px)
+    .u-pt-2-half - Padding Top with 1 line an a half (40px)
+    .u-pt-3 - Padding Top with 2 lines (48px)
+    .u-pb-half - Padding Bottom with half a line (8px)
+    .u-pb-1 - Padding Bottom with 1 line (16px)
+    .u-pb-1-half - Padding Bottom with 1 line an a half (24px)
+    .u-pb-2 - Padding Bottom with 2 lines (32px)
+    .u-pb-2-half - Padding Bottom with 1 line an a half (40px)
+    .u-pb-3 - Padding Bottom with 2 lines (48px)
+    .u-pl-half - Padding Left with half a line (8px)
+    .u-pl-1 - Padding Left with 1 line (16px)
+    .u-pl-1-half - Padding Left with 1 line an a half (24px)
+    .u-pl-2 - Padding Left with 2 lines (32px)
+    .u-pl-2-half - Padding Left with 1 line an a half (40px)
+    .u-pl-3 - Padding Left with 2 lines (48px)
+    .u-pr-half - Padding Right with half a line (8px)
+    .u-pr-1 - Padding Right with 1 line (16px)
+    .u-pr-1-half - Padding Right with 1 line an a half (24px)
+    .u-pr-2 - Padding Right with 2 lines (32px)
+    .u-pr-2-half - Padding Right with 1 line an a half (40px)
+    .u-pr-3 - Padding Right with 2 lines (48px)
+
+    Markup:
+    <div style="background-color:gainsboro; display: inline-block;" class="{{modifier_class}}"><span style="background-color:bisque;">🎼 Gimme some padding 💃</span></div>
+
+    Styleguide utilities.paddings
+*/
+.u-p-half
+    @extend $m-half
+
+.u-p-1
+    @extend $m-1
+
+.u-p-1-half
+    @extend $m-1-half
+
+.u-p-2
+    @extend $m-2
+
+.u-p-2-half
+    @extend $m-2-half
+
+.u-p-3
+    @extend $m-3
+
+.u-pt-half
+    @extend $mt-half
+
+.u-pt-1
+    @extend $mt-1
+
+.u-pt-1-half
+    @extend $mt-1-half
+
+.u-pt-2
+    @extend $mt-2
+
+.u-pt-2-half
+    @extend $mt-2-half
+
+.u-pt-3
+    @extend $mt-3
+
+.u-pb-half
+    @extend $mb-half
+
+.u-pb-1
+    @extend $mb-1
+
+.u-pb-1-half
+    @extend $mb-1-half
+
+.u-pb-2
+    @extend $mb-2
+
+.u-pb-2-half
+    @extend $mb-2-half
+
+.u-pb-3
+    @extend $mb-3
+
+.u-pl-half
+    @extend $ml-half
+
+.u-pl-1
+    @extend $ml-1
+
+.u-pl-1-half
+    @extend $ml-1-half
+
+.u-pl-2
+    @extend $ml-2
+
+.u-pl-2-half
+    @extend $ml-2-half
+
+.u-pl-3
+    @extend $ml-3
+
+.u-pr-half
+    @extend $mr-half
+
+.u-pr-1
+    @extend $mr-1
+
+.u-pr-1-half
+    @extend $mr-1-half
+
+.u-pr-2
+    @extend $mr-2
+
+.u-pr-2-half
+    @extend $mr-2-half
+
+.u-pr-3
+    @extend $mr-3
+

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -285,7 +285,7 @@
     Styleguide utilities.visibility
 */
 .u-visuallyhidden
-    @extend $visuallyHidden
+    @extend $visuallyhidden
 
 .u-hide
     @extend $hide

--- a/stylus/objects/sidebar.styl
+++ b/stylus/objects/sidebar.styl
@@ -4,8 +4,7 @@
   Sidebar
 \*------------------------------------*/
 
-.coz-sidebar // deprecated
-.o-sidebar
+$sidebar
     width             em(220px, 16px)
     border-right      1px solid silver
     background-color  pale-grey

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -1,46 +1,17 @@
-/*
-    Utilities
-
-    Ready-to-use utility classes
-
-    Weight: -4
-
-    Styleguide utilities
-*/
-
-/*
-    Display
-
-    Utilities that change the box model of an element or its visibility.
-
-    Styleguide utilities.display
-*/
-
-/*
-    Visibility
-
-    Utilities that show or hide an element for a giving viewport size.
-
-    Markup:
-    <p class="{{modifier_class}}">I'm visible! 🎉</p>
-
-    .u-hidden - Element is visually hidden but still readable by screen-readers
-    .u-hide - Element is totally hidden (even for screen readers)
-    .u-hide--desk - Element is hidden on desktop (>768px)
-    .u-hide--mob - Element is hidden on mobile (<1023px)
-
-    Styleguide utilities.visibility
-*/
 @require '../settings/breakpoints'
 @require '../tools/mixins'
+
+/*------------------------------------*\
+  Display utilities
+\*------------------------------------*/
 
 /*
     Visually hidden element but still readable by screen-readers
     FR : http://www.ffoodd.fr/cache-cache-css/
     EN : http://hugogiraudel.com/2016/10/13/css-hide-and-seek/
 */
-.coz-hidden // deprecated
-.u-visuallyhidden
+
+$visuallyHidden
 // @stylint off
     position     absolute !important
     border       0 !important
@@ -53,17 +24,15 @@
     clip-path    inset(50%) !important
 // @stylint on
 
-.u-hide
+$hide
 [aria-hidden=true]
     hide()
 
-.coz-desktop // deprecated
-.u-hide--mob
+$hide--mob
     +no-desktop()
         display none !important // @stylint ignore
 
-.coz-mobile // deprecated
-.u-hide--desk
+$hide--desk
     +no-mobile()
         display none !important // @stylint ignore
 

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -11,7 +11,7 @@
     EN : http://hugogiraudel.com/2016/10/13/css-hide-and-seek/
 */
 
-$visuallyHidden
+$visuallyhidden
 // @stylint off
     position     absolute !important
     border       0 !important

--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -1,88 +1,6 @@
-/*
-    Margins
-
-    Classes to add margins on top, bottom, right, left or all of them based on
-    default font-size (16px)
-
-    .u-m-half - Margins on all sides with half a line (8px)
-    .u-m-1 - Margins on all sides with 1 line (16px)
-    .u-m-1-half - Margins on all sides with 1 line an a half (24px)
-    .u-m-2 - Margins on all sides with 2 lines (32px)
-    .u-m-2-half - Margins on all sides with 1 line an a half (40px)
-    .u-m-3 - Margins on all sides with 2 lines (48px)
-    .u-mt-half - Margin Top with half a line (8px)
-    .u-mt-1 - Margin Top with 1 line (16px)
-    .u-mt-1-half - Margin Top with 1 line an a half (24px)
-    .u-mt-2 - Margin Top with 2 lines (32px)
-    .u-mt-2-half - Margin Top with 1 line an a half (40px)
-    .u-mt-3 - Margin Top with 2 lines (48px)
-    .u-mb-half - Margin Bottom with half a line (8px)
-    .u-mb-1 - Margin Bottom with 1 line (16px)
-    .u-mb-1-half - Margin Bottom with 1 line an a half (24px)
-    .u-mb-2 - Margin Bottom with 2 lines (32px)
-    .u-mb-2-half - Margin Bottom with 1 line an a half (40px)
-    .u-mb-3 - Margin Bottom with 2 lines (48px)
-    .u-ml-half - Margin Left with half a line (8px)
-    .u-ml-1 - Margin Left with 1 line (16px)
-    .u-ml-1-half - Margin Left with 1 line an a half (24px)
-    .u-ml-2 - Margin Left with 2 lines (32px)
-    .u-ml-2-half - Margin Left with 1 line an a half (40px)
-    .u-ml-3 - Margin Left with 2 lines (48px)
-    .u-mr-half - Margin Right with half a line (8px)
-    .u-mr-1 - Margin Right with 1 line (16px)
-    .u-mr-1-half - Margin Right with 1 line an a half (24px)
-    .u-mr-2 - Margin Right with 2 lines (32px)
-    .u-mr-2-half - Margin Right with 1 line an a half (40px)
-    .u-mr-3 - Margin Right with 2 lines (48px)
-
-    Markup:
-    <div style="background-color:dimgrey; border: 1px solid black;"><div style="padding:.5rem; background-color:gainsboro;" class="{{modifier_class}}">🎶 Gimme some margin 🎵 </div></div>
-
-    Styleguide utilities.margins
-*/
-
-/*
-    Paddings
-
-    Classes to add paddings on top, bottom, right, left or all of them based on
-    default font-size (16px)
-
-    .u-p-half - Paddings on all sides with half a line (8px)
-    .u-p-1 - Paddings on all sides with 1 line (16px)
-    .u-p-1-half - Paddings on all sides with 1 line an a half (24px)
-    .u-p-2 - Paddings on all sides with 2 lines (32px)
-    .u-p-2-half - Paddings on all sides with 1 line an a half (40px)
-    .u-p-3 - Paddings on all sides with 2 lines (48px)
-    .u-pt-half - Padding Top with half a line (8px)
-    .u-pt-1 - Padding Top with 1 line (16px)
-    .u-pt-1-half - Padding Top with 1 line an a half (24px)
-    .u-pt-2 - Padding Top with 2 lines (32px)
-    .u-pt-2-half - Padding Top with 1 line an a half (40px)
-    .u-pt-3 - Padding Top with 2 lines (48px)
-    .u-pb-half - Padding Bottom with half a line (8px)
-    .u-pb-1 - Padding Bottom with 1 line (16px)
-    .u-pb-1-half - Padding Bottom with 1 line an a half (24px)
-    .u-pb-2 - Padding Bottom with 2 lines (32px)
-    .u-pb-2-half - Padding Bottom with 1 line an a half (40px)
-    .u-pb-3 - Padding Bottom with 2 lines (48px)
-    .u-pl-half - Padding Left with half a line (8px)
-    .u-pl-1 - Padding Left with 1 line (16px)
-    .u-pl-1-half - Padding Left with 1 line an a half (24px)
-    .u-pl-2 - Padding Left with 2 lines (32px)
-    .u-pl-2-half - Padding Left with 1 line an a half (40px)
-    .u-pl-3 - Padding Left with 2 lines (48px)
-    .u-pr-half - Padding Right with half a line (8px)
-    .u-pr-1 - Padding Right with 1 line (16px)
-    .u-pr-1-half - Padding Right with 1 line an a half (24px)
-    .u-pr-2 - Padding Right with 2 lines (32px)
-    .u-pr-2-half - Padding Right with 1 line an a half (40px)
-    .u-pr-3 - Padding Right with 2 lines (48px)
-
-    Markup:
-    <div style="background-color:gainsboro; display: inline-block;" class="{{modifier_class}}"><span style="background-color:bisque;">🎼 Gimme some padding 💃</span></div>
-
-    Styleguide utilities.paddings
-*/
+/*------------------------------------*\
+  Space utilities
+\*------------------------------------*/
 
 // @stylint off
 types = {
@@ -108,9 +26,9 @@ for kType, vType in types
     for kSize, vSize in sizes
         for kDir, vDir in directions
             if vDir != all
-                .u-{kType}{kDir}-{kSize}
+                ${kType}{kDir}-{kSize}
                     {vType}-{vDir}: vSize
             else
-                .u-{kType}-{kSize}
+                ${kType}-{kSize}
                     {vType}: vSize
 // @stylint on

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -1,43 +1,14 @@
-/*
-    Text
-
-    Utilities that mess only with with wild texts.
-
-    Styleguide utilities.text
-*/
-
-/*
-    Error
-
-    Utilities that give text some semantic color in case of error.
-
-    Markup: <p class="{{modifier_class}}">Somehow you messed up somewhere.</p>
-
-    .u-error - simple error text
-
-    Styleguide utilities.text.error
-*/
-
-/*
-    Error with warning icon
-
-    Utilities that give text some semantic color in case of important error.
-
-    Markup: <p class="u-error {{modifier_class}}">You really missed, badly.</p>
-
-    .u-error--warning - error with warning icon
-
-    Styleguide utilities.text.errorWarn
-*/
-
 @require '../settings/palette'
 
-.coz-error // deprecated
-.u-error
+/*------------------------------------*\
+  Text utilities
+\*------------------------------------*/
+
+$error
     color  pomegranate
 
-    &.coz-error--warning:before // deprecated
-    &.u-error--warning:before
+$error-warning
+    &:before
         content         ''
         display         inline-block
         margin-right    .5rem
@@ -46,30 +17,8 @@
         background      embedurl('../assets/icons/ui/icon-warning.svg') center center / contain no-repeat
         vertical-align  text-bottom
 
-/*
- Valid
-
- Utilities that give text some semantic color in case of success.
-
- Markup: <p class="{{modifier_class}}">Yay, you did it!</p>
-
- .u-valid - simple valid text
-
- Styleguide utilities.text.valid
-*/
-.u-valid
+$valid
     color  malachite
 
-/*
- Warning
-
- Utilities that give text some semantic color in case of warning.
-
- Markup: <p class="{{modifier_class}}">Ok, something went wrong but it's not that bad.</p>
-
- .u-warn - simple warning text
-
- Styleguide utilities.text.warn
-*/
-.u-warn
+$warn
     color  texas-rose


### PR DESCRIPTION
Replaced CSS classes with placeholders to gain performance.
Used a `build.styl` file to replace those missing classes (for the styleguide or people who wants vanilla CSS).