### PR TITLE
default Spinner color prevented other colors to be used

### DIFF
--- a/react/Spinner/Readme.md
+++ b/react/Spinner/Readme.md
@@ -1,6 +1,6 @@
 Show a spinner when loading something.
 
-### Default 
+### Default
 
 ```
 <Spinner />
@@ -10,7 +10,7 @@ Show a spinner when loading something.
 
 ```
 <div>
-  blue: <Spinner color='blue' />
+  (default): <Spinner />
   grey: <Spinner color='grey' />
   white: <Spinner color='white' />
   red: <Spinner color='red' />
@@ -31,7 +31,7 @@ Show a spinner when loading something.
 <div>
   tiny: <Spinner size='tiny' /><br/>
   small: <Spinner size='small' /><br/>
-  medium: <Spinner size='medium' /><br/>
+  (default): <Spinner /><br/>
   large: <Spinner size='large' /><br/>
   xlarge: <Spinner size='xlarge' /><br/>
   xxlarge: <Spinner size='xxlarge' />

--- a/react/Spinner/index.jsx
+++ b/react/Spinner/index.jsx
@@ -4,13 +4,13 @@ import classNames from 'classnames'
 
 import styles from './styles'
 
-export const Spinner = ({ t, loadingType, middle, noMargin, color = 'blue', size }) => {
+export const Spinner = ({ t, loadingType, middle, noMargin, color, size }) => {
   return (
     <div
       className={classNames(
         styles['coz-spinner'], {
           [styles['coz-spinner--middle']]: middle,
-          [styles['coz-spinner--no-margin']]: noMargin,
+          [styles['coz-spinner--nomargin']]: noMargin,
           [styles[`coz-spinner--${color}`]]: color,
           [styles[`coz-spinner--${size}`]]: size
         }

--- a/react/Spinner/index.jsx
+++ b/react/Spinner/index.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import styles from './styles'
 
-export const Spinner = ({ t, loadingType, middle, noMargin, color, size }) => {
+export const Spinner = ({ t, loadingType, middle, noMargin, color = 'blue', size }) => {
   return (
     <div
       className={classNames(

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -8,6 +8,7 @@
     &:before
         content ''
         // Default setup
+        @extend $icon-spinner-blue
         @extend $icon-16
 
     p
@@ -15,51 +16,45 @@
         color       cool-grey
         line-height 1.5
 
-// === Modifiers ===
+    // === Modifiers ===
 
-// Box-model
-.coz-spinner--middle
-    position   absolute
-    top        50%
-    left       50%
-    transform  translateX(-50%) translateY(-50%)
-    text-align  center
+    // Box-model
+    &.coz-spinner--middle
+        position   absolute
+        top        50%
+        left       50%
+        transform  translateX(-50%) translateY(-50%)
+        text-align  center
 
-    &:before
-        display     block
-        margin      0 auto
+        &:before
+            display     block
+            margin      0 auto
 
-.coz-spinner--nomargin
-    margin 0
+    &.coz-spinner--nomargin
+        margin 0
 
-// Colors
-.coz-spinner--blue:before
-    @extend $icon-spinner-blue
+    // Colors
+    &.coz-spinner--grey:before
+        @extend $icon-spinner-grey
 
-.coz-spinner--grey:before
-    @extend $icon-spinner-grey
+    &.coz-spinner--white:before
+        @extend $icon-spinner-white
 
-.coz-spinner--white:before
-    @extend $icon-spinner-white
+    &.coz-spinner--red:before
+        @extend $icon-spinner-red
 
-.coz-spinner--red:before
-    @extend $icon-spinner-red
+    // Sizes
+    &.coz-spinner--tiny:before
+        @extend $icon-8
 
-// Sizes
-.coz-spinner--tiny:before
-    @extend $icon-8
+    &.coz-spinner--small:before
+        @extend $icon-12
 
-.coz-spinner--small:before
-    @extend $icon-12
+    &.coz-spinner--large:before
+        @extend $icon-24
 
-.coz-spinner--medium:before
-    @extend $icon-16
+    &.coz-spinner--xlarge:before
+        @extend $icon-36
 
-.coz-spinner--large:before
-    @extend $icon-24
-
-.coz-spinner--xlarge:before
-    @extend $icon-36
-
-.coz-spinner--xxlarge:before
-    @extend $icon-80
+    &.coz-spinner--xxlarge:before
+        @extend $icon-80

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -8,7 +8,6 @@
     &:before
         content ''
         // Default setup
-        @extend $icon-spinner-blue
         @extend $icon-16
 
     p


### PR DESCRIPTION
Like described in the title, nothing fancy but just a fix: using another color than blue wasn't possible.