### PR TITLE
fix: locale is deprecated, parameter is lang

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -35,7 +35,7 @@ export class I18n extends Component {
   }
 
   componentWillReceiveProps (newProps) {
-    if (newProps.locale !== this.props.locale) {
+    if (newProps.lang !== this.props.lang) {
       this.init(newProps)
     }
   }
@@ -67,3 +67,5 @@ export const translate = () => {
     return _translate
   }
 }
+
+export default I18n


### PR DESCRIPTION
On utilise pas le paramètre `locale` mais `lang`.

La cozy-bar arrive à faire le changement puisqu'il surcharge la fonction : https://github.com/cozy/cozy-bar/blob/7f60e84e75d21fe3313776aa6eb34eb95a8f9958/src/lib/I18n.js#L69

Vu que je suis entrain de supprimer cette surcharge, je me dis que c'est mieux d'avoir le fix dans le fichier que tout le monde utilise ;)