### PR TITLE
💎 Release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 
+## [4.1.0] - 2017-11-28
+### Changed
+- Use babel-preset-cozy-app in .babelrc
+- Modal improvements:
+  - Cannot scroll while Modal is opened
+  - Modal content is scrollable
+  - Buttons are correctly displayed on mobile
+  - Exports <ModalDescription/> and <ModalTitle /> for complex usages
+  - Modal title can be a node
+
+### Fixed
+- Default Spinner color prevented other colors to be used
+- Visited links color
+
+### Added
+- Add direction parameter to breakpoints
+- Add shortcut to access breakpoints helper
+- Add back & forward icons
+- Add `<ActionMenu />` component: see on [style guide](https://cozy.github.io/cozy-ui/react/#actionmenu)
+- Add `<Overlay />` component: see on [style guide](https://cozy.github.io/cozy-ui/react/#overlay)
+
+### Removed
+- Remove i18n duplicate file
+
+
 ## [4.0.5] - 2017-11-16
 ### Fixed
 - 🎨 Fixing default html element's background color
@@ -509,7 +534,8 @@ on desktop or mobile view
 - Everything we did before adopting CHANGELOG…
 
 
-[Unreleased]: https://github.com/cozy/cozy-ui/compare/v4.0.5...HEAD
+[Unreleased]: https://github.com/cozy/cozy-ui/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/cozy/cozy-ui/compare/v4.0.5...v4.1.0
 [4.0.5]: https://github.com/cozy/cozy-ui/compare/v4.0.4...v4.0.5
 [4.0.4]: https://github.com/cozy/cozy-ui/compare/v4.0.3...v4.0.4
 [4.0.3]: https://github.com/cozy/cozy-ui/compare/v4.0.2...v4.0.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-ui",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Cozy apps Ui SDK",
   "repository": {
     "type": "git",

--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -61,10 +61,9 @@ I18n.childContextTypes = {
 // higher order decorator for components that need `t` and/or `f`
 export const translate = () => {
   return (WrappedComponent) => {
-    const _translate = (props, context) => (
+    return (props, context) => (
       <WrappedComponent {...props} t={context.t} f={context.f} lang={context.lang} />
     )
-    return _translate
   }
 }
 


### PR DESCRIPTION
### Changed
- Use babel-preset-cozy-app in .babelrc
- Modal improvements:
  - Cannot scroll while Modal is opened
  - Modal content is scrollable
  - Buttons are correctly displayed on mobile
  - Exports <ModalDescription/> and <ModalTitle /> for complex usages
  - Modal title can be a node

### Fixed
- Default Spinner color prevented other colors to be used
- Visited links color

### Added
- Add direction parameter to breakpoints
- Add shortcut to access breakpoints helper
- Add back & forward icons
- Add `<ActionMenu />` component: see on [style guide](https://cozy.github.io/cozy-ui/react/#actionmenu)
- Add `<Overlay />` component: see on [style guide](https://cozy.github.io/cozy-ui/react/#overlay)

### Removed
- Remove i18n duplicate file