### PR TITLE
fix: ligter margins for modal elements on mobile

### DIFF
--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -63,6 +63,7 @@ $modals
 
         +small-screen()
             font-size 1.25rem
+            margin-bottom .5rem
 
     .coz-btn-modal-close
         position         absolute
@@ -95,6 +96,7 @@ $modals
                 display flex
                 flex-direction column-reverse
                 flex-shrink 0
+                margin-top .5rem
                 button
                     width 100%
                     margin-left 0


### PR DESCRIPTION
Before:
![screenshot_2017-12-04_17-33-23](https://user-images.githubusercontent.com/1280069/33563920-7f97e5ea-d919-11e7-9a4b-affd85419c38.png)

After:
![screenshot_2017-12-04_17-31-21](https://user-images.githubusercontent.com/1280069/33563942-89a0163e-d919-11e7-98fe-ca19582250cd.png)
