### PR TITLE
Deprecate with cross

### DIFF
--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -7,7 +7,7 @@ initialState = { modalDisplayed: false};
   <button onClick={()=>setState({ modalDisplayed: !state.modalDisplayed })}>
     Toggle modal
   </button>
-  {state.modalDisplayed && <Modal title='Ada Lovelace' description={content.ada.short} secondaryAction={() => setState({ modalDisplayed: false })} /> }
+  {state.modalDisplayed && <Modal title='Ada Lovelace' description={content.ada.short} dismissAction={() => setState({ modalDisplayed: false })} /> }
 </div>
 ```
 
@@ -38,7 +38,7 @@ If you have a long content, the modal's content will scroll. For the scrollbars 
     Toggle modal
   </button>
   {state.modalDisplayed && <Modal
-    secondaryAction={()=>setState({ modalDisplayed: false})}
+    dismissAction={()=>setState({ modalDisplayed: false})}
     overflowHidden={true}
     title='Ada Lovelace'
     description={ content.ada.long } />}
@@ -63,6 +63,7 @@ const hideModal = () => setState({ modalDisplayed: false });
       primaryAction={hideModal}
       secondaryText='Touch me'
       secondaryAction={hideModal}
+      dismissAction={hideModal}
       overflowHidden={true}
       title='Ada Lovelace'
       description={ content.ada.short } /> }
@@ -83,7 +84,7 @@ const { ModalDescription, ModalTitle } = Modal;
   {state.modalDisplayed &&
     <Modal
         overflowHidden={true}
-        secondaryAction={()=>setState({ modalDisplayed: false})} >
+        dismissAction={()=>setState({ modalDisplayed: false})} >
       <div style={{background: 'red', color: 'white'}}>
         <ModalTitle>Yo ho ho !</ModalTitle>
       </div>

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -11,16 +11,16 @@ initialState = { modalDisplayed: false};
 </div>
 ```
 
-### No cross
+### Closable
 
-With `withCross` set to `false`, the user will not be able to close the modal, even by clicking outside the modal. You must manage the modal's closing by yourself.
+With `closable` set to `false`, the user will not be able to close the modal, even by clicking outside the modal. You must manage the modal's closing by yourself.
 
 ```
 <div>
   <button onClick={()=>setState({ modalDisplayed: !state.modalDisplayed })}>
     Toggle modal
   </button>
-  {state.modalDisplayed && <Modal withCross={false}
+  {state.modalDisplayed && <Modal closable={false}
   title='Ada Lovelace' description={<div>
     <button onClick={()=>setState({modalDisplayed: false})}>Close the modal</button><br/>
     { content.ada.short }

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import styles from './styles.styl'
 import Overlay from '../Overlay'
+import migrateProps from '../helpers/migrateProps'
 
 const ModalContent = ({children, className}) =>
   (<div className={classNames(styles['coz-modal-content'], className)}>
@@ -21,8 +22,8 @@ const ModalTitle = ({ children, className }) =>
     </h2>
   )
 
-const ModalCross = ({ withCross, secondaryAction, secondaryText }) =>
-  withCross &&
+const ModalCross = ({ closable, secondaryAction, secondaryText }) =>
+  closable &&
   (
     <button
       className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'])}
@@ -64,11 +65,11 @@ class Modal extends Component {
   }
 
   render () {
-    const { children, description, title, withCross, overflowHidden, className } = this.props
+    const { children, description, title, closable, overflowHidden, className } = this.props
     return (
       <div className={styles['coz-modal-container']}>
-        <Overlay onEscape={withCross && this.props.secondaryAction}>
-          <div className={styles['coz-modal-wrapper']} onClick={withCross && this.handleOutsideClick}>
+        <Overlay onEscape={closable && this.props.secondaryAction}>
+          <div className={styles['coz-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
             <div className={classNames(styles['coz-modal'], className, { [styles['coz-modal--overflowHidden']]: overflowHidden })}>
               <ModalCross {...this.props} />
               { title && <ModalTitle>{ title }</ModalTitle> }
@@ -92,18 +93,20 @@ Modal.propTypes = {
   primaryType: PropTypes.string,
   primaryText: PropTypes.string,
   primaryAction: PropTypes.func,
-  withCross: PropTypes.bool,
+  closable: PropTypes.bool,
   overflowHidden: PropTypes.bool
 }
 
 Modal.defaultProps = {
   primaryType: 'secondary',
   secondaryType: 'regular',
-  withCross: true,
+  closable: true,
   overflowHidden: false
 }
 
-export default Modal
+export default migrateProps([
+  { src: 'withCross', dest: 'closable' }, // withCross -> closable
+])(Modal)
 
 // to be able to use them in Styleguidist
 Object.assign(Modal, {

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -22,14 +22,14 @@ const ModalTitle = ({ children, className }) =>
     </h2>
   )
 
-const ModalCross = ({ closable, secondaryAction, secondaryText }) =>
+const ModalCross = ({ closable, dismissAction, secondaryText }) =>
   closable &&
   (
     <button
       className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'])}
-      onClick={secondaryAction}
+      onClick={dismissAction}
       >
-      <span className={styles['coz-hidden']}>{secondaryText}</span>
+      <span className={styles['coz-hidden']}></span>
     </button>
 )
 
@@ -61,14 +61,14 @@ const ModalButtons = ({ secondaryText, secondaryAction, secondaryType, primaryTe
 
 class Modal extends Component {
   handleOutsideClick = (e) => {
-    if (e.target === e.currentTarget) this.props.secondaryAction()
+    if (e.target === e.currentTarget) this.props.dismissAction()
   }
 
   render () {
-    const { children, description, title, closable, overflowHidden, className } = this.props
+    const { children, description, title, closable, dismissAction, overflowHidden, className } = this.props
     return (
       <div className={styles['coz-modal-container']}>
-        <Overlay onEscape={closable && this.props.secondaryAction}>
+        <Overlay onEscape={closable && dismissAction}>
           <div className={styles['coz-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
             <div className={classNames(styles['coz-modal'], className, { [styles['coz-modal--overflowHidden']]: overflowHidden })}>
               <ModalCross {...this.props} />
@@ -106,6 +106,20 @@ Modal.defaultProps = {
 
 export default migrateProps([
   { src: 'withCross', dest: 'closable' }, // withCross -> closable
+  {
+    fn: props => {
+      let newProps
+      if (props.secondaryAction && !props.dismissAction) {
+        newProps = {...props}
+        newProps.dismissAction = props.secondaryAction
+        const msg =
+          'In the future, `secondaryAction` will not be bound to closing actions (clicking on cross, clicking outside), please use `dismissAction` for that'
+        return [newProps, msg]
+      } else {
+        return [props, null]
+      }
+    }
+  }
 ])(Modal)
 
 // to be able to use them in Styleguidist

--- a/react/helpers/migrateProps.jsx
+++ b/react/helpers/migrateProps.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+
+const migrate = (oldProps, options, Component) => {
+  let newProps, msg
+  for (let option of options) {
+    if (option.src && option.dest) { // simple mode
+      const src = option.src
+      const dest = option.dest
+      const oldProp = oldProps[src]
+      if (oldProp === undefined) { continue }
+      newProps = newProps || {...oldProps} // copy props only if we change them
+      newProps[dest] = oldProps[src]
+      delete newProps[src]
+      msg = `\`${src}\` is deprecated and has been migrated automatically, you should use \`${dest}\` now`
+    } else if (option.fn) { // advanced mode
+      const res = option.fn(newProps || oldProps)
+      if (res.length !== 2) { throw new Error('migrateOption `fn` should return [newProps, msg].') }
+      [newProps, msg] = res
+    } else {
+      console.warn('migrateProps option is not valid, valid properties are `src`, `dest`, `fn`. You passed', option)
+    }
+    if (process.env.NODE_ENV !== 'production' && msg) {
+      console.warn(`Deprecation: ${msg}`)
+      msg = null
+    }
+  }
+  // It is possible that no migration has been made, in this case newProps is undefined and we simply
+  // return the oldProps
+  return newProps || oldProps
+}
+
+/**
+ * HOC to migrate old props for deprecation purpose.
+ *
+ * @example
+ * Let's say we deprecated the property `withCross` of Modal and replaced
+ * it with `closable`. To preserve backward compatibility we use the `migrate`
+ * HOC, and provide an array of migrations to perform on the old props.
+ *
+ * ```
+ * const migrateOptions = [{ src: 'withCross', dest: 'closable'}]
+ * const Modal = migrate(migrateOptions)(_Modal)
+ * ```
+ *
+ * Here we only have one migration, to rename `withCross` (source) to `closable` (destination).
+ * For more complex migration, it is possible to use the `fn` property of a migration. In this
+ * case you are responsible for providing a warning message as part of the return value of `fn`.
+ *
+ * ```
+ * const migrateClosableAndReverse = oldProps => {
+ *   let newProps
+ *   if (oldProps.withoutCross) {
+ *     newProps = {...oldProps}
+ *     newProps.closable = !oldProps.withoutCross
+ *     return [newProps, '`withoutCross` is deprecated. Use `closable` now. Be careful closable = !withoutCross']
+ *   } else {
+ *     return [oldProps, null]
+ *   }
+ *   return newProps || oldProps
+ * }
+ *
+ * const migrateOptions = [{ fn: migrateClosableAndReverse }]
+ * const Modal = migrate(migrateOptions)(_Modal)
+ * ```
+ *
+ * @param  {Array} migrateOptions - Prop migrations that will be done on the old props
+ * @return {[type]}         [description]
+ */
+export default migrateOptions => Wrapped => oldProps => {
+  const newProps = migrate(oldProps, migrateOptions, Wrapped)
+  return <Wrapped {...newProps} />
+}


### PR DESCRIPTION
- [x] HOC to handle migrations
- [x] `withCross` property is renamed to `closable`. Backward compatibility is preserved via automatic renaming of the property
- [x]  Add `dismissAction` property that will be callled on click outside on on click on the cross. Backward compatibility is preserved by copying `secondaryAction` into this property if it does not exist