### PR TITLE
Paperplane icon

### DIFF
--- a/assets/icons/ui/icon-paperplane.svg
+++ b/assets/icons/ui/icon-paperplane.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <g fill="none" fill-rule="evenodd" transform="translate(-256 -64)">
-    <polygon fill="#FFFFFF" points="272 64 266 79 263.5 76.5 260 79 259 75 269 66.5 259 72.5 256 70"/>
+  <g fill-rule="evenodd" transform="translate(-256 -64)">
+    <polygon points="272 64 266 79 263.5 76.5 260 79 259 75 269 66.5 259 72.5 256 70"/>
   </g>
 </svg>


### PR DESCRIPTION
- [x] Remove color from SVG

Fixes https://github.com/cozy/cozy-ui/issues/210

This icon is not used in our codebase since drive uses two custom paperplane icons : 

- drive/mobile/assets/icons/icon-paperplane-blue.svg
- drive/mobile/assets/icons/icon-paperplane-white.svg

In the future, I think drive should used colorless icons with the `Icon` components which lets you control the color of the icon without duplicating the file.

Occurences of paperplane

```bash
cozy $   rg paperplane
cozy-ui/src/icons.jsx
20:    'icon-paperplane',

cozy-ui/react/README.md
45:* paperplane

cozy-ui/stylus/components/button.styl
149:    background-image     embedurl('../assets/icons/ui/icon-paperplane.svg')

drive/src/drive/mobile/styles/feedback.styl
20:.c-btn--paperplane
21:    background-image embedurl('../assets/icons/icon-paperplane-white.svg')

drive/src/drive/mobile/ducks/mediaBackup/styles.styl
59:    background embedurl('../../assets/icons/icon-paperplane-blue.svg') .2rem center no-repeat

drive/src/drive/mobile/ducks/mediaBackup/UploadQuotaError.jsx
74:                  styles['c-btn--paperplane']
```

Occurrences of `button-send` : 

```bash
cozy $   rg 'button--send'
cozy-ui/CHANGELOG.md
246:- `$button--send` class for button with paperplan icon

cozy-ui/stylus/components/button.styl
147:$button--send

cozy-ui/stylus/cozy-ui/build.styl
98:    @extend $button--send
```

Occurrences of `c-btn--send` : 

```bash
 cozy   rg 'c-btn--send'
cozy-ui/stylus/cozy-ui/build.styl
87: .c-btn--send - Send
97:.c-btn--send
```