### PR TITLE
✨ feat: add doc for <Menu /> and improvements

### DIFF
--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import Hammer from 'hammerjs'
-import Menu from '../Menu'
 import styles from './styles.styl'
 import Overlay from '../Overlay'
 import once from 'lodash/once'
@@ -126,12 +125,14 @@ class ActionMenu extends Component {
   }
 
   render () {
-    const props = this.props
+    const { children } = this.props
     const { closing } = this.state
     return (
       <div className={styles.ActionMenu}>
         <Overlay style={{ opacity: closing ? 0 : 1 }} onClick={this.animateClose} onEscape={this.animateClose}>
-          <Menu className={styles['c-actionmenu']} {...props} ref={this.handleMenuRef} />
+          <div className={styles['c-actionmenu']} ref={this.handleMenuRef}>
+            { children }
+          </div>
         </Overlay>
       </div>
     )

--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -13,7 +13,7 @@ const showWarning = itemData => alert(itemData + ' is disabled');
   <MenuItem data='hello'>Hello !</MenuItem>
   <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
   <hr />
-  <MenuItem data='hola'>¡Hola!</MenuItem>
+  <MenuItem icon={<Icon icon='paperplane'/>} data='hola'>¡Hola!</MenuItem>
 </Menu>
 ```
 
@@ -21,6 +21,7 @@ Use the `position` attribute to put the menu to the right.
 
 ```
 const { MenuItem } = require('.');
+const { Icon } = require('../Icon');
 
 <Menu position='right' text='Click me !' onSelect={ itemData => alert(JSON.stringify(itemData)) }>
   <MenuItem data='hello'>Hello !</MenuItem>

--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -1,0 +1,43 @@
+A menu to display choices to the user.
+
+Pass data to the `MenuItem`s and use `onSelect` to handle user selecting
+an item in the `Menu`.
+
+```
+const { MenuItem } = require('.');
+const Button = require('../Button').default;
+const showItem = itemData => alert(JSON.stringify(itemData));
+const showWarning = itemData => alert(itemData + ' is disabled');
+
+<Menu text='Click me !' onSelect={ showItem } onSelectDisabled={ showWarning }>
+  <MenuItem data='hello'>Hello !</MenuItem>
+  <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
+  <hr />
+  <MenuItem data='hola'>¡Hola!</MenuItem>
+</Menu>
+```
+
+Use the `position` attribute to put the menu to the right.
+
+```
+const { MenuItem } = require('.');
+
+<Menu position='right' text='Click me !' onSelect={ itemData => alert(JSON.stringify(itemData)) }>
+  <MenuItem data='hello'>Hello !</MenuItem>
+  <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
+  <MenuItem data='hola'>¡Hola!</MenuItem>
+</Menu>
+```
+
+Use the `component` attribute if you want to use a custom component for the
+opener.
+
+```
+const { MenuItem } = require('.');
+
+<Menu component={<Button>Greetings with custom component</Button>} onSelect={ itemData => alert(JSON.stringify(itemData)) }>
+  <MenuItem data='hello'>Hello !</MenuItem>
+  <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
+  <MenuItem data='hola'>¡Hola!</MenuItem>
+</Menu>
+```

--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -3,6 +3,10 @@ A menu to display choices to the user.
 Pass data to the `MenuItem`s and use `onSelect` to handle user selecting
 an item in the `Menu`.
 
+`MenuItem`s can also have their own `onSelect`, in this case, the global
+`onSelect` will not be called. `MenuItem`s `onSelect` is not called if
+the item is `disabled`.
+
 ```
 const { MenuItem } = require('.');
 const Button = require('../Button').default;
@@ -13,7 +17,7 @@ const showWarning = itemData => alert(itemData + ' is disabled');
   <MenuItem data='hello'>Hello !</MenuItem>
   <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
   <hr />
-  <MenuItem icon={<Icon icon='paperplane'/>} data='hola'>¡Hola!</MenuItem>
+  <MenuItem icon={<Icon icon='paperplane'/>} onSelect={x => alert('You clicked hola')} data='hola'>¡Hola!</MenuItem>
 </Menu>
 ```
 

--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -3,9 +3,10 @@ import classNames from 'classnames'
 import styles from './styles.styl'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
+import { Media, Bd, Img } from '../Media'
 
 class MenuItem extends Component {
-  render ({ disabled, className, onClick, children }) {
+  render ({ disabled, className, onClick, children, icon }) {
     return (
       <div
           className={
@@ -14,7 +15,14 @@ class MenuItem extends Component {
             }, className)
           }
           onClick={onClick}>
-        {children}
+        { !icon ? children : (
+          <Media>
+            <Img className={styles['c-menu__item-icon']}>
+              { icon }
+            </Img>
+            <Bd>{ children }</Bd>
+          </Media>
+        )}
       </div>
     )
   }

--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -9,12 +9,12 @@ class MenuItem extends Component {
   render ({ disabled, className, onClick, children, icon }) {
     return (
       <div
+          onClick={ onClick }
           className={
             cx(styles['c-menu__item'], {
               [styles['c-menu__item--disabled']]: disabled
             }, className)
-          }
-          onClick={onClick}>
+          }>
         { !icon ? children : (
           <Media>
             <Img className={styles['c-menu__item-icon']}>
@@ -40,9 +40,10 @@ class Menu extends Component {
     }
   }
 
-  handleSelect = (item, e) => {
+  handleClick = (item, e) => {
     const isDisabled = item.props.disabled
-    const handler = this.props[!isDisabled ? 'onSelect' : 'onSelectDisabled']
+    const itemHandler = isDisabled ? null : item.props.onSelect
+    const handler = itemHandler || this.props[!isDisabled ? 'onSelect' : 'onSelectDisabled']
     if (handler) {
       const res = handler(item.props.data)
       if (res !== false) {
@@ -74,10 +75,10 @@ class Menu extends Component {
       // type === Item, but for some reason, preact vnodes don't have this property
       if (item.nodeName !== 'hr') {
         return React.cloneElement(item, {
-          onClick: this.handleSelect.bind(this, item)
+          onClick: this.handleClick.bind(this, item)
         })
       }
-      return React.cloneElement(item)
+      return item
     })
   }
 

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -36,12 +36,18 @@
 .c-menu__btn:not([disabled]):not([aria-disabled=true]):focus
     background transparent
 
+$paddingItem = .5rem
+
 .c-menu__item
     cursor pointer
-    padding   .5rem .5rem
+    padding   $paddingItem
 
 .c-menu__item-icon
-    margin-right 0.5rem
+    $marginIcon = .75rem
+    margin-right $marginIcon
+    // we need to compensate for the already present margin
+    margin-left $marginIcon - $paddingItem
+    font-size 1.0625rem
 
 .c-menu__item:hover
 .c-menu__item:focus

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -1,5 +1,49 @@
-@require '../../stylus/components/menu'
+@require 'settings/palette.styl'
+@require 'components/popover.styl'
 
-.c-menu-wrapper
-    @extend $menu
-    background: red
+.c-menu
+    position relative
+    display  inline-block
+
+.c-menu__inner
+    @extend    $popover
+    display    none
+    position   absolute
+    margin     0
+    margin-top 1px
+    min-width  220px
+    // cuts the hover background properly (border-radius)
+    overflow   hidden
+    border 0
+
+.c-menu--left
+    .c-menu__inner
+        left 0
+
+.c-menu--right
+    .c-menu__inner
+        right 0
+
+.c-menu__inner--opened
+    display block
+
+.c-menu__btn
+    font-size 1rem
+    border 0
+
+.c-menu__btn:not([disabled]):not([aria-disabled=true]):hover
+.c-menu__btn:not([disabled]):not([aria-disabled=true]):active
+.c-menu__btn:not([disabled]):not([aria-disabled=true]):focus
+    background transparent
+
+.c-menu__item
+    cursor pointer
+    padding   .5rem .5rem
+
+.c-menu__item:hover
+.c-menu__item:focus
+    background-color paleGrey
+    outline          none
+
+.c-menu__item--disabled
+    opacity .5

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -40,6 +40,9 @@
     cursor pointer
     padding   .5rem .5rem
 
+.c-menu__item-icon
+    margin-right 0.5rem
+
 .c-menu__item:hover
 .c-menu__item:focus
     background-color paleGrey

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -22,7 +22,7 @@ $popover
     // @stylint on
 
     hr
-        margin      em(5px) 0
+        margin      .3125rem 0
         border      0
         border-top  1px solid silver
 

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -1,3 +1,4 @@
+@require '../settings/palette'
 @require '../settings/z-index'
 
 /*------------------------------------*\


### PR DESCRIPTION
https://ptbrowne.github.io/cozy-ui/react/#menu

Prop name | Type | Default | Description
-- | -- | -- | --
position | string | left | Use position='right' to display the menu to the right
disabled | bool | false | Disables the menu
component | element | null | Specifies a custom component for the opener
onSelect | func | null | onClick handler for non disabled items
onSelectDisabled | func | null | onClick handler for disabled items

<img width='250px' src='https://user-images.githubusercontent.com/465582/33841266-9027640c-de97-11e7-93b8-f900b9e3f0a8.png' />


