### PR TITLE
Modal cross classname

### DIFF
--- a/react/IntentOpener/IntentIframe.jsx
+++ b/react/IntentOpener/IntentIframe.jsx
@@ -4,6 +4,13 @@ import PropTypes from 'prop-types'
 import Spinner from '../Spinner'
 import styles from './styles.styl'
 
+const DEFAULT_OPTIONS = {
+  // TODO remove `closeable` since it is only there for backward compatibility
+  // https://mattermost.cozycloud.cc/test-team/pl/t1iagfhqp3n8mqf3nchp6bxsur
+  closeable: false,
+  exposeIntentFrameRemoval: true
+}
+
 class IntentIframe extends React.Component {
   state = { loading: false }
 
@@ -14,7 +21,7 @@ class IntentIframe extends React.Component {
 
     this.setState({ loading: true })
     create(action, doctype, {
-        exposeIntentFrameRemoval: true,
+        ...DEFAULT_OPTIONS,
         ...options
       })
       .start(this.intentViewer, this.onFrameLoaded)

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -72,7 +72,7 @@ const hideModal = () => setState({ modalDisplayed: false });
 
 ### Complex modals
 
-For more complex modals, you can use individual components
+For more complex modals, you can use individual components.
 
 ```
 const { ModalDescription, ModalTitle } = Modal;

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -22,9 +22,9 @@ const ModalTitle = ({ children, className }) =>
     </h2>
   )
 
-const ModalCross = ({ onClick }) => (
+const ModalCross = ({ onClick, className }) => (
   <button
-    className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'])}
+    className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'], className)}
     onClick={onClick}
     >
     <span className={styles['coz-hidden']}></span>
@@ -63,13 +63,13 @@ class Modal extends Component {
   }
 
   render () {
-    const { children, description, title, closable, dismissAction, overflowHidden, className } = this.props
+    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName } = this.props
     return (
       <div className={styles['coz-modal-container']}>
         <Overlay onEscape={closable && dismissAction}>
           <div className={styles['coz-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
             <div className={classNames(styles['coz-modal'], className, { [styles['coz-modal--overflowHidden']]: overflowHidden })}>
-              { closable && <ModalCross onClick={dismissAction} /> }
+              { closable && <ModalCross className={crossClassName} onClick={dismissAction} /> }
               { title && <ModalTitle>{ title }</ModalTitle> }
               { description && <ModalDescription>{ description }</ModalDescription> }
               { children }
@@ -93,6 +93,8 @@ Modal.propTypes = {
   primaryAction: PropTypes.func,
   closable: PropTypes.bool,
   overflowHidden: PropTypes.bool
+  /** `className` used on the cross, useful if you want to custom its CSS */
+  crossClassName: PropTypes.string
 }
 
 Modal.defaultProps = {

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -32,7 +32,7 @@ const ModalCross = ({ onClick, className }) => (
 )
 
 const ModalDescription = ({ children, className }) => (
-  <div className={classNames(styles['coz-modal-content'], styles['coz-description'])}>
+  <div className={classNames(styles['coz-modal-content'], styles['coz-description'], className)}>
     {children}
   </div>
 )

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -83,16 +83,28 @@ class Modal extends Component {
 }
 
 Modal.propTypes = {
+  /** Modal title */
   title: PropTypes.node,
+  /** Content for simple modals */
   description: PropTypes.node,
+  /** Secondary button type */
   secondaryType: PropTypes.string,
+  /** Secondary button text*/
   secondaryText: PropTypes.string,
+  /** Secondary button callback */
   secondaryAction: PropTypes.func,
+  /** Primary button type */
   primaryType: PropTypes.string,
+  /** Primary button text*/
   primaryText: PropTypes.string,
+  /** Primary button callback */
   primaryAction: PropTypes.func,
+  /** Display the cross and enable click outside and escape key to close */
   closable: PropTypes.bool,
-  overflowHidden: PropTypes.bool
+  /** Use overflowHidden when your content may overflow of your modal */
+  overflowHidden: PropTypes.bool,
+  /** `className` used on the modal, useful if you want to custom its CSS */
+  className: PropTypes.string,
   /** `className` used on the cross, useful if you want to custom its CSS */
   crossClassName: PropTypes.string
 }

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -22,19 +22,17 @@ const ModalTitle = ({ children, className }) =>
     </h2>
   )
 
-const ModalCross = ({ closable, dismissAction, secondaryText }) =>
-  closable &&
-  (
-    <button
-      className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'])}
-      onClick={dismissAction}
-      >
-      <span className={styles['coz-hidden']}></span>
-    </button>
+const ModalCross = ({ onClick }) => (
+  <button
+    className={classNames(styles['coz-btn'], styles['coz-btn--close'], styles['coz-btn-modal-close'])}
+    onClick={onClick}
+    >
+    <span className={styles['coz-hidden']}></span>
+  </button>
 )
 
 const ModalDescription = ({ children, className }) => (
-  <div className={classNames(styles['coz-modal-content'], styles['coz-description'], className)}>
+  <div className={classNames(styles['coz-modal-content'], styles['coz-description'])}>
     {children}
   </div>
 )
@@ -71,7 +69,7 @@ class Modal extends Component {
         <Overlay onEscape={closable && dismissAction}>
           <div className={styles['coz-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
             <div className={classNames(styles['coz-modal'], className, { [styles['coz-modal--overflowHidden']]: overflowHidden })}>
-              <ModalCross {...this.props} />
+              { closable && <ModalCross onClick={dismissAction} /> }
               { title && <ModalTitle>{ title }</ModalTitle> }
               { description && <ModalDescription>{ description }</ModalDescription> }
               { children }


### PR DESCRIPTION
- Ability to pass `crossClassName` to `<Modal />` that gets applied to the `<ModalCross />`
- Add doc

fixing https://github.com/cozy/cozy-ui/issues/248