### PR TITLE
Intent modal cross

### DIFF
--- a/react/IntentOpener/IntentOpener.jsx
+++ b/react/IntentOpener/IntentOpener.jsx
@@ -53,7 +53,13 @@ class IntentOpener extends React.Component {
 
     if (modalOpened) {
       elements.push(
-        <Modal key='modal' closable={closable} overflowHidden className={styles.intentModal} dismissAction={this.handleDismiss}>
+        <Modal
+            key='modal'
+            closable={closable}
+            overflowHidden
+            className={styles.intentModal}
+            crossClassName={styles.intentModal__cross}
+            dismissAction={this.handleDismiss}>
           <IntentIframe
             action={action}
             doctype={doctype}

--- a/react/IntentOpener/styles.styl
+++ b/react/IntentOpener/styles.styl
@@ -33,3 +33,9 @@
     display flex
     justify-content center
     align-items center
+
+// TODO remove the second selector when specificity
+// of cozy-ui selectors has decreased
+.intentModal__cross.intentModal__cross
+    top .25rem
+    right .25rem


### PR DESCRIPTION
~~⚠️ Wait for #249 to be merged~~ EDIT: merged ✅

Use the new crossClassName to apply a specific class to intent modals cross since they need to be displayed inside the collect bar.

Before

![image](https://user-images.githubusercontent.com/465582/33934825-4c2d9c26-dffa-11e7-9f49-42d7c95e163d.png)

After

![image](https://user-images.githubusercontent.com/465582/33934856-5c2bd1a6-dffa-11e7-94b1-44ce85f8fdd5.png)

