### PR TITLE
fix: New layout on iOS 9-10

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -80,6 +80,10 @@ $app-2panes-sticky
     +medium-screen()
         display block
 
+        main,
+        main > [role=contentinfo]
+            display block
+
         // Those pseudo-elements are "ghost" elements replacing bar and nav
         &:before
         &:after


### PR DESCRIPTION
Removed `display: flex` on `.main` & `[role=contentinfo]` so the layout doesn't break on iOS 9-10 Safari.