### PR TITLE
Overflow hidden only if body taller than viewport

### DIFF
--- a/react/Overlay/index.jsx
+++ b/react/Overlay/index.jsx
@@ -27,9 +27,6 @@ class Overlay extends Component {
     if (bodyTallerThanWindow()) {
       this.restoreScrollBody = disableScroll(document.body)
       this.restoreScrollHtml = disableScroll(document.body.parentNode)
-      console.log('Overflow hidden')
-    } else {
-      console.log('No overflow hidden')
     }
     if (this.props.onEscape) {
       document.addEventListener('keydown', this.handleKeydown)

--- a/react/Overlay/index.jsx
+++ b/react/Overlay/index.jsx
@@ -12,6 +12,10 @@ const disableScroll = node => {
 
 const ESC_KEYCODE = 27
 
+const bodyTallerThanWindow = () => {
+  return document.body.getBoundingClientRect().height > window.innerHeight
+}
+
 /**
  * Display a black overlay on the screen. Stops
  * scrolling on the html/body while displayed.
@@ -20,8 +24,13 @@ const ESC_KEYCODE = 27
  */
 class Overlay extends Component {
   componentDidMount () {
-    this.restoreScrollBody = disableScroll(document.body)
-    this.restoreScrollHtml = disableScroll(document.body.parentNode)
+    if (bodyTallerThanWindow()) {
+      this.restoreScrollBody = disableScroll(document.body)
+      this.restoreScrollHtml = disableScroll(document.body.parentNode)
+      console.log('Overflow hidden')
+    } else {
+      console.log('No overflow hidden')
+    }
     if (this.props.onEscape) {
       document.addEventListener('keydown', this.handleKeydown)
     }

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -20,9 +20,6 @@ textarea
 // LAYOUT
 html
   height  100%
-  // Necessary not to have broken layout on iOS
-  // https://github.com/cozy/cozy-ui/issues/161
-  overflow hidden
 
 body
   display         flex
@@ -30,15 +27,12 @@ body
   align-items     stretch
   width           100vw
   height          100%
-  overflow        hidden
 
 html
 body
     +medium-screen()
         display block
         height auto
-        overflow auto
-        overflow-x hidden
 
 [role=application]
     display     flex
@@ -46,6 +40,9 @@ body
     flex        1 1 100%
     overflow-x  hidden
     overflow-y  auto
+
+     +medium-screen()
+        overflow visible
 
 // COLORS
 html,

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -76,6 +76,7 @@ $app-2panes-sticky
     main,
     main > [role=contentinfo]
         height auto
+        overflow visible
 
     +medium-screen()
         display block


### PR DESCRIPTION
Made sure that if the body is taller than the viewport, content behind the modal doesn't scroll and if the body is smaller then the modal isn't cropped by an overflow.