### PR TITLE
📚 doc: fixed max instead of min in breakpoint stylus styleguide

### DIFF
--- a/stylus/settings/breakpoints.styl
+++ b/stylus/settings/breakpoints.styl
@@ -80,7 +80,7 @@ medium-screen(direction='max')
     large-screen()
 
     large-screen() Refers to (max-width: 1200px)
-    large-screen('min') Refers to (max-width: 1201px)
+    large-screen('min') Refers to (min-width: 1201px)
 
     Weight: -2
 


### PR DESCRIPTION
[`large-screen`](https://cozy.github.io/cozy-ui/styleguide/section-settings.html#kssref-settings-breakpoints-large) media query mixin documentation was indicating that "large-screen('**min**') Refers to (**max**-width: 1201px)".