### PR TITLE
fix: oops didn't code on the right selector

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -76,7 +76,6 @@ $app-2panes-sticky
     main,
     main > [role=contentinfo]
         height auto
-        overflow visible
 
     +medium-screen()
         display block
@@ -84,6 +83,7 @@ $app-2panes-sticky
         main,
         main > [role=contentinfo]
             display block
+            overflow visible
 
         // Those pseudo-elements are "ghost" elements replacing bar and nav
         &:before


### PR DESCRIPTION
What fatigue does to us…
The previous fix was good, just not at the right place, causing desktop view to scroll entirely when it obviously shouldn't.