### PR TITLE
Deprecate font size em

### DIFF
--- a/stylus/scripts/deprecate.js
+++ b/stylus/scripts/deprecate.js
@@ -1,0 +1,19 @@
+const nodes = require('stylus/lib/nodes')
+const chalk = require('chalk')
+
+const last = function (arr) {
+  return arr[arr.length - 1]
+}
+const plugin = function () {
+  return function (style) {
+    style.define('deprecate', function (msg) {
+      const parentSel = last(this.selectorStack)[0]
+      if (process.env.SHOW_STYLUS_DEPRECATION) {
+        console.log(chalk.yellow('\nDeprecation: ' + parentSel.filename + ':' + parentSel.lineno + '\n' + msg.val))
+      }
+      return nodes.null
+    })
+  }
+}
+
+module.exports = plugin

--- a/stylus/scripts/deprecate.js
+++ b/stylus/scripts/deprecate.js
@@ -8,9 +8,7 @@ const plugin = function () {
   return function (style) {
     style.define('deprecate', function (msg) {
       const parentSel = last(this.selectorStack)[0]
-      if (process.env.SHOW_STYLUS_DEPRECATION) {
-        console.log(chalk.yellow('\nDeprecation: ' + parentSel.filename + ':' + parentSel.lineno + '\n' + msg.val))
-      }
+      console.log(chalk.yellow('\nDeprecation: ' + parentSel.filename + ':' + parentSel.lineno + '\n' + msg.val))
       return nodes.null
     })
   }

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -105,16 +105,16 @@ font-size(n)
 //  applies a conversion to _EM_ based on the contextual basefont size.
 em(n, base = null)
     if base is not null
-        basefont = base
+        ctx_font = base
     else
         _id = checksum(selector())
         if _id in basefonts
-            basefont = basefonts[_id]
+            ctx_font = basefonts[_id]
         else
-            basefont = context-basefont(selector())
+            ctx_font = context-basefont(selector())
 
     if unit(n) is 'px'
-        val = round(n / basefont, 5)
+        val = round(n / ctx_font, 5)
     else
         val = n
     unit(val, 'em')

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -41,6 +41,7 @@
 // @stylint off
 use('../scripts/checksum.js')
 use('../scripts/split.js')
+use('../scripts/deprecate.js')
 
 // Contextual fonts store, based on the selector checksum hash
 basefonts = {}
@@ -79,7 +80,10 @@ font-size(n)
 
     unitName=unit(n)
     if unitName is 'px'
-        font-size em(n, currentBasefont)
+        res=em(n, currentBasefont)
+        res_rem=unit(em(res/basefont), 'rem')
+        deprecate('font-size will no longer convert px to em, use rem. Replace font-size: ' + n + ' by font-size: ' + res_rem + ' (ctx_font: ' + currentBasefont +')')
+        font-size res
     else
         font-size n
 
@@ -115,6 +119,9 @@ em(n, base = null)
 
     if unit(n) is 'px'
         val = round(n / ctx_font, 5)
+        em_val = unit(val, 'em')
+        rem_val = unit(round(n / basefont, 5), 'rem')
+        deprecate('Do not use em() : replace ' + n + ' by ' + rem_val + ' (output em: ' + em_val + ', ctx_font: ' + ctx_font + ')')
     else
         val = n
     unit(val, 'em')

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -51,7 +51,7 @@ basefonts = {}
 basefont = 16px
 
 // contextual-basefont takes a selector string as input, and try to get the
-// basefont in this context. If it doesn't explcitely exists, it checks its
+// basefont in this context. If it doesn't explicitely exists, it checks its
 // parent, etc, and fallback to the global basefont.
 context-basefont(selector)
     parent = split(' ', selector)

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -45,6 +45,11 @@ use('../scripts/split.js')
 // Contextual fonts store, based on the selector checksum hash
 basefonts = {}
 
+// We need a base font-size for _px to em_ computation. We assume those size to
+// be 16px (as default desktop browsers), but it really don't care as well as
+// all relative units should be expressed in `em`
+basefont = 16px
+
 // contextual-basefont takes a selector string as input, and try to get the
 // basefont in this context. If it doesn't explcitely exists, it checks its
 // parent, etc, and fallback to the global basefont.
@@ -113,12 +118,6 @@ em(n, base = null)
     else
         val = n
     unit(val, 'em')
-
-
-// We need a base font-size for _px to em_ computation. We assume those size to
-// be 16px (as default desktop browsers), but it really don't care as well as
-// all relative units should be expressed in `em`
-basefont = 16px
 
 /*
     hide()


### PR DESCRIPTION
- [x] Add a deprecate() function to stylus via its plugin API to be able to show deprecation messages that output the selector() using the deprecated function
- [x] Add deprecation messages for em() and font-size()
- [x] Show deprecation messages behind an environment variable flag not to pollute everything while the work on font-size and em is not done. Later we could remove this environment variable flag.

The environment variable flag is `SHOW_STYLUS_DEPRECATION`. If you launch your app watcher with this variable, you'll have deprecation warnings.

```js
env SHOW_STYLUS_DEPRECATION=1 yarn watch:browser
```