### PR TITLE
✨ feat: add missing import

### DIFF
--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -2,6 +2,7 @@
 
 // FONTS
 @require '../settings/fontstack'
+@require '../settings/breakpoints'
 
 body
     font 1em/1.5


### PR DESCRIPTION
Without that import I had a very weird error : 

```
ERROR in ./src/styles/main.styl
Module build failed: ModuleBuildError: Module build failed: Unknown word (44:19)

  42 | /**
  43 |  * Correct the font size and margin on `h1` elements within `section` and
> 44 |  * `article` contexts in Chrome, Firefox, and Safari.
     |                   ^
  45 |  */
  46 |
  47 | h1 {

    at runLoaders (/Users/pbrowne/code/cozy/bank/node_modules/webpack/lib/NormalModule.js:195:19)
    at /Users/pbrowne/code/cozy/bank/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /Users/pbrowne/code/cozy/bank/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/Users/pbrowne/code/cozy/bank/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Object.<anonymous> (/Users/pbrowne/code/cozy/bank/node_modules/css-loader/lib/loader.js:50:18)
    at /Users/pbrowne/code/cozy/bank/node_modules/css-loader/lib/processCss.js:234:4
    at runMicrotasksCallback (internal/process/next_tick.js:64:5)
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
    at process._tickCallback (internal/process/next_tick.js:104:9)
 @ ./src/main.jsx 5:0-22
 @ multi ./src/main

ERROR in ./src/styles/main.styl
Module build failed: ModuleBuildError: Module build failed: Unknown word (44:19)

  42 | /**
  43 |  * Correct the font size and margin on `h1` elements within `section` and
> 44 |  * `article` contexts in Chrome, Firefox, and Safari.
     |                   ^
  45 |  */
  46 |
  47 | h1 {

    at runLoaders (/Users/pbrowne/code/cozy/bank/node_modules/webpack/lib/NormalModule.js:195:19)
    at /Users/pbrowne/code/cozy/bank/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /Users/pbrowne/code/cozy/bank/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/Users/pbrowne/code/cozy/bank/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Object.<anonymous> (/Users/pbrowne/code/cozy/bank/node_modules/css-loader/lib/loader.js:50:18)
    at /Users/pbrowne/code/cozy/bank/node_modules/css-loader/lib/processCss.js:234:4
    at runMicrotasksCallback (internal/process/next_tick.js:64:5)
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
    at process._tickCallback (internal/process/next_tick.js:104:9)
 @ ./src/styles/main.styl
 @ ./src/main.jsx
 @ multi ./src/main
```

By doing a `git bisect`, I arrived at this commit aa00259ec9c9e9f86fd5d4c6772194fb7790a153 which has nothing to do with this error.

Looking at the file, I saw that it used `+medium-screen()` without importing `settings/breakpoints.styl`. Importing the file made the error disappear.
We have to be very careful to import the files because Stylus errors and failure modes can be very surprising :/

