### PR TITLE
fix: layout with long overflowed content

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -45,7 +45,7 @@ $fullbleed
 $app-2panes
     box-sizing  border-box
     display     flex
-    width       100%
+    max-width       100%
     height      100%
 
     main


### PR DESCRIPTION
On Firefox when a content with `white-space: nowrap`, even if its parent has `overflow:hidden`, is longer than its parent size, the flebox parent will push its width.
This fix prevents the growth of the flexbox parent.