### PR TITLE
React compatible

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -41,7 +41,7 @@ export class I18n extends Component {
   }
 
   render () {
-    return (this.props.children && this.props.children[0]) || null
+    return React.Children.only(this.props.children)
   }
 }
 
@@ -52,19 +52,21 @@ I18n.propTypes = {
   defaultLang: PropTypes.string           // default language. By default is 'en'
 }
 
-I18n.childContextTypes = {
+const i18nContextTypes = {
   t: PropTypes.func,
   f: PropTypes.func,
   lang: PropTypes.string
 }
 
+I18n.childContextTypes = i18nContextTypes
+
 // higher order decorator for components that need `t` and/or `f`
-export const translate = () => {
-  return (WrappedComponent) => {
-    return (props, context) => (
-      <WrappedComponent {...props} t={context.t} f={context.f} lang={context.lang} />
-    )
-  }
+export const translate = () => WrappedComponent => {
+  const Wrapper = (props, context) => (
+    <WrappedComponent {...props} t={context.t} f={context.f} lang={context.lang} />
+  )
+  Wrapper.contextTypes = i18nContextTypes
+  return Wrapper
 }
 
 export default I18n

--- a/react/IntentOpener/IntentIframe.jsx
+++ b/react/IntentOpener/IntentIframe.jsx
@@ -36,7 +36,9 @@ class IntentIframe extends React.Component {
     this.setState({ loading: false })
   }
 
-  render (props, { loading }) {
+  render () {
+    const props = this.props
+    const { loading } = this.state
     return (
       <div ref={intentViewer => (this.intentViewer = intentViewer)}>
         { loading ? <div className={styles.intentModal__loading}>

--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -6,7 +6,8 @@ import PropTypes from 'prop-types'
 import { Media, Bd, Img } from '../Media'
 
 class MenuItem extends Component {
-  render ({ disabled, className, onClick, children, icon }) {
+  render () {
+    const { disabled, className, onClick, children, icon } = this.props
     return (
       <div
           onClick={ onClick }

--- a/react/README.md
+++ b/react/README.md
@@ -125,7 +125,8 @@ const example = () =>
 
 ```jsx
 class HelloWorld extends Component {
-  render ({t}) {
+  render () {
+    const {t} = this.props
     return <div>{t('hello-world')}</div>
   }
 }

--- a/react/Tabs/index.jsx
+++ b/react/Tabs/index.jsx
@@ -8,7 +8,8 @@ export class Tab extends Component {
     this.onClick = this.onClick.bind(this)
   }
 
-  render ({ name, children, className, active, activeClass, changeTab, onClick }) {
+  render () {
+    const { name, children, className, active, activeClass, changeTab, onClick } = this.props
     const activeStyle = {
       [styles['coz-tab--active']]: active
     }
@@ -72,7 +73,9 @@ export class Tabs extends Component {
     this.setState({ activeTab: tabName })
   }
 
-  render ({ children, className }, { activeTab }) {
+  render () {
+    const { children, className } = this.props
+    const { activeTab } = this.state
     const changeTab = this.changeTab
     return <div className={classnames(styles['coz-tabs'], className)}>{
       React.Children.map(children, child =>

--- a/react/Toggle/index.jsx
+++ b/react/Toggle/index.jsx
@@ -9,7 +9,9 @@ class Toggle extends Component {
       this.props.onToggle(!this.props.checked)
     }
   }
-  render (props, state) {
+  render () {
+    const props = this.props
+    const state = this.state
     return (
       <span className={styles['toggle']}>
         <input type='checkbox' id={props.id} className={styles['checkbox']} checked={props.checked} onChange={this.onChange.bind(this)} />

--- a/react/helpers/withBreakpoints.jsx
+++ b/react/helpers/withBreakpoints.jsx
@@ -73,7 +73,9 @@ const withBreakpoints = (bp = breakpoints) => Wrapped =>
       window.removeEventListener('resize', this.checkBreakpoints)
     }
 
-    render(props, { breakpoints }) {
+    render() {
+      const props = this.props
+      const { breakpoints } = this.state
       return <Wrapped {...props} breakpoints={breakpoints} />
     }
   }
@@ -84,7 +86,9 @@ const withBreakpoints = (bp = breakpoints) => Wrapped =>
  */
 export const renderOnlyIf = predicate => Wrapped =>
   class extends Component {
-    render(props, state) {
+    render() {
+      const props = this.props
+      const state = this.state
       if (predicate(props, state)) {
         return <Wrapped {...props} />
       }


### PR DESCRIPTION
Since in our tests we use React (I plan to try to use preact with enzyme but wanted to have something running quick), we need to have cozy-ui compatible with React. We also advertise cozy-ui as a React library of components so it should anyway be compatible.

- `props` and `state` are not passed in the `render()` of `Component`s in React so we use `this.props`, `this.state`
- `context` properties are not passed to `CustomComponent` if you do not add a static property `contextTypes` to `CustomComponent`