### PR TITLE
fix: selection bar's icons on mobile

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -42,7 +42,7 @@ const SelectionBar = ({ t, actions, selected, hideSelectionBar }) => {
           onClick={() => actions[actionName].action(selected)}
         >
           <Icon icon={actionName.toLowerCase()} />
-          {t('SelectionBar.' + actionName)}
+          <span>{t('SelectionBar.' + actionName)}</span>
         </button>
       ))}
       <Button

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -1,5 +1,6 @@
 @require '../settings/breakpoints'
 @require '../settings/z-index'
+@require '../utilities/display'
 
 /*------------------------------------*\
   Selection Bar
@@ -81,8 +82,5 @@ $selectionbar
                 margin   0 0 0 1rem
 
             button
-                width         3rem
-                overflow      hidden
-                text-indent   -5000px
-                padding-left  0
-                color         transparent
+                span
+                    @extend $visuallyhidden


### PR DESCRIPTION
Removed obsolete instructions due to the use of `<Icon />` component instead of CSS backgrounds