### PR TITLE
Fix/repair

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -46,7 +46,7 @@ const ModalButtons = ({ secondaryText, secondaryAction, secondaryType, primaryTe
     (
       <div className={classNames(styles['coz-modal-content'], styles['coz-modal-buttons'])}>
         { displaySecondary &&
-          <button className={styles['c-btn']} onClick={secondaryAction}>
+          <button className={classNames(styles['c-btn'], styles['c-btn--' + secondaryType])} onClick={secondaryAction}>
             {secondaryText}
           </button>
         }
@@ -112,8 +112,8 @@ Modal.propTypes = {
 }
 
 Modal.defaultProps = {
-  primaryType: 'secondary',
-  secondaryType: 'regular',
+  primaryType: 'regular',
+  secondaryType: 'secondary',
   closable: true,
   overflowHidden: false
 }

--- a/src/icons.jsx
+++ b/src/icons.jsx
@@ -20,6 +20,7 @@ const importIcons = function () {
     'icon-openwith',
     'icon-paperplane',
     'icon-rename',
+    'icon-restore',
     'icon-share',
     'icon-trash',
     'icon-upload',

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -2,6 +2,7 @@
 @require '../settings/z-index'
 @require '../utilities/display'
 
+
 /*------------------------------------*\
   Selection Bar
   ======
@@ -82,16 +83,5 @@ $selectionbar
                 margin   0 0 0 1rem
 
             button
-                // I know, it's a duplicate, but I can't figure out why Stylus takes this selector out of the MQ when you @extend a placeholder… yet.
                 span
-                    // @stylint off
-                    position     absolute !important
-                    border       0 !important
-                    width        1px !important
-                    height       1px !important
-                    overflow     hidden !important
-                    padding      0 !important
-                    white-space  nowrap !important
-                    clip         rect(1px, 1px, 1px, 1px) !important
-                    clip-path    inset(50%) !important
-                    // @stylint on
+                    @extend $visuallyhidden-mobile

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -82,5 +82,16 @@ $selectionbar
                 margin   0 0 0 1rem
 
             button
+                // I know, it's a duplicate, but I can't figure out why Stylus takes this selector out of the MQ when you @extend a placeholder… yet.
                 span
-                    @extend $visuallyhidden
+                    // @stylint off
+                    position     absolute !important
+                    border       0 !important
+                    width        1px !important
+                    height       1px !important
+                    overflow     hidden !important
+                    padding      0 !important
+                    white-space  nowrap !important
+                    clip         rect(1px, 1px, 1px, 1px) !important
+                    clip-path    inset(50%) !important
+                    // @stylint on

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -24,6 +24,21 @@ $visuallyhidden
     clip-path    inset(50%) !important
 // @stylint on
 
+// Because Stylus doesn't allow me to @extend inside @media… yeah… that sucks
++medium-screen()
+    $visuallyhidden-mobile
+    // @stylint off
+        position     absolute !important
+        border       0 !important
+        width        1px !important
+        height       1px !important
+        overflow     hidden !important
+        padding      0 !important
+        white-space  nowrap !important
+        clip         rect(1px, 1px, 1px, 1px) !important
+        clip-path    inset(50%) !important
+    // @stylint on
+
 $hide
 [aria-hidden=true]
     hide()


### PR DESCRIPTION
I messed up with Modal's buttons color, my bad. 
And I saw a Stylus bug that I can't fix right now. 
Basically, with Stylus, when you `@extend` any `$placeholder` within a media query, Stylus just… ignores the MQ and output the instruction as a global one. 
See https://codepen.io/GoOz/pen/yppqmm Yay /o\