### PR TITLE
fix: alerts MQ for desktop

### DIFF
--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -8,19 +8,19 @@
  */
 
 $alerts
-    alert-width = em(480px)
+    alert-width = 30rem
     .coz-alert
         position          fixed
         z-index           $alert-index-mobile
         top               auto
         right             0
-        bottom            em(48px, 16px)
+        bottom            3rem
         left              0
         display           block
         box-sizing        border-box
-        box-shadow        0 em(6px) em(18px) 0 rgba(50, 54, 63, .23)
+        box-shadow        0 .375rem 1.125rem 0 rgba(50, 54, 63, .23)
         background-color  emerald
-        padding           .8em 1em
+        padding           .8rem 1rem
         color             white
         opacity           1
         transition        bottom .5s ease-out, top .5s ease-out, opacity .2s ease-out
@@ -52,14 +52,14 @@ $alerts
     @media all and (min-width alert-width)
         .coz-alert
             z-index       $alert-index
-            top           em(16px)
+            top           1rem
             bottom        auto
             left          50%
             margin-left   -(alert-width / 2)
             max-width     alert-width
-            padding       1em 1.5em
+            padding       1rem 1.5rem
             width         100%
-            border-radius em(10px)
+            border-radius .625rem
 
             &.coz-alert--hidden
                 top     -25%


### PR DESCRIPTION
Don't know exactly why but on Photos, the `@media all and (min-width alert-width)` turned into `@media all and (min-width: 480em)` which is… bad. With rem, everything is in order.