### PR TITLE
fix: react styleguide was broken

### DIFF
--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -39,6 +39,7 @@ opener.
 
 ```
 const { MenuItem } = require('.');
+const { Button } = require('../Button');
 
 <Menu component={<Button>Greetings with custom component</Button>} onSelect={ itemData => alert(JSON.stringify(itemData)) }>
   <MenuItem data='hello'>Hello !</MenuItem>


### PR DESCRIPTION
That caused the Styleguide to break. Wasn't showing any source code anymore and this example of `<Menu />` didn't show up too.