### PR TITLE
feat: refactoring Table styles

### DIFF
--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -1,79 +1,78 @@
 @require '../settings/breakpoints'
+@require '../settings/palette'
 
 $table
-    .coz-table
-        position        relative
-        display         flex
-        flex-direction  column
-        flex            1 1 100%
-        height          100%
-        text-align      left
-        color           coolGrey
+    position relative
+    display flex
+    flex-direction column
+    flex 1 1 100%
+    height 100%
+    text-align left
+    color coolGrey
 
-    .coz-table-head
-        flex 0 0 1.9375rem
-
-        &.coz-table-row:hover
-            background-color white
-
-    .coz-table-body
-        flex      1 1 auto
-        display   flex
-        flex-direction column
-        // Because it needs a height to be scrollable. Don't ask.
-        height    1px
-        overflow  auto
-
-    .coz-table-header
-    .coz-table-cell
-        box-sizing  border-box
-        padding     .9375rem 2rem
-        font-size   .875rem
-
-    .coz-table-row
-        display         flex
-        flex-direction  row
-        align-items     center
-        flex            0 0 auto
-        width           100%
-        border-bottom   1px solid silver
-
-        &:hover
-            background-color paleGrey
-
-    .coz-table-cell.coz-table-primary
-        padding-left   2.8125rem
-        font-size      1rem
-        line-height    1.3
-        white-space    nowrap
-        overflow       hidden
-        text-overflow  ellipsis
-
-    .coz-table-primary
-        color charcoalGrey
-
-    .coz-table-ext
-        color coolGrey
-
-    .coz-table-header
-        padding         .5rem 2rem
-        font-size       .75rem
-        text-transform  uppercase
-
-    +medium-screen()
-        .coz-table-row
-            max-width  100vw
+$table-head
+    flex 0 0 2rem
 
     +small-screen()
-        .coz-table-head
-            display none
+        display none
 
-        .coz-table-body
-            max-height  100%
+$table-body
+    flex 1 1 auto
+    display flex
+    flex-direction column
+    overflow auto
 
-        .coz-table-primary
-            flex 1 1 auto
+    +small-screen()
+        max-height 100%
 
-        .coz-table-cell.coz-table-primary
-            padding-left 3.8125rem
-            background-position 1rem center
+$table-row
+    box-sizing border-box
+    display flex
+    flex-direction row
+    align-items center
+    flex 0 0 auto
+    height 3rem
+    width 100%
+    border-bottom 1px solid silver
+
+    &:hover
+        background-color paleGrey
+
+    +medium-screen()
+        max-width 100vw
+
+$table-row-head
+    @extend $table-row
+
+    &:hover
+        background-color transparent
+
+$table-row-selected
+    &
+    &:hover
+        background-color alpha(dodgerBlue, .1)
+
+$table-cell
+    box-sizing border-box
+    padding .875rem 2rem
+    font-size .875rem
+    line-height 1.3
+
+
+$table-header
+    @extend $table-cell
+    padding .5rem 2rem
+    font-size .75rem
+    font-weight bold
+    text-transform uppercase
+
+$table-cell--primary
+    font-size 1rem
+    line-height 1.15
+    white-space nowrap
+    overflow hidden
+    text-overflow ellipsis
+    color charcoalGrey
+
+    +small-screen()
+        flex 1 1 auto

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -15,6 +15,7 @@
 @require '../objects/*'
 @require '../components/button'
 @require '../components/nav'
+@require '../components/table'
 @require '../utilities/*'
 
 /*------------------------------------*\
@@ -310,6 +311,88 @@
 */
 .c-textarea
     @extend $textarea
+
+/*
+ Table
+
+ You should decide by yourself the sizes of the columns. In those examples we use the style tag but you definitely should use CSS classes.
+
+ Markup:
+ <div>
+    <h2>Table with table element</h2>
+    <table class="c-table">
+        <thead class="c-table-head">
+            <tr class="c-table-row-head">
+                <th class="c-table-header" style="width:50%">Header 1</th>
+                <th class="c-table-header" style="width:25%">Header 2</th>
+                <th class="c-table-header" style="width:25%">Header 3</th>
+            </tr>
+        </thead>
+        <tbody class="c-table-body">
+            <tr class="c-table-row is-selected">
+                <td class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet</td>
+                <td class="c-table-cell" style="width:25%">lorem</td>
+                <td class="c-table-cell" style="width:25%">ipsum</td>
+            </tr>
+            <tr class="c-table-row">
+                <td class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus voluptate officia culpa debitis, vero quia quae vel laboriosam</td>
+                <td class="c-table-cell" style="width:25%">corporis</td>
+                <td class="c-table-cell" style="width:25%">placeat</td>
+            </tr>
+        </tbody>
+    </table>
+    <h2>Table with div element</h2>
+    <div class="c-table">
+        <div class="c-table-head">
+            <div class="c-table-row-head">
+                <div class="c-table-header" style="width:50%">Header 1</div>
+                <div class="c-table-header" style="width:25%">Header 2</div>
+                <div class="c-table-header" style="width:25%">Header 3</div>
+            </div>
+        </div>
+        <div class="c-table-body">
+            <div class="c-table-row is-selected">
+                <div class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet</div>
+                <div class="c-table-cell" style="width:25%">lorem</div>
+                <div class="c-table-cell" style="width:25%">ipsum</div>
+            </div>
+            <div class="c-table-row">
+                <div class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus voluptate officia culpa debitis, vero quia quae vel laboriosam</div>
+                <div class="c-table-cell" style="width:25%">corporis</div>
+                <div class="c-table-cell" style="width:25%">placeat</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+ Styleguide Components.table
+*/
+.c-table
+    @extend $table
+
+.c-table-head
+    @extend $table-head
+
+.c-table-body
+    @extend $table-body
+
+.c-table-row
+    @extend $table-row
+
+    &.is-selected
+        @extend $table-row-selected
+
+.c-table-row-head
+    @extend $table-row-head
+
+.c-table-cell
+    @extend $table-cell
+
+.c-table-cell--primary
+    @extend $table-cell--primary
+
+.c-table-header
+    @extend $table-header
 
 /*------------------------------------*\
   Utilities


### PR DESCRIPTION
Refactoring of Table's styles.
- [x] No more immutable classes
- [x] clean up
- [x] Placeholders everywhere.
- [x] Should work with new layout now

Preview: https://gooz.github.io/cozy-ui/styleguide/section-components.html (at the end of the page) 

⚠️You just can't use table's styles by extending `$table` anymore, you'll have to explicitely declare every part of the table you need now. e.g. `$table-head`, `$table-row`, `$table-cell`, etc
There's still predefined classes in the build of UI though.