### PR TITLE
🐝 fix: repair nav doc

### DIFF
--- a/react/Sidebar/Readme.md
+++ b/react/Sidebar/Readme.md
@@ -15,8 +15,11 @@ In action :
 
 ```
 const _Nav = require('../Nav')
-const { NavItem, NavIcon, NavText, NavLink } = _Nav
-const Nav = _Nav.default;
+const { NavItem, NavIcon, NavText, genNavLink } = _Nav
+const Nav = _Nav.default
+
+const NavLink = genNavLink(({ children, className }) =>
+  <a className={className}>{ children }</a>);
 
 <Sidebar>
   <Nav>


### PR DESCRIPTION
NavLink is no longer a component but merely a container for classes, this is why, only in the doc, we have to write it by hand.