### PR TITLE
✨ feat: Modal is rendered into a Portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "hammerjs": "^2.0.8",
     "md5": "^2.2.0",
     "normalize.css": "^7.0.0",
+    "preact-portal": "^1.1.2",
     "stylus": "^0.54.5"
   },
   "peerDependencies": {

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -94,3 +94,18 @@ const { ModalDescription, ModalTitle } = Modal;
     </Modal>}
 </div>
 ```
+
+### Portal modals
+
+You can use the `into` prop to wrap the `Modal` in a `Portal`. This `prop` will be set to `"body"` in future versions so try to put it now to check if your Modal does not break when rendered in a Portal.
+
+```jsx
+initialState = { modalDisplayed: false};
+
+<div>
+  <button onClick={()=>setState({ modalDisplayed: !state.modalDisplayed })}>
+    Toggle modal
+  </button>
+  {state.modalDisplayed && <Modal into='body' title='Ada Lovelace' description={content.ada.short} dismissAction={() => setState({ modalDisplayed: false })} /> }
+</div>
+```

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -6,6 +6,7 @@ import Overlay from '../Overlay'
 import Icon from '../Icon'
 import migrateProps from '../helpers/migrateProps'
 import palette from '../../stylus/settings/palette.json'
+import Portal from 'preact-portal'
 
 const ModalContent = ({children, className}) =>
   (<div className={classNames(styles['coz-modal-content'], className)}>
@@ -65,8 +66,9 @@ class Modal extends Component {
   }
 
   render () {
-    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName } = this.props
-    return (
+    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName, into } = this.props
+    const maybeWrapInPortal = children => into ? <Portal into={into}>{ children }</Portal> : children
+    return maybeWrapInPortal(
       <div className={styles['coz-modal-container']}>
         <Overlay onEscape={closable && dismissAction}>
           <div className={styles['coz-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
@@ -108,7 +110,10 @@ Modal.propTypes = {
   /** `className` used on the modal, useful if you want to custom its CSS */
   className: PropTypes.string,
   /** `className` used on the cross, useful if you want to custom its CSS */
-  crossClassName: PropTypes.string
+  crossClassName: PropTypes.string,
+  /** If has a value, the modal will be rendered inside a portal and its value will be passed to Portal
+  to control the rendering destination of the Modal */
+  into: PropTypes.string
 }
 
 Modal.defaultProps = {
@@ -120,6 +125,15 @@ Modal.defaultProps = {
 
 export default migrateProps([
   { src: 'withCross', dest: 'closable' }, // withCross -> closable
+  {
+    fn: props => {
+      let msg = null
+      if (!props.into) {
+        msg = 'In the future, `into` default value will be "body" : Modals will be rendered inside a <Portal />. Try to render your Modal with into=`body`'
+      }
+      return [props, msg]
+    }
+  },
   {
     fn: props => {
       let newProps

--- a/yarn.lock
+++ b/yarn.lock
@@ -4979,6 +4979,10 @@ preact-compat@^3.13.1:
     prop-types "^15.5.8"
     standalone-react-addons-pure-render-mixin "^0.1.1"
 
+preact-portal@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/preact-portal/-/preact-portal-1.1.2.tgz#14313ed97a8ee28ee405f5ff17456d31797a11cd"
+
 preact-render-to-string@^3.6.0:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.6.3.tgz#481d0d5bdac9192d3347557437d5cd00aa312043"


### PR DESCRIPTION
Now, Modals are rendered exactly like other components and their DOM node is rendered inside the DOM node of the component rendering it. It can cause problems when the parent node has `overflow: hidden` or is `position: fixed`. We experienced this first hand in Bank when we rendered a Modal inside a Menu : the UI was broken since the Modal was rendered inside the Menu instead of being rendered inside the body.

Portals solve this problem in React world by transporting their children where you want (most of the time body).

You can see the result on https://ptbrowne.github.io/cozy-ui/react/#modal : 

![image](https://user-images.githubusercontent.com/465582/35060205-fe1bc280-fbbd-11e7-8906-d7de15d650ee.png)

Fixes #301 