### PR TITLE
fix: nav mobile was misplaced with smaller icons

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -65,6 +65,10 @@ $nav-item-icon
         margin-right 0
         text-align center
 
+        svg
+            width 1.5rem
+            height 1.5rem
+
 $nav-item-text
     +medium-screen()
         display block
@@ -101,7 +105,7 @@ $nav-link
     +medium-screen()
         display              block
         height               auto
-        padding              1.8125rem 0 0
+        padding              0
         text-align           center
         color                slateGrey
         font-size            .625rem


### PR DESCRIPTION
Forgot to take a look at the nav with `<Icon />` only on mobile… 😕