### PR TITLE
fix: center text in buttons on Safari 10

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -56,6 +56,12 @@ $button
             position   relative
             top        -.0625rem
 
+    // Trick for Safari 10 to ensure that
+    // button's text is horizontally centered
+    &::before
+    &::after
+        content ''
+        flex 1 0 auto
 
 $button--regular  // Deprecated
     @extend $button


### PR DESCRIPTION
Wide buttons on safari 10 had their text aligned to the left instead of being centered due to a wrong implementation of flexbox in the browser.
This trick fix this issue.

https://trello.com/c/EhgqPVkX