### PR TITLE
Add divider + lowered paddings between cells

### DIFF
--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -54,14 +54,14 @@ $table-row-selected
 
 $table-cell
     box-sizing border-box
-    padding .875rem 2rem
+    padding .875rem 1rem
     font-size .875rem
     line-height 1.3
 
 
 $table-header
     @extend $table-cell
-    padding .5rem 2rem
+    padding .5rem 1rem
     font-size .75rem
     font-weight bold
     text-transform uppercase
@@ -76,3 +76,26 @@ $table-cell--primary
 
     +small-screen()
         flex 1 1 auto
+
+$table-divider
+    position sticky
+    top 0
+    background-color white
+    text-indent 2rem
+    font-weight bold
+    font-size .75rem
+    line-height 1.33
+    color coolGrey
+
+    &::before
+        content ''
+        position absolute
+        top 0
+        left 0
+        width 100%
+        height 100%
+        background-color alpha(dodgerBlue, .05)
+
+
+    +small-screen()
+        text-indent 1rem

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -339,6 +339,14 @@
                 <td class="c-table-cell" style="width:25%">corporis</td>
                 <td class="c-table-cell" style="width:25%">placeat</td>
             </tr>
+            <tr class="c-table-divider">
+                <td colspan="3">Divider</td>
+            </tr>
+            <tr class="c-table-row">
+                <td class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus voluptate officia culpa debitis, vero quia quae vel laboriosam</td>
+                <td class="c-table-cell" style="width:25%">corporis</td>
+                <td class="c-table-cell" style="width:25%">placeat</td>
+            </tr>
         </tbody>
     </table>
     <h2>Table with div element</h2>
@@ -356,6 +364,12 @@
                 <div class="c-table-cell" style="width:25%">lorem</div>
                 <div class="c-table-cell" style="width:25%">ipsum</div>
             </div>
+            <div class="c-table-row">
+                <div class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus voluptate officia culpa debitis, vero quia quae vel laboriosam</div>
+                <div class="c-table-cell" style="width:25%">corporis</div>
+                <div class="c-table-cell" style="width:25%">placeat</div>
+            </div>
+            <div class="c-table-divider">Divider</div>
             <div class="c-table-row">
                 <div class="c-table-cell c-table-cell--primary" style="width:50%">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus voluptate officia culpa debitis, vero quia quae vel laboriosam</div>
                 <div class="c-table-cell" style="width:25%">corporis</div>
@@ -393,6 +407,9 @@
 
 .c-table-header
     @extend $table-header
+
+.c-table-divider
+    @extend $table-divider
 
 /*------------------------------------*\
   Utilities


### PR DESCRIPTION
Added a "divider"  style in table-like layout. (Used in Contacts, Bank and/or Health apps too I think)
Preview on the [KSS Styleguide](https://gooz.github.io/cozy-ui/styleguide/section-components.html) in the Table section.

Also, due to recent Design Styleguide changes, padding inside table cells has been decreased.