### PR TITLE
Feat/button sizes

### DIFF
--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -23,6 +23,31 @@ const { Button } = require('./index');
 </div>
 ```
 
+#### Different sizes from the default one (tiny, small, large):
+
+```
+const { Button } = require('./index');
+
+<div>
+  <p><Button size='tiny'>Tiny</Button></p>
+  <p><Button size='small'>Small</Button></p>
+  <p><Button>Normal</Button></p>
+  <p><Button size='large'>Large</Button></p>
+</div>
+```
+
+### Different width, `narrow` to ignore Button's `min-width`  & `full` to enable full width:
+
+```
+const { Button } = require('./index');
+
+<div>
+  <p><Button>Normal</Button></p>
+  <p><Button extension="narrow">N…</Button></p>
+  <p><Button extension="full">Full width</Button></p>
+</div>
+```
+
 #### Add a action on click
 
 ```
@@ -66,5 +91,18 @@ const icons = require('../../src/icons');
 
 ```
 const { ButtonLink } = require('./index');
-<ButtonLink href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+<div>
+  <p>
+    <ButtonLink size="tiny" href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+  </p>
+  <p>
+    <ButtonLink size="small" href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+  </p>
+  <p>
+    <ButtonLink href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+  </p>
+  <p>
+    <ButtonLink size="large" href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+  </p>
+</div>
 ```

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -3,22 +3,24 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles'
 
-const btnClass = function (theme, className) {
+const btnClass = function (theme, size, extension, className) {
   return cx(
     styles['c-btn'], {
-      [styles[`c-btn--${theme}`]] : theme
+      [styles[`c-btn--${theme}`]] : theme,
+      [styles[`c-btn--${size}`]] : size,
+      [styles[`c-btn--${extension}`]] : extension
     },
     className)
 }
 
 export const Button = props => {
-  const { theme, busy, disabled, className, children, onClick } = props
+  const { theme, size, extension, busy, disabled, className, children, onClick } = props
   return (
     <button
       aria-busy={busy}
       disabled={disabled}
       role="button"
-      className={btnClass(theme, className)}
+      className={btnClass(theme, size, extension, className)}
       onClick={onClick}
     >
       <span>{children}</span>
@@ -27,12 +29,12 @@ export const Button = props => {
 }
 
 export const ButtonLink = props => {
-  const { theme, href, target, className, children, onClick } = props
+  const { theme, size, extension, href, target, className, children, onClick } = props
   return (
     <a
       href={href}
       target={target ? '_blank' : undefined}
-      className={btnClass(theme, className)}
+      className={btnClass(theme, size, extension, className)}
       onClick={onClick}
     >
       <span>{children}</span>
@@ -44,6 +46,8 @@ export const ButtonLink = props => {
 const commonPropTypes = {
   children: PropTypes.node.isRequired,
   theme: PropTypes.string,
+  size: PropTypes.oneOf(['tiny','small','large']),
+  extension: PropTypes.oneOf(['narrow','full']),
   className: PropTypes.string,
   onClick: PropTypes.func
 }
@@ -63,6 +67,8 @@ ButtonLink.PropTypes = {
 // DefaultProps
 const commonDefaultProps = {
   theme: '',
+  size: '',
+  extension: '',
   className: '',
   onClick: null
 }

--- a/react/Button/styles.styl
+++ b/react/Button/styles.styl
@@ -26,3 +26,18 @@
 
 .c-btn--close
     @extend $button--close
+
+.c-btn--tiny
+    @extend $button--tiny
+
+.c-btn--small
+    @extend $button--small
+
+.c-btn--large
+    @extend $button--large
+
+.c-btn--full
+    @extend $button--full
+
+.c-btn--narrow
+    @extend $button--narrow

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -3,16 +3,18 @@
 @require '../tools/mixins'
 
 /*------------------------------------*\
-  Buttons of any kind
+  Button
 \*------------------------------------*/
 
 $button
     box-sizing       border-box
+    display          inline-block
     margin           0 .25em
     border           1px solid dodgerBlue
     border-radius    2px
     min-height       2.5rem
-    padding          .5rem .9375rem
+    min-width        7rem
+    padding          .8125rem 1rem
     background       dodgerBlue
     vertical-align   top
     text-align       center
@@ -59,7 +61,9 @@ $button
             position   relative
             top        -.0625rem
 
-
+/*------------------------------------*\
+  Variants
+\*------------------------------------*/
 $button--regular  // Deprecated
     @extend $button
 
@@ -273,3 +277,31 @@ $button-client-mobile
         border-radius       .5em
         border              .3em solid white
         background          white embedurl('../assets/icons/ui/icon-cozy.svg') 0 0 / contain no-repeat
+
+/*------------------------------------*\
+  Sizes
+\*------------------------------------*/
+$button--tiny
+    min-height 1.5rem
+    min-width 5rem
+    padding .3125rem 1rem
+
+$button--small
+    min-height 2rem
+    min-width 6rem
+    padding .5rem
+
+$button--large
+    min-height 3rem
+    min-width 10rem
+    padding 1rem 1.5rem
+    font-size 1rem
+
+/*------------------------------------*\
+  Extensions
+\*------------------------------------*/
+$button--full
+    width 100%
+
+$button--narrow
+    min-width auto

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -75,6 +75,52 @@
     @extend $button--highlight
 
 /*
+ Button sizes
+
+ Different sizes of buttons
+
+ Markup:
+ <div class="u-p-1">
+     <button class="c-btn {{modifier_class}}"><span>Click me</span></button>
+ </div>
+
+ .c-btn--tiny - Tiny button (for Alerts mostly)
+ .c-btn--small - Small button
+ .c-btn--large - Large button
+
+ Styleguide Components.buttons.sizes
+*/
+.c-btn--tiny
+    @extend $button--tiny
+
+.c-btn--small
+    @extend $button--small
+
+.c-btn--large
+    @extend $button--large
+
+/*
+ Button extensions
+
+ Different extensions of buttons
+
+ Markup:
+ <div class="u-p-1">
+     <button class="c-btn {{modifier_class}}"><span>Click</span></button>
+ </div>
+
+ .c-btn--narrow - Narrow button (ignore button's min-width)
+ .c-btn--full - Full button
+
+ Styleguide Components.buttons.extension
+*/
+.c-btn--narrow
+    @extend $button--narrow
+
+.c-btn--full
+    @extend $button--full
+
+/*
  Buttons with icons
 
  Those buttons can inherit any flavour of buttons described above.


### PR DESCRIPTION
Buttons have evolved!
They have now a `min-width` and there's different Sizes (tiny, small, large) available along with Extensions (narrow, full)

See proper sections in the styleguides:
- [React](https://gooz.github.io/cozy-ui/react/#button)
- [KSS](https://gooz.github.io/cozy-ui/styleguide/section-components.html)