### PR TITLE
Feat/size modal

### DIFF
--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -1,6 +1,6 @@
 ### Simple
 
-```jsx
+```
 initialState = { modalDisplayed: false};
 
 <div>
@@ -8,6 +8,29 @@ initialState = { modalDisplayed: false};
     Toggle modal
   </button>
   {state.modalDisplayed && <Modal title='Ada Lovelace' description={content.ada.short} dismissAction={() => setState({ modalDisplayed: false })} /> }
+</div>
+```
+
+### Size
+
+Several sizes avalaible: `small`, `medium`, `large`, `xlarge`, `xxlarge`.
+`small` being the default one.
+
+```
+initialState = { modalDisplayed: false};
+const sizes = [
+  'small',
+  'medium',
+  'large',
+  'xlarge',
+  'xxlarge'
+];
+
+<div>
+  {sizes.map(size => <button onClick={()=>setState({ size, modalDisplayed: !state.modalDisplayed, })}>
+    { size }
+  </button>)}
+  {state.modalDisplayed && <Modal title={ state.size + ' modal'} size={state.size} description={content.ada.short} dismissAction={() => setState({ modalDisplayed: false })} /> }
 </div>
 ```
 

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import styles from './styles.styl'
 import Overlay from '../Overlay'
+import { Button} from '../Button'
 import Icon from '../Icon'
 import migrateProps from '../helpers/migrateProps'
 import palette from '../../stylus/settings/palette.json'
@@ -66,13 +67,21 @@ class Modal extends Component {
   }
 
   render () {
-    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName, into } = this.props
+    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName, into, size } = this.props
     const maybeWrapInPortal = children => into ? <Portal into={into}>{ children }</Portal> : children
     return maybeWrapInPortal(
       <div className={styles['coz-modal-container']}>
         <Overlay onEscape={closable && dismissAction}>
           <div className={styles['coz-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
-            <div className={classNames(styles['coz-modal'], className, { [styles['coz-modal--overflowHidden']]: overflowHidden })}>
+            <div className={
+              classNames(
+                styles['coz-modal'],
+                styles[`coz-modal--${size}`],
+                className,
+                {
+                  [styles['coz-modal--overflowHidden']]: overflowHidden
+                }
+              )}>
               { closable && <ModalCross className={crossClassName} onClick={dismissAction} /> }
               { title && <ModalTitle>{ title }</ModalTitle> }
               { description && <ModalDescription>{ description }</ModalDescription> }
@@ -113,14 +122,16 @@ Modal.propTypes = {
   crossClassName: PropTypes.string,
   /** If has a value, the modal will be rendered inside a portal and its value will be passed to Portal
   to control the rendering destination of the Modal */
-  into: PropTypes.string
+  into: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'xxlarge'])
 }
 
 Modal.defaultProps = {
   primaryType: 'regular',
   secondaryType: 'secondary',
   closable: true,
-  overflowHidden: false
+  overflowHidden: false,
+  size: 'small'
 }
 
 export default migrateProps([

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -28,8 +28,8 @@ const ModalTitle = ({ children, className }) =>
 
 const ModalCross = ({ onClick, className }) => (
   <Button
-    theme="secondary"
-    className={classNames(styles['c-btn--close'], styles['coz-btn-modal-close'], className)}
+    theme="close"
+    className={classNames(styles['coz-btn-modal-close'], className)}
     onClick={onClick}
     extension='narrow'
     >

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -27,12 +27,14 @@ const ModalTitle = ({ children, className }) =>
   )
 
 const ModalCross = ({ onClick, className }) => (
-  <button
-    className={classNames(styles['c-btn'], styles['c-btn--close'], styles['coz-btn-modal-close'], className)}
+  <Button
+    theme="secondary"
+    className={classNames(styles['c-btn--close'], styles['coz-btn-modal-close'], className)}
     onClick={onClick}
+    extension='narrow'
     >
     <Icon icon='cross' width='24' height='24' color={palette['coolGrey']} />
-  </button>
+  </Button>
 )
 
 const ModalDescription = ({ children, className }) => (

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -10,7 +10,7 @@
 \*------------------------------------*/
 
 $modals
-    modal-width = 30rem
+    modal-width = 34rem
     position relative
     z-index $modal-index
 
@@ -30,7 +30,6 @@ $modals
     .coz-modal
         position          relative
         margin            auto
-        max-width         modal-width
         border-radius     .5rem
         min-width         modal-width
         max-height        100%
@@ -39,6 +38,21 @@ $modals
         color             charcoalGrey
         display           flex
         flex-direction    column
+
+    .coz-modal--small
+        max-width 34rem
+
+    .coz-modal--medium
+        max-width 36rem
+
+    .coz-modal--large
+        max-width 40rem
+
+    .coz-modal--xlarge
+        max-width 50rem
+
+    .coz-modal--xxlarge
+        max-width 60rem
 
     .coz-modal-content:first-child
     .coz-btn-modal-close + .coz-modal-content


### PR DESCRIPTION
Modals no longer have their width defined by its content. 
Things went wild too much so I added a set of predefined sizes.
* `small` (544px/34rem)
* `medium` (576px/36rem)
* `large` (640px/40rem)
* `xlarge` (800px/50rem)
* `xxlarge` (960px/60rem)

`small` being the default size if you don't choose any for your modal.

Preview: https://gooz.github.io/cozy-ui/react/#modal

Also fixed the size of the cross button.