### PR TITLE
feat: ButtonLink's target attribute becomes a string

### DIFF
--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -7,7 +7,7 @@ Both look exactly the same, they share the same `theme`, `className` & `onClick`
 
 when `<ButtonLink>` has:
 - `href` to add an URL (default `''`)
-- `target` to enable `target="_blank"` (default `false`)
+- `target` to pass the link's `target` value (default `''`)
 
 #### Different themes:
 
@@ -93,16 +93,16 @@ const icons = require('../../src/icons');
 const { ButtonLink } = require('./index');
 <div>
   <p>
-    <ButtonLink size="tiny" href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+    <ButtonLink size="tiny" href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
   </p>
   <p>
-    <ButtonLink size="small" href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+    <ButtonLink size="small" href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
   </p>
   <p>
-    <ButtonLink href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+    <ButtonLink href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
   </p>
   <p>
-    <ButtonLink size="large" href="https://cozy.io" target>Link to Cozy.io</ButtonLink>
+    <ButtonLink size="large" href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
   </p>
 </div>
 ```

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -33,7 +33,7 @@ export const ButtonLink = props => {
   return (
     <a
       href={href}
-      target={target ? '_blank' : undefined}
+      target={target}
       className={btnClass(theme, size, extension, className)}
       onClick={onClick}
     >
@@ -61,7 +61,7 @@ Button.PropTypes = {
 ButtonLink.PropTypes = {
    ...commonPropTypes,
   href: PropTypes.string.isRequired,
-  target: PropTypes.bool,
+  target: PropTypes.string,
 }
 
 // DefaultProps
@@ -81,7 +81,7 @@ Button.defaultProps = {
 
 ButtonLink.defaultProps = {
   ...commonDefaultProps,
-  target: false,
+  target: '',
   href: ''
 }
 


### PR DESCRIPTION
…instead of a boolean

It was decided to just pass the target's value as the HTML spec allows and let HTML do its job.