### PR TITLE
fix: size overwrite classes have more specificity to avoid conflict

### DIFF
--- a/react/Button/styles.styl
+++ b/react/Button/styles.styl
@@ -3,6 +3,21 @@
 .c-btn
     @extend $button
 
+    &.c-btn--tiny
+        @extend $button--tiny
+
+    &.c-btn--small
+        @extend $button--small
+
+    &.c-btn--large
+        @extend $button--large
+
+    &.c-btn--full
+        @extend $button--full
+
+    &.c-btn--narrow
+        @extend $button--narrow
+
 .c-btn--regular
     @extend $button--regular
 
@@ -27,17 +42,6 @@
 .c-btn--close
     @extend $button--close
 
-.c-btn--tiny
-    @extend $button--tiny
 
-.c-btn--small
-    @extend $button--small
 
-.c-btn--large
-    @extend $button--large
 
-.c-btn--full
-    @extend $button--full
-
-.c-btn--narrow
-    @extend $button--narrow


### PR DESCRIPTION
It turns out that, for some reasons I quite don't understand, sometimes CSS builders don't necessarily respect the classes order in the component's styles.

In this case, the base class is `.c-btn` is overwritten by modifier classes like `.c-btn--small` or `.c-btn--narrow`. In order to work properly, the basic class should be at the top of the file and modifier classes beneath it. As CSS builders don't always respect this, modifiers classes that appear before the basic class are overwritten by it. 
So I added a little more weight on modifer classes specificity in order to keep the overwrite effect even if the order is not respected.