### PR TITLE
fix: repositionned Intent modal cross button

### DIFF
--- a/react/IntentOpener/styles.styl
+++ b/react/IntentOpener/styles.styl
@@ -38,4 +38,4 @@
 // of cozy-ui selectors has decreased
 .intentModal__cross.intentModal__cross
     top .25rem
-    right .25rem
+    right .5rem


### PR DESCRIPTION
Cross button in Intent modal was misplaced.