### PR TITLE
fix: blurry SVG icons on Firefox

### DIFF
--- a/react/Icon/styles.styl
+++ b/react/Icon/styles.styl
@@ -1,5 +1,7 @@
 .icon
     fill currentColor
+    // Fix blurry icons on Firefox
+    transform translateZ(0)
 
 .icon--preserveColor
     fill inherit


### PR DESCRIPTION
A little hack to prevent Firefox from messing with SVG's rendering when line-height doesn't fit well for it.

Fix #341 