### PR TITLE
fix: add Lato font on Styleguidist

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -52,6 +52,12 @@ module.exports = {
     }
   ],
   components: '../react/**/*.jsx',
+  template: 'template.html',
+  theme: {
+    fontFamily: {
+      base: 'Lato, sans-serif'
+    }
+  },
   webpackConfig: require('./webpack.config.js'),
   serverPort: 6161,
   skipComponentsWithoutExample: true,

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title><%=htmlWebpackPlugin.options.title%></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700,300">
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>


### PR DESCRIPTION
I couldn't stand the lack of Lato font on Styleguidist anymore, so I added it. 
/me feels better 😀 