### PR TITLE
fix: normal button padding was wrong

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -14,7 +14,7 @@ $button
     border-radius    2px
     min-height       2.5rem
     min-width        7rem
-    padding          .5rem 1rem
+    padding          .75rem 1rem
     background       dodgerBlue
     vertical-align   top
     text-align       center


### PR DESCRIPTION
Padding-top and bottom was wrong on the normal size of a button but it wasn't really noticable because it's a button. It was clearly noticable on ButtonLink though.

So here's the fix.

Fix #343 