### PR TITLE
fix: lowercase propTypes

### DIFF
--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -54,13 +54,13 @@ const commonPropTypes = {
   onClick: PropTypes.func
 }
 
-Button.PropTypes = {
+Button.propTypes = {
    ...commonPropTypes,
   busy: PropTypes.bool,
   disabled: PropTypes.bool
 }
 
-ButtonLink.PropTypes = {
+ButtonLink.propTypes = {
    ...commonPropTypes,
   href: PropTypes.string.isRequired,
   target: PropTypes.string,


### PR DESCRIPTION
[The conventional way](https://reactjs.org/docs/typechecking-with-proptypes.html) to declare propTypes is with a lower-case "p", and we have a linter complaining about this.