### PR TITLE
feat: Deprecated children and added label & icon in Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-- `<Button />` & `<ButtonLink />` take `label` and/or `icon` instead of `basic children`
+- `<Button />` & `<ButtonLink />` take `label` and/or `icon` instead of `basic children`. A [codeshift](http://astexplorer.net/#/gist/cc94c9c4cc446d1958729300581bb250/2daaa0365e0424e191250f888704b1d9fc551fe9) is available for easier transition.
 
 ### Removed
 - none yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-- none yet
+- `<Button />` & `<ButtonLink />` take `label` and/or `icon` instead of `basic children`
 
 ### Removed
 - none yet

--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -15,11 +15,10 @@ when `<ButtonLink>` has:
 const { Button } = require('./index');
 
 <div>
-  <p><Button>normal action</Button></p>
-  <p><Button theme='danger'>erase or destroy</Button></p>
-  <p><Button theme='highlight'>events communication</Button></p>
-  <p><Button theme='secondary'>cancel or second option</Button></p>
-  <p><Button theme='danger-outline'>erase but not in danger</Button></p>
+  <p><Button label='normal action' /></p>
+  <p><Button theme='danger' label='erase or destroy' /></p>
+  <p><Button theme='highlight' label='events communication' /></p>
+  <p><Button theme='secondary' label='cancel or second option' /></p>
 </div>
 ```
 
@@ -29,10 +28,10 @@ const { Button } = require('./index');
 const { Button } = require('./index');
 
 <div>
-  <p><Button size='tiny'>Tiny</Button></p>
-  <p><Button size='small'>Small</Button></p>
-  <p><Button>Normal</Button></p>
-  <p><Button size='large'>Large</Button></p>
+  <p><Button size='tiny' label='Tiny' /></p>
+  <p><Button size='small' label='Small' /></p>
+  <p><Button label='Normal' /></p>
+  <p><Button size='large' label='Large' /></p>
 </div>
 ```
 
@@ -42,9 +41,9 @@ const { Button } = require('./index');
 const { Button } = require('./index');
 
 <div>
-  <p><Button>Normal</Button></p>
-  <p><Button extension="narrow">N…</Button></p>
-  <p><Button extension="full">Full width</Button></p>
+  <p><Button label='Normal'/></p>
+  <p><Button extension="narrow" label='N…'/></p>
+  <p><Button extension="full" label='Full width'/></p>
 </div>
 ```
 
@@ -52,27 +51,27 @@ const { Button } = require('./index');
 
 ```
 const { Button } = require('./index');
-<Button theme='danger-outline' onClick={ () => alert('yay !') }>Show alert</Button>
+<Button theme='danger-outline' onClick={ () => alert('yay !') } label='Show alert' />
 ```
 
 #### When loading, put a spinner
 
 ```
 const { Button } = require('./index');
-<Button busy>Loading</Button>
+<Button busy label='Loading'/>
 ```
 
 ```
 const { Button } = require('./index');
 initialState = { busy:false };
-<Button onClick={() => {setState(state => ({busy: !state.busy}))}} busy={state.busy}>Toggle busy</Button>
+<Button onClick={() => {setState(state => ({busy: !state.busy}))}} busy={state.busy} label='Toggle busy'/>
 ```
 
 #### To disable a button
 
 ```
 const { Button } = require('./index');
-<Button disabled>Loading</Button>
+<Button disabled label='Loading' />
 ```
 
 #### Create a button with an icon
@@ -83,7 +82,8 @@ The color of the icon is taken care of by the button style, there's no need to s
 const { Button } = require('./index');
 const icons = require('../../src/icons');
 <div>
-  <Button theme="danger"><Icon icon={ icons['delete'] } />delete</Button>
+  <Button theme="danger" icon={ icons['delete'] } label='delete' />
+  <Button theme="secondary" icon={ icons['dots'] } extension='narrow' />
 </div>
 ```
 
@@ -93,16 +93,16 @@ const icons = require('../../src/icons');
 const { ButtonLink } = require('./index');
 <div>
   <p>
-    <ButtonLink size="tiny" href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
+    <ButtonLink size="tiny" href="https://cozy.io" target="_blank" label='Link to Cozy.io'/>
   </p>
   <p>
-    <ButtonLink size="small" href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
+    <ButtonLink size="small" href="https://cozy.io" target="_blank" label='Link to Cozy.io'/>
   </p>
   <p>
-    <ButtonLink href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
+    <ButtonLink href="https://cozy.io" target="_blank" label='Link to Cozy.io'/>
   </p>
   <p>
-    <ButtonLink size="large" href="https://cozy.io" target="_blank">Link to Cozy.io</ButtonLink>
+    <ButtonLink size="large" href="https://cozy.io" target="_blank" label='Link to Cozy.io'/>
   </p>
 </div>
 ```

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
+import Icon from '../Icon'
 
 const btnClass = function (theme, size, extension, className) {
   return cx(
@@ -14,7 +15,7 @@ const btnClass = function (theme, size, extension, className) {
 }
 
 export const Button = props => {
-  const { theme, size, extension, busy, disabled, className, children, onClick } = props
+  const { theme, size, extension, busy, disabled, className, children, label, icon, onClick } = props
   return (
     <button
       aria-busy={busy}
@@ -23,7 +24,11 @@ export const Button = props => {
       className={btnClass(theme, size, extension, className)}
       onClick={onClick}
     >
-      <span>{children}</span>
+      <span>
+        {icon && <Icon icon={icon} />}
+        {label && <span>{label}</span>}
+        {children && {children}}
+      </span>
     </button>
   )
 }
@@ -31,7 +36,7 @@ export const Button = props => {
 export default Button
 
 export const ButtonLink = props => {
-  const { theme, size, extension, href, target, className, children, onClick } = props
+  const { theme, size, extension, href, target, className, children, label, icon, onClick } = props
   return (
     <a
       href={href}
@@ -39,14 +44,20 @@ export const ButtonLink = props => {
       className={btnClass(theme, size, extension, className)}
       onClick={onClick}
     >
-      <span>{children}</span>
+      <span>
+        {icon && <Icon icon={icon} />}
+        {label && <span>label</span>}
+        {children && {children}}
+      </span>
     </a>
   )
 }
 
 // Proptypes
 const commonPropTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  label: PropTypes.string,
+  icon: PropTypes.string,
   theme: PropTypes.string,
   size: PropTypes.oneOf(['tiny','small','large']),
   extension: PropTypes.oneOf(['narrow','full']),
@@ -68,6 +79,8 @@ ButtonLink.propTypes = {
 
 // DefaultProps
 const commonDefaultProps = {
+  label: '',
+  icon: '',
   theme: '',
   size: '',
   extension: '',
@@ -86,4 +99,3 @@ ButtonLink.defaultProps = {
   target: '',
   href: ''
 }
-

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -29,6 +29,9 @@ $button
         fill         currentColor
         margin-right .4rem
 
+        &:only-child
+            margin 0
+
     input
         cursor pointer
 
@@ -55,7 +58,7 @@ $button
         background-color  scienceBlue
 
     &[aria-busy=true]
-        span::after
+        > span::after
             @extend    $icon-16
             @extend    $icon-spinner-white
             position   relative


### PR DESCRIPTION
In order to have more control over the rendering of the basic usage of Button, I added two props `icon` and `label`. That way you can easily have a button with single text, icon+text or single icon.
You don't have to build those kind of buttons by yourself by sending the component the children node you need. 
That being said, you still can choose to send node children but you may have to add your own style if it doesn't render as you wish.