### PR TITLE
feat: forward props to textarea

### DIFF
--- a/react/Textarea/Readme.md
+++ b/react/Textarea/Readme.md
@@ -9,3 +9,13 @@
 ```
 <Textarea error placeholder="Once upon a time, there was an error…"></Textarea>
 ```
+
+### Props forwarding
+
+`Textarea` forwards unknown props to the underlying `<textarea />` element.
+
+```
+<div>
+  <Textarea name='my-field' />
+</div>
+```

--- a/react/Textarea/index.jsx
+++ b/react/Textarea/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
 const Textarea = props => {
-  const { className, placeholder, children, error } = props
+  const { className, placeholder, children, error, ...restProps } = props
   return (
     <textarea
       placeholder={placeholder}
@@ -13,6 +13,7 @@ const Textarea = props => {
           [styles[`is-error`]] : error
         },
         className)}
+      {...restProps}
     >
       {children}
     </textarea>


### PR DESCRIPTION
Just like `Input`, forwards any remaining props to the underlying element. useful for things like a `name` prop.