### PR TITLE
 Add utility classes for colors

### DIFF
--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -1,4 +1,9 @@
 json('palette.json')
+colors=json('palette.json', { hash: true })
+
+for color in keys(colors)
+    .u--{color}
+        color: lookup(color) !important // @stylint ignore
 
 /*------------------------------------*\
   Palette


### PR DESCRIPTION
 `.u--paleGrey`, `.u--dodgerBlue` etc... are now available.

I put !important since they are utility classes and we will always want this behavior.

 ```css
 ....

 .u--paleGrey {
       color: #f5f6f7 !important;
 }
 .u--silver {
       color: #d6d8da !important;
 }
 .u--coolGrey {
       color: #95999d !important;
 }
 .u--slateGrey {
       color: #5d6165 !important;
 }
 ....
 ```

fixes #353