### PR TITLE
fix: export modal title

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -40,7 +40,7 @@ const ModalHeader = ({ children, className }) =>
     </h2>
   )
 
-const ModalTitle = () => {
+const ModalTitle = (props) => {
   return <ModalHeader {...props } />
 }
 
@@ -205,6 +205,7 @@ export {
   ModalSection,
   ModalFooter,
   ModalHeader,
+  ModalTitle,
   ModalBrandedHeader,
   ModalDescription
 }


### PR DESCRIPTION
The latest release notes say `ModalTitle` is deprecated, but actually it was not exported at all so the modals that use `ModalTitle` are broken.