### PR TITLE
✨ feat: mkComponent supports className when forwarding props

### DIFF
--- a/react/utils.jsx
+++ b/react/utils.jsx
@@ -1,7 +1,13 @@
 import React from 'react'
 
-const mkComponent = (Tag, extra = {}) => ({children, ...props}) => (
-  <Tag {...extra} {...props}>{children}</Tag>
-)
+const mkComponent = (Tag, extra = {}) => ({children, className, ...props}) => {
+  const { className: extraClassName, ...restExtra} = extra
+
+  return <Tag {...restExtra} {...props} className={
+    (className || '') + ' ' + (extraClassName || '')
+  }>
+    {children}
+  </Tag>
+}
 
 export { mkComponent }


### PR DESCRIPTION
When forwarding className, it would shadow the className defined
when creating the Component. Now it merges classNames