### PR TITLE
fix: buttonlink label and children

### DIFF
--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -47,8 +47,8 @@ export const ButtonLink = props => {
     >
       <span>
         {icon && <Icon icon={icon} />}
-        {label && <span>label</span>}
-        {children && {children}}
+        {label && <span>{label}</span>}
+        {children}
       </span>
     </a>
   )


### PR DESCRIPTION
Fixes the labels and the children for `ButtonLink`