### PR TITLE
fix: svg symbol detection

### DIFF
--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -15,7 +15,7 @@ const btnClass = function (theme, size, extension, className) {
 }
 
 const usableByIcon = icon => {
-  const isSvgSymbol = !!icon.id
+  const isSvgSymbol = icon && !!icon.id
   const isIconIdentifier = typeof icon === 'string'
   return isSvgSymbol || isIconIdentifier
 }


### PR DESCRIPTION
Unfortunate side-effect of the fix from earlier : if a button has no icon, the `icon` variable is `null` and reading `icon.id` produces a type error and crashes the whole thing :(