### PR TITLE
feat: Add input & textarea different sizes

### DIFF
--- a/react/Input/Readme.md
+++ b/react/Input/Readme.md
@@ -15,6 +15,19 @@
 <Input error placeholder="This is a input[type=text] with error" />
 ```
 
+### Alternative input sizes
+
+```
+<div>
+  <p>
+    <Input placeholder="I have a tiny size" size="tiny" />
+  </p>
+  <p>
+    <Input placeholder="I have a medium size" size="medium" />
+  </p>
+</div>
+```
+
 ### Props forwarding
 
 `Input` forwards unknown props to the underlying `<input />` element.

--- a/react/Input/index.jsx
+++ b/react/Input/index.jsx
@@ -4,14 +4,15 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
 const Input = props => {
-  const { type, id, className, value, placeholder, error, ...restProps } = props
+  const { type, id, className, value, placeholder, error, size, ...restProps } = props
   return (
     <input
       type={type}
       id={id}
       className={cx(
         styles['c-input-text'], {
-          [styles[`is-error`]] : error
+          [styles[`is-error`]] : error,
+          [styles[`c-input-text--${size}`]] : size
         },
         className)}
       placeholder={placeholder}
@@ -27,7 +28,8 @@ Input.propTypes = {
   className: PropTypes.string,
   value: PropTypes.string,
   placeholder: PropTypes.string,
-  error: PropTypes.bool
+  error: PropTypes.bool,
+  size: PropTypes.oneOf(['tiny','medium'])
 }
 
 Input.defaultProps = {

--- a/react/Input/styles.styl
+++ b/react/Input/styles.styl
@@ -2,3 +2,9 @@
 
 .c-input-text
     @extend $input-text
+
+.c-input-text--tiny
+    @extend $input-text--tiny
+
+.c-input-text--medium
+    @extend $input-text--medium

--- a/react/Textarea/Readme.md
+++ b/react/Textarea/Readme.md
@@ -10,6 +10,19 @@
 <Textarea error placeholder="Once upon a time, there was an error…"></Textarea>
 ```
 
+#### Alternative textarea sizes
+
+```
+<div>
+  <p>
+    <Textarea placeholder="I'm have a tiny size" size="tiny"></Textarea>
+  </p>
+  <p>
+    <Textarea placeholder="I'm have a medium size" size="medium"></Textarea>
+  </p>
+</div>
+```
+
 ### Props forwarding
 
 `Textarea` forwards unknown props to the underlying `<textarea />` element.

--- a/react/Textarea/index.jsx
+++ b/react/Textarea/index.jsx
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
 const Textarea = props => {
-  const { className, placeholder, children, error, ...restProps } = props
+  const { className, placeholder, children, error, size, ...restProps } = props
   return (
     <textarea
       placeholder={placeholder}
       className={cx(
         styles['c-textarea'], {
-          [styles[`is-error`]] : error
+          [styles[`is-error`]] : error,
+          [styles[`c-textarea--${size}`]] : size
         },
         className)}
       {...restProps}
@@ -24,7 +25,8 @@ Textarea.propTypes = {
   children: PropTypes.string,
   placeholder: PropTypes.string,
   className: PropTypes.string,
-  error: PropTypes.bool
+  error: PropTypes.bool,
+  size: PropTypes.oneOf(['tiny','medium'])
 }
 
 Textarea.defaultProps = {

--- a/react/Textarea/styles.styl
+++ b/react/Textarea/styles.styl
@@ -2,3 +2,9 @@
 
 .c-textarea
     @extend $textarea
+
+.c-textarea--tiny
+    @extend $textarea--tiny
+
+.c-textarea--medium
+    @extend $textarea--medium

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -242,12 +242,13 @@ $input-text
     display inline-block
     width 100%
     max-width 30rem
-    padding .8125rem .75rem .8125rem .9rem
+    padding .8125rem 1rem
     box-sizing border-box
     border-radius .1875rem
     border .0625rem solid silver
     background white
     font-size 1rem
+    line-height 1.25
     color black
     outline 0
 
@@ -266,12 +267,28 @@ $input-text
     &:invalid
         border .0625rem solid pomegranate
 
+$input-text--tiny
+    border-radius .125rem
+    padding .225rem .5rem .4rem
+
+$input-text--medium
+    border-radius .125rem
+    padding .485rem 1rem .64rem
+
 $textarea
     @extend $input-text
     display block
     width 100%
     min-height 7.5rem
     resize vertical
+
+$textarea--tiny
+    @extend $input-text--tiny
+    min-height 3rem
+
+$textarea--medium
+    @extend $input-text--medium
+    min-height 5rem
 
 $select
     @extend $input-text

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -334,6 +334,8 @@
  </form>
 
  .is-error - Error variant
+ .c-input-text--tiny - Tiny size variant
+ .c-input-text--medium - Medium size variant
 
  Weight: 2
 
@@ -341,6 +343,12 @@
 */
 .c-input-text
     @extend $input-text
+
+.c-input-text--tiny
+    @extend $input-text--tiny
+
+.c-input-text--medium
+    @extend $input-text--medium
 
 /*
  Textarea
@@ -353,6 +361,8 @@
  </form>
 
  .is-error - Error variant
+ .c-textarea--tiny - Tiny size variant
+ .c-textarea--medium - Medium size variant
 
  Weight: 3
 
@@ -360,6 +370,12 @@
 */
 .c-textarea
     @extend $textarea
+
+.c-textarea--tiny
+    @extend $textarea--tiny
+
+.c-textarea--medium
+    @extend $textarea--medium
 
 /*
  Select


### PR DESCRIPTION
Added `size` prop on inputs & textareas with `tiny` & `medium` options.
Inputs & textareas are large by default but can be smaller now.