### PR TITLE
feat: Center modal on mobile & add fullscreen option on mobile

### DIFF
--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -68,7 +68,7 @@ const spacings = [
 
 ### mobileFullscreen
 
-If you have a modal filled with content and want it to occupy all the available space on mobile screen.
+If you want the modal to fill all the available space, without margin, on mobile screen.
 
 ```
 initialState = { modalDisplayed: false};

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -66,6 +66,21 @@ const spacings = [
 </div>
 ```
 
+### mobileFullscreen
+
+If you have a modal filled with content and want it to occupy all the available space on mobile screen.
+
+```
+initialState = { modalDisplayed: false};
+
+<div>
+  <button onClick={()=>setState({ modalDisplayed: !state.modalDisplayed })}>
+    Toggle modal
+  </button>
+  {state.modalDisplayed && <Modal title='Ada Lovelace' description={content.ada.long} mobileFullscreen dismissAction={() => setState({ modalDisplayed: false })} /> }
+</div>
+```
+
 ### Closable
 
 With `closable` set to `false`, the user will not be able to close the modal, even by clicking outside the modal. You must manage the modal's closing by yourself.

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -84,12 +84,18 @@ class Modal extends Component {
   }
 
   render () {
-    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName, crossColor, into, size, spacing } = this.props
+    const { children, description, title, closable, dismissAction, overflowHidden, className, crossClassName, crossColor, into, size, spacing, mobileFullscreen } = this.props
     const maybeWrapInPortal = children => into ? <Portal into={into}>{ children }</Portal> : children
     return maybeWrapInPortal(
       <div className={styles['c-modal-container']}>
         <Overlay onEscape={closable && dismissAction}>
-          <div className={styles['c-modal-wrapper']} onClick={closable && this.handleOutsideClick}>
+          <div className={
+            cx(
+              styles['c-modal-wrapper'],
+              {
+                [styles['c-modal-wrapper--fullscreen']]: mobileFullscreen
+              }
+          )} onClick={closable && this.handleOutsideClick}>
             <div className={
               cx(
                 styles['c-modal'],
@@ -97,7 +103,8 @@ class Modal extends Component {
                 className,
                 {
                   [styles['c-modal--overflowHidden']]: overflowHidden,
-                  [styles[`c-modal--${spacing}-spacing`]]: spacing
+                  [styles[`c-modal--${spacing}-spacing`]]: spacing,
+                  [styles['c-modal--fullscreen']]: mobileFullscreen
                 }
               )}>
               { closable && <ModalCross className={crossClassName} onClick={dismissAction} color={crossColor} /> }
@@ -144,7 +151,9 @@ Modal.propTypes = {
   to control the rendering destination of the Modal */
   into: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'xxlarge']),
-  spacing: PropTypes.oneOf(['small', 'large'])
+  spacing: PropTypes.oneOf(['small', 'large']),
+  /** If you want your modal taking all the screen on mobile */
+  mobileFullscreen: PropTypes.bool
 }
 
 Modal.defaultProps = {
@@ -153,6 +162,7 @@ Modal.defaultProps = {
   closable: true,
   overflowHidden: false,
   size: 'small',
+  mobileFullscreen: false
 }
 
 ModalBrandedHeader.propTypes = {

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -10,6 +10,9 @@
 .c-modal-wrapper
     @extend $modal-wrapper
 
+.c-modal-wrapper--fullscreen
+    @extend $modal-wrapper--fullscreen
+
 .c-modal
     @extend $modal
 
@@ -27,6 +30,9 @@
 
 .c-modal--xxlarge
     @extend $modal--xxlarge
+
+.c-modal--fullscreen
+    @extend $modal--fullscreen
 
 .c-modal-header
     @extend $modal-header

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -51,6 +51,7 @@ $modal-wrapper
     padding large-margin
 
     +small-screen()
+        justify-content center
         padding medium-margin
 
     +tiny-screen()
@@ -71,6 +72,16 @@ for size in 'small' 'medium' 'large' 'xlarge' 'xxlarge'
         $max-width=lookup(size + '-width') + lookup(size + '-margin') * 2
         @media (max-width: $max-width)
             width auto
+
+$modal-wrapper--fullscreen
+    +small-screen()
+        padding 0
+
+$modal--fullscreen
+    +small-screen()
+        height 100%
+        width 100%
+        border-radius 0
 
 $modal-header
     @extend $elastic-bar


### PR DESCRIPTION
- [x] Modal are now vertically centered on mobile (<768px)
- [x] Added `fullscreen` boolean props to allow a Modal to fit the entire screen on mobile (<768px) if needed (default `false`), mostly for Modals with a lot of content.