### PR TITLE
modalHeader have h2 only if title props defined

### DIFF
--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -141,7 +141,7 @@ const { ModalDescription, ModalHeader } = Modal;
         overflowHidden={true}
         dismissAction={()=>setState({ modalDisplayed: false})} >
       <div style={{background: 'red', color: 'white'}}>
-        <ModalHeader title="Yo ho ho !"></ModalHeader>
+        <ModalHeader title="Yo ho ho !" />
       </div>
       <ModalDescription className='u-mt-half'>
         { content.ada.short }

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -141,7 +141,7 @@ const { ModalDescription, ModalHeader } = Modal;
         overflowHidden={true}
         dismissAction={()=>setState({ modalDisplayed: false})} >
       <div style={{background: 'red', color: 'white'}}>
-        <ModalHeader>Yo ho ho !</ModalHeader>
+        <ModalHeader title="Yo ho ho !"></ModalHeader>
       </div>
       <ModalDescription className='u-mt-half'>
         { content.ada.short }

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -33,12 +33,12 @@ const ModalBrandedHeader = ({logo, bg, className, style={}}) => (
   </h2>
 )
 
-const ModalHeader = ({ children, className }) =>
-  (
-    <h2 className={cx(styles['c-modal-header'], className)}>
-      {children}
-    </h2>
-  )
+const ModalHeader = ({ title, children, className }) => (
+  <div className={cx(styles['c-modal-header'], className)}>
+    {title && <h2>{title}</h2>}
+    {children}
+  </div>
+)
 
 const ModalTitle = props => {
   console.log('ModalTitle is a deprecated component, use ModalHeader instead')
@@ -101,7 +101,7 @@ class Modal extends Component {
                 }
               )}>
               { closable && <ModalCross className={crossClassName} onClick={dismissAction} color={crossColor} /> }
-              { title && <ModalHeader>{title}</ModalHeader> }
+              { title && <ModalHeader title={title}></ModalHeader> }
               { description && <ModalDescription>{ description }</ModalDescription> }
               {children}
               <ModalFooter {...this.props} />

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -33,12 +33,15 @@ const ModalBrandedHeader = ({logo, bg, className, style={}}) => (
   </h2>
 )
 
-const ModalHeader = ({ title, children, className }) => (
-  <div className={cx(styles['c-modal-header'], className)}>
-    {title && <h2>{title}</h2>}
-    {children}
-  </div>
-)
+const ModalHeader = ({ title, children, className }) => {
+  const isTitle = typeof children === 'string'
+  return (
+    <div className={cx(styles['c-modal-header'], className)}>
+      {title && <h2>{title}</h2>}
+      {isTitle ? <h2>{children}</h2> : children}
+    </div>
+  )
+}
 
 const ModalTitle = props => {
   console.log('ModalTitle is a deprecated component, use ModalHeader instead')

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -76,14 +76,19 @@ $modal-header
     @extend $elastic-bar
     margin 0 0 1rem
     padding 'calc(%s - .3rem)' % medium-padding 3rem 0 medium-padding
-    font-weight bold
     overflow visible
     min-height 2.5rem
+
+    h2
+        margin 0
+        font-weight bold
 
     +tiny-screen()
         margin-bottom .5rem
         padding 'calc(%s - .3rem)' % small-padding 2rem 0 small-padding
-        font-size 1.25rem
+
+        h2
+            font-size 1.25rem
 
 $modal-header--branded
     @extend $modal-header


### PR DESCRIPTION
But still works if `children` is just a string.

Fix: #387 