### PR TITLE
fix: elastic layout background on Safari

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -49,8 +49,8 @@ $elastic
 
 $elastic-content
     // Those backgrounds give a visual information that the content is scrollable
-    background  linear-gradient(white 30%, alpha(black, 0)),
-                linear-gradient(alpha(black, 0), white 70%) 0 100%,
+    background  linear-gradient(white 30%, alpha(white, 0)),
+                linear-gradient(alpha(white, 0), white 70%) 0 100%,
                 linear-gradient(alpha(coolGrey, .25) 0, alpha(coolGrey, .25) 25%, alpha(white, 0) 26%, alpha(white, 0) 100%),
                 linear-gradient(alpha(white, 0) 0, alpha(white, 0) 74%, alpha(coolGrey, .25) 75%, alpha(coolGrey, .25) 100%) 0 100%
     background-repeat no-repeat


### PR DESCRIPTION
Background gradient in elastic layout was buggy on Safari.
Apparently, for Safari, `rgba(0, 0, 0, 0)` ≠ transparent… 
Thankfully, it works better with `rgba(255, 255, 255, 0)` 🎉