### PR TITLE
fix: some underlying errors & warnings

### DIFF
--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -117,8 +117,6 @@ const commonDefaultProps = {
   label: null,
   icon: null,
   theme: '',
-  size: '',
-  extension: '',
   className: '',
   onClick: null
 }

--- a/react/Hero/index.jsx
+++ b/react/Hero/index.jsx
@@ -15,7 +15,7 @@ export const Sections = mkComponent('div', {className: styles['Hero-sections']})
 export const Paragraph = mkComponent('p', {})
 export const CTA = mkComponent('p', {className: styles['Hero-cta']})
 export const Icon = ({ color, icon }) => (
-  <BaseIcon width='auto' height='5rem' style={{ color }} icon={icon} />
+  <BaseIcon width={80} height={80} style={{ color }} icon={icon} />
 )
 
 Hero.Title = Title

--- a/react/Icon/Readme.md
+++ b/react/Icon/Readme.md
@@ -29,7 +29,7 @@ to load your SVG (either explicitly or, better, implicitly in your `webpack.conf
 
 import myIcon from 'my-icon.svg' 
 
-<Icon icon={ myIcon } width='2rem' height='2rem' color='purple' />
+<Icon icon={ myIcon } width={32} height={32} color='purple' />
 ```
 
 ### Props forwarding
@@ -38,6 +38,6 @@ Icon forwards unknown props to the underlying `<svg />` element.
 
 ```
 <div>
-  <Icon icon='warning' onClick={() => alert('Be careful !')} width='2rem' height='2rem' color='purple' /><span>← Click it</span>
+  <Icon icon='warning' onClick={() => alert('Be careful !')} width={32} height={32} color='purple' /><span>← Click it</span>
 </div>
 ```

--- a/react/Textarea/index.jsx
+++ b/react/Textarea/index.jsx
@@ -22,7 +22,7 @@ const Textarea = props => {
 }
 
 Textarea.propTypes = {
-  children: PropTypes.string,
+  children: PropTypes.node,
   placeholder: PropTypes.string,
   className: PropTypes.string,
   error: PropTypes.bool,


### PR DESCRIPTION
- [x] Removed `<Button />`'s props `size`& `extension` default value as it was not needed and caused an console error.
- [x] `width` & `height` HTML attributes never take a value with a unit, values should equals pixel sizes. Those attributes doesn't recognize and understand any unit or keyword. Only number related to pixels.
- [x] `<Textarea />`'s children proptypes was `string`