### PR TITLE
feat: add disabled attribute for ButtonLink ✨

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-- none yet
+- `disabled` attribute for `<ButtonLink />` component
 
 ### Removed
 - none yet

--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -1,9 +1,8 @@
 There's two kinds of Button at your disposal : `<Button />` & `<ButtonLink />`.
 The first is a basic `<button>` for a click event, the second is a `<a>`, a link.
-Both look exactly the same, they share the same `theme`, `className` & `onClick` parameters but `<Button>` has also: 
+Both look exactly the same, they share the same `className`, `disabled`, `onClick` & `theme` parameters but `<Button>` has also:
 
 - `busy` that adds a spinner (default `false`)
-- `disabled` that disable the click event (default `false`)
 - `type`, eg. `submit` or `reset` (default `submit`)
 
 when `<ButtonLink>` has:
@@ -74,8 +73,9 @@ initialState = { busy:false };
 #### Disable a button
 
 ```
-const { Button } = require('./index');
+const { Button, ButtonLink } = require('./index');
 <Button disabled label='Loading' />
+<ButtonLink disabled href='http://cozy.io' label='Go to Cozy website' />
 ```
 
 #### Create a button with an icon

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -43,13 +43,14 @@ export const Button = props => {
 export default Button
 
 export const ButtonLink = props => {
-  const { theme, size, extension, href, target, className, children, label, icon, onClick } = props
+  const { disabled, theme, size, extension, href, target, className, children, label, icon, onClick } = props
   return (
     <a
+      aria-disabled={disabled}
       href={href}
       target={target}
       className={btnClass(theme, size, extension, className)}
-      onClick={onClick}
+      onClick={disabled ? (event) => event.preventDefault() : onClick}
     >
       <span>
         {usableByIcon(icon) ? <Icon icon={icon} /> : icon}
@@ -91,6 +92,8 @@ Button.propTypes = {
 ButtonLink.propTypes = {
   /** DEPRECATED: please use label and icon */
   children: PropTypes.node,
+  /** Disables the button */
+  disabled: PropTypes.bool,
   /** Label of the button */
   label: PropTypes.node,
   /** Icon identifier or `<Icon />` */
@@ -130,6 +133,7 @@ Button.defaultProps = {
 
 ButtonLink.defaultProps = {
   ...commonDefaultProps,
+  disabled: false,
   target: '',
   href: ''
 }


### PR DESCRIPTION
This PR adds a `disabled` attribute for `<ButtonLink />`. In a few case we may display a `<ButtonLink />` having an `href` fetched asynchronously. Or an `href` with no value. In those case, the `<ButtonLink />` could be displayed as disabled an the `onClick` handled ignored.

Example : in [Cozy-Collect](http://github.com/cozy/cozy-collect/) we are fetching the cozy-store URL. In some environment this app may not be installed, so the `<ButtonLink />` is disabled.