### PR TITLE
🐝 fix: remove default props that are defaulted by react

### DIFF
--- a/react/Input/index.jsx
+++ b/react/Input/index.jsx
@@ -34,10 +34,6 @@ Input.propTypes = {
 
 Input.defaultProps = {
   type: 'text',
-  id: '',
-  className: '',
-  value: '',
-  placeholder: '',
   error: false
 }
 


### PR DESCRIPTION
React defaults undefined to "" automatically.

Additionally, setting id to "" would cause errors in the styleguide.

![image](https://user-images.githubusercontent.com/465582/38356204-62ae9d88-38bf-11e8-86fd-72de7197dd7e.png)
