### PR TITLE
fix: fill strip loader lowercase

### DIFF
--- a/loaders/strip-fill-loader.js
+++ b/loaders/strip-fill-loader.js
@@ -9,9 +9,6 @@ module.exports = function (source) {
     return source
   }
   const replaced = source
-    .replace('fill="#FFF"', '')
-    .replace('fill="#FFFFFF"', '')
-    .replace('fill=\'#FFF\'', '')
-    .replace('fill=\'#FFFFFF\'', '')
+    .replace(/fill=["']#f{3,6}["']/gi, '')
   return replaced
 }


### PR DESCRIPTION
Some icons (such as `rename`) were not properly stripped of their fill color because they use lower-case color values.