### PR TITLE
feat: hide overflowing content from Bd component

### DIFF
--- a/react/Media/Media.styl
+++ b/react/Media/Media.styl
@@ -10,6 +10,7 @@
 
 .bd
     flex 1 1 auto
+    overflow hidden
 
 .img
     line-height 0


### PR DESCRIPTION
This just add `overflow: hidden` in the `Bd` component.

In general, since this component must constraint its content's width, I think it should hide what's overflowing.

More particulary, in banks we use the `ListItemText` component inside a `Bd` component. Since the `ListItemText` has `white-space: nowrap`, it expands to fit the wider line of text is contains. But in that case, if `Bd` doesn't have `overflow: hidden`, its content may overflow : 

![image](https://user-images.githubusercontent.com/1606068/38691075-0554e48c-3e80-11e8-90db-149a638047f7.png)

You may think this is a particular case we have here. But on the contrary I think it's very generic : `Bd` must fill the available space, and what it contains must never overflow.