### PR TITLE
🚑  fix: avoid IntentModal dismissAction to be called twice

### DIFF
--- a/react/IntentModal/IntentModal.jsx
+++ b/react/IntentModal/IntentModal.jsx
@@ -1,8 +1,11 @@
 import React, { Component } from 'react'
-import Modal from '../Modal'
-import IntentIframe from '../IntentIframe'
 import styles from './styles.styl'
 import PropTypes from 'prop-types'
+
+import once from 'lodash/once'
+
+import IntentIframe from '../IntentIframe'
+import Modal from '../Modal'
 
 /**
  * Render a modal for the specified intent.
@@ -10,11 +13,22 @@ import PropTypes from 'prop-types'
  * The modal for an intent takes the majority of the viewport.
  */
 class IntentModal extends Component {
+
+  // As dismissAction is passed twice to the modal, both for closing and for
+  // intent cancellation, we need to ensure that it is only actually
+  // called once.
+  // FIXME: this should be fixed by diferenciating dismissAction (for closing
+  // modal) and onCancel (for intent cancellation), but it implies deprecating
+  // dismissAction first, ensure legacy, prevent regressions, etc.
+  dismiss = once(() => {
+    const { dismissAction } = this.props
+    dismissAction && dismissAction()
+  })
+
   render() {
     const {
       closable,
       overflowHidden,
-      dismissAction,
       action,
       doctype,
       options,
@@ -30,13 +44,13 @@ class IntentModal extends Component {
         overflowHidden={overflowHidden}
         className={styles.intentModal}
         crossClassName={styles.intentModal__cross}
-        dismissAction={dismissAction}
+        dismissAction={this.dismiss}
       >
         <IntentIframe
           action={action}
           create={create}
           data={options}
-          onCancel={dismissAction}
+          onCancel={this.dismiss}
           onError={onError}
           onTerminate={onComplete}
           type={doctype}

--- a/react/IntentModal/IntentModal.jsx
+++ b/react/IntentModal/IntentModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import Modal from '../Modal'
 import IntentIframe from '../IntentIframe'
 import styles from './styles.styl'
@@ -9,36 +9,42 @@ import PropTypes from 'prop-types'
  *
  * The modal for an intent takes the majority of the viewport.
  */
-const IntentModal = ({
-  closable,
-  overflowHidden,
-  dismissAction,
-  action,
-  doctype,
-  options,
-  onComplete,
-  onError,
-  create
-}) => (
-  <Modal
-    key='modal'
-    closable={closable}
-    overflowHidden
-    className={styles.intentModal}
-    crossClassName={styles.intentModal__cross}
-    dismissAction={dismissAction}
-  >
-    <IntentIframe
-      action={action}
-      create={create}
-      data={options}
-      onCancel={dismissAction}
-      onError={onError}
-      onTerminate={onComplete}
-      type={doctype}
-    />
-  </Modal>
-)
+class IntentModal extends Component {
+  render() {
+    const {
+      closable,
+      overflowHidden,
+      dismissAction,
+      action,
+      doctype,
+      options,
+      onComplete,
+      onError,
+      create
+    } = this.props
+
+    return (
+      <Modal
+        key="modal"
+        closable={closable}
+        overflowHidden={overflowHidden}
+        className={styles.intentModal}
+        crossClassName={styles.intentModal__cross}
+        dismissAction={dismissAction}
+      >
+        <IntentIframe
+          action={action}
+          create={create}
+          data={options}
+          onCancel={dismissAction}
+          onError={onError}
+          onTerminate={onComplete}
+          type={doctype}
+        />
+      </Modal>
+    )
+  }
+}
 
 IntentModal.propTypes = {
   /** What should happen when the intent has completed */

--- a/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
+++ b/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
@@ -5,7 +5,7 @@ exports[`IntentModal component renders as expected 1`] = `
   className="intentModal"
   closable={true}
   crossClassName="intentModal__cross"
-  dismissAction={[MockFunction onDismissMock]}
+  dismissAction={[Function]}
   overflowHidden={true}
 >
   <IntentIframe
@@ -16,7 +16,7 @@ exports[`IntentModal component renders as expected 1`] = `
         "key": "value",
       }
     }
-    onCancel={[MockFunction onDismissMock]}
+    onCancel={[Function]}
     onError={[MockFunction onErrorMock]}
     onTerminate={[MockFunction onCompleteMock]}
     type="io.cozy.whatever"


### PR DESCRIPTION
Spent one hour tonight dealing with this.

In the future we shoud improve this fix, by separating the logic between modal closing and intent cancellation. But it implies deprecating properties like `dismissAction`, ensure legacy and avoid regression.

I think we should wait for the release of cozy-interapp to make Cozy-UI components up to date and improve this fix.