### PR TITLE
feat: remove dimensions and border on compact version of ButtonAction

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -379,10 +379,7 @@ $actionbtn
 $actionbtn--compact
     @extend $button--narrow
     position relative
-    margin-left .5rem
     border 0
-    width 3rem
-    height 3rem
     background-color transparent
     padding 0
 
@@ -399,16 +396,6 @@ $actionbtn--compact
         border-left none
         margin-left 0
         padding 0
-
-    &:before
-        content ''
-        position absolute
-        top 50%
-        left -.0625rem
-        transform translateY(-50%)
-        width .0625rem
-        height 1.5rem
-        background-color silver
 
     &:hover
     &:focus


### PR DESCRIPTION
I updated the compact version of the `ButtonAction` component to make it match the requirements banks.

It means : 

* Remove the border on the left (we need to handle it at the application level since even if a transaction row does'nt have an action, it shows this border)
* Remove specific size for the compact variant

See https://drazik.github.io/cozy-ui/react/#buttonaction , and the result in banks : 

![image](https://user-images.githubusercontent.com/1606068/38939834-1472e18c-4329-11e8-8d60-89a2da3517d5.png)