### PR TITLE
feat: add Badge component

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -9,7 +9,8 @@ module.exports = {
         '../react/Button/index.jsx',
         '../react/ButtonAction/index.jsx',
         '../react/Spinner/index.jsx',
-        '../react/Icon/index.jsx'
+        '../react/Icon/index.jsx',
+        '../react/Badge/index.jsx'
       ]
     },
     {

--- a/react/Badge/Readme.md
+++ b/react/Badge/Readme.md
@@ -1,0 +1,27 @@
+`<Badge />` component wraps the element on which you want to apply a badge. In the following examples, it is applied to compact `<ButtonAction />`.
+
+This component spreads all other props to its root element.
+
+#### Available types
+
+Default type is `normal`
+
+```
+<div>
+  <p>
+    <Badge content="2" type="normal">
+      <ButtonAction label='Normal' rightIcon='openwith' compact />
+    </Badge>
+  </p>
+  <p>
+    <Badge content="2" type="new">
+      <ButtonAction type='new' leftIcon="plus" label='New' compact />
+    </Badge>
+  </p>
+  <p>
+    <Badge content="2" type="error">
+      <ButtonAction type='error' label='Error' rightIcon='file-none' compact />
+    </Badge>
+  </p>
+</div>
+```

--- a/react/Badge/index.jsx
+++ b/react/Badge/index.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import styles from './styles.styl'
+
+export const Badge = ({ children, content, type, ...props }) => {
+  return (
+    <span
+      className={styles['c-badge-root']}
+      {...props}
+    >
+      {children}
+      <span
+        className={classNames(
+          styles['c-badge'],
+          {
+            [styles[`c-badge--${type}`]]: type
+          }
+        )}
+      >
+        {content}
+      </span>
+    </span>
+  )
+}
+
+Badge.propTypes = {
+  /** The content of the badge */
+  content: PropTypes.string,
+  /** The type of the badge */
+  type: PropTypes.oneOf(['normal', 'new', 'error'])
+}
+
+Badge.defaultProps = {
+  content: '',
+  type: 'normal'
+}
+
+export default Badge

--- a/react/Badge/styles.styl
+++ b/react/Badge/styles.styl
@@ -1,0 +1,16 @@
+@require '../../stylus/components/badge'
+
+.c-badge-root
+    @extend $badge-root
+
+.c-badge
+    @extend $badge
+
+.c-badge--new
+    @extend $badge--new
+
+.c-badge--normal
+    @extend $badge--normal
+
+.c-badge--error
+    @extend $badge--error

--- a/react/index.js
+++ b/react/index.js
@@ -1,4 +1,5 @@
 export {default as Alerter} from './Alerter'
+export { default as Badge } from './Badge'
 export { Button, ButtonLink } from './Button'
 export { default as ButtonAction } from './ButtonAction'
 export {default as I18n, translate} from './I18n'

--- a/stylus/components/badge.styl
+++ b/stylus/components/badge.styl
@@ -1,6 +1,6 @@
 @require '../settings/palette'
 
-radius = .4375rem
+size = .875rem
 
 $badge-root
     position relative
@@ -8,10 +8,10 @@ $badge-root
 
 $badge
     position absolute
-    bottom - radius
-    right - radius
-    width radius * 2
-    height radius * 2
+    bottom - size / 2
+    right - size / 2
+    width size
+    height size
     border-radius 50%
     background-color black
     color white
@@ -23,7 +23,7 @@ $badge
     align-content center
     align-items center
     font-size .625rem
-    border 1px solid white
+    border .0625rem solid white
 
 $badge--new
     color zircon

--- a/stylus/components/badge.styl
+++ b/stylus/components/badge.styl
@@ -1,6 +1,6 @@
 @require '../settings/palette'
 
-radius = 0.4375rem
+radius = .4375rem
 
 $badge-root
     position relative
@@ -22,8 +22,8 @@ $badge
     justify-content center
     align-content center
     align-items center
-    font-size 0.625rem
-    border: 1px solid #fff
+    font-size .625rem
+    border 1px solid white
 
 $badge--new
     color zircon

--- a/stylus/components/badge.styl
+++ b/stylus/components/badge.styl
@@ -1,0 +1,38 @@
+@require '../settings/palette'
+
+radius = 0.4375rem
+
+$badge-root
+    position relative
+    display inline-flex
+
+$badge
+    position absolute
+    bottom - radius
+    right - radius
+    width radius * 2
+    height radius * 2
+    border-radius 50%
+    background-color black
+    color white
+    z-index 1
+    display flex
+    flex-direction row
+    flex-wrap wrap
+    justify-content center
+    align-content center
+    align-items center
+    font-size 0.625rem
+    border: 1px solid #fff
+
+$badge--new
+    color zircon
+    background-color dodgerBlue
+
+$badge--normal
+    color paleGrey
+    background-color charcoalGrey
+
+$badge--error
+    color chablis
+    background-color pomegranate

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -382,6 +382,8 @@ $actionbtn--compact
     border 0
     background-color transparent
     padding 0
+    min-height 0
+    margin 0
 
     > span
         justify-content center


### PR DESCRIPTION
This adds a `<Badge />` component that can wrap any other component to add a little circle with some content to it.

See https://drazik.github.io/cozy-ui/react/#badge
