### PR TITLE
enhancement: Adds "subtle" <Button /> variant

### DIFF
--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -17,7 +17,7 @@ const props = [{}, { disabled: true}, { busy: true }];
 const themes = ['regular', 'danger', 'highlight', 'secondary', 'danger-outline', 'alpha'];
 
 <div>
-  {themes.map(theme => 
+  {themes.map(theme =>
     <p>{
       props.map(
         props => <Button label={theme} theme={theme} {...props} />
@@ -122,6 +122,35 @@ const { ButtonLink } = require('./index');
   </p>
   <p>
     <ButtonLink size="large" href="https://cozy.io" target="_blank" label='Link to Cozy.io'/>
+  </p>
+</div>
+```
+
+### Subtle Buttons
+Subtle buttons are buttons without background and borders, wich look "inverted" compared to the basic Buttons.
+
+```
+const { Button } = require('./index');
+<div>
+  <p>
+    <Button subtle size='tiny' label='Tiny text' onClick={() => alert('Clicked on Tiny text')} />
+    <Button subtle size='small' label='Small text' onClick={() => alert('Clicked on Small text')} />
+    <Button subtle label='Regular text' onClick={() => alert('Clicked on Regular text')} />
+    <Button subtle size='large' label='Large text' onClick={() => alert('Clicked on Large text')} />
+  </p>
+  <p>
+    <Button subtle theme='secondary' label='Secondary theme' onClick={() => alert('Clicked on Secondary theme')} />
+    <Button subtle theme='highlight' label='Highlight theme' onClick={() => alert('Clicked on Highlight theme')} />
+    <Button subtle theme='danger' label='DANGER theme' onClick={() => alert('Clicked on DANGER theme')} />
+  </p>
+  <p>
+    <Button subtle disabled='true' label='Disabled'  onClick={() => alert('Clicked on Disabled')} />
+  </p>
+  <p>
+    <Button subtle busy='true' label='Busy'  onClick={() => alert('Clicked on Busy')} />
+    <Button subtle busy='true' theme='secondary' label='Busy secondary'  onClick={() => alert('Clicked on Busy secondary')} />
+    <Button subtle busy='true' theme='highlight' label='Busy highlight'  onClick={() => alert('Clicked on Busy highlight')} />
+    <Button subtle busy='true' theme='danger' label='Busy danger'  onClick={() => alert('Clicked on Busy danger')} />
   </p>
 </div>
 ```

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -4,25 +4,14 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 import Icon from '../Icon'
 
-const btnClass = function(theme, size, extension, className) {
+const btnClass = function(options) {
+  const { className, extension, size, theme, variant } = options
   return cx(
     styles['c-btn'],
     {
       [styles[`c-btn--${theme}`]]: theme,
       [styles[`c-btn--${size}`]]: size,
-      [styles[`c-btn--${extension}`]]: extension
-    },
-    className
-  )
-}
-
-const btnTextClass = function(theme, size, extension, className) {
-  return cx(
-    styles['c-btn'],
-    styles['c-btn'],
-    {
-      [styles[`c-btn-text--${theme}`]]: theme,
-      [styles[`c-btn--${size}`]]: size,
+      [styles[`c-btn--${variant}`]]: variant,
       [styles[`c-btn--${extension}`]]: extension
     },
     className
@@ -41,7 +30,8 @@ export const Button = props => {
     label,
     icon,
     onClick,
-    type
+    type,
+    subtle
   } = props
   return (
     <button
@@ -49,7 +39,13 @@ export const Button = props => {
       disabled={disabled}
       type={type}
       role="button"
-      className={btnClass(theme, size, extension, className)}
+      className={btnClass({
+        className,
+        extension,
+        size,
+        theme,
+        variant: subtle && 'subtle'
+      })}
       onClick={onClick}
     >
       <span>
@@ -94,16 +90,6 @@ export const ButtonLink = props => {
   )
 }
 
-export const ButtonText = props => {
-  const { className, extension, size, theme } = props
-  return (
-    <Button
-      {...props}
-      className={btnTextClass(theme, size, extension, className)}
-    />
-  )
-}
-
 // Proptypes (unfortunately, Styleguidist does not pick
 // proptypes coming from a spread so we have to keep both
 // proptypes in sync)
@@ -129,7 +115,9 @@ Button.propTypes = {
   /** Disables the button */
   disabled: PropTypes.bool,
   /** Type of the underlying `<button />` */
-  type: PropTypes.oneOf(['reset', 'submit'])
+  type: PropTypes.oneOf(['reset', 'submit']),
+  /** Use the `subtle` alternative look for the Button  */
+  subtle: PropTypes.bool
 }
 
 ButtonLink.propTypes = {
@@ -157,31 +145,6 @@ ButtonLink.propTypes = {
   target: PropTypes.string
 }
 
-ButtonText.propTypes = {
-  /** DEPRECATED: please use label and icon */
-  children: PropTypes.node,
-  /** Label of the button */
-  label: PropTypes.node,
-  /** Icon of the button */
-  icon: PropTypes.node,
-  theme: PropTypes.string,
-  size: PropTypes.oneOf(['tiny', 'small', 'large']),
-  /** Spacing of the button */
-  extension: PropTypes.oneOf(['narrow', 'full']),
-  /** Extra class */
-  className: PropTypes.string,
-  /** What to do on click */
-  onClick: PropTypes.func,
-
-  // Only for Button
-  /** Will display a spinner if true */
-  busy: PropTypes.bool,
-  /** Disables the button */
-  disabled: PropTypes.bool,
-  /** Type of the underlying `<button />` */
-  type: PropTypes.oneOf(['reset', 'submit'])
-}
-
 // DefaultProps
 const commonDefaultProps = {
   label: null,
@@ -195,7 +158,8 @@ Button.defaultProps = {
   ...commonDefaultProps,
   busy: false,
   disabled: false,
-  type: 'submit'
+  type: 'submit',
+  subtle: false
 }
 
 ButtonLink.defaultProps = {

--- a/react/Button/styles.styl
+++ b/react/Button/styles.styl
@@ -42,6 +42,26 @@
 .c-btn--close
     @extend $button--close
 
+.c-btn--subtle
+    @extend $button-subtle
 
+    &.c-btn--regular
+        @extend $button-subtle--regular
 
+    &.c-btn--secondary
+        @extend $button-subtle--secondary
 
+    &.c-btn--danger
+        @extend $button-subtle--danger
+
+    &.c-btn--highlight
+        @extend $button-subtle--highlight
+
+    &.c-btn--tiny
+        @extend $button-subtle--tiny
+
+    &.c-btn--small
+        @extend $button-subtle--small
+
+    &.c-btn--large
+        @extend $button-subtle--large

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -662,6 +662,63 @@ exports[`Button should render examples: Button 10`] = `
 </div>"
 `;
 
+exports[`Button should render examples: Button 11`] = `
+"<div>
+  <div>
+    <div>
+      <p>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        </button>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        </button>
+      </p>
+      <p>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        </button>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        </button>
+      </p>
+      <p>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        </button>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        </button>
+      </p>
+      <p>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
+        </button>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
+        </button>
+      </p>
+      <p>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        </button>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        </button>
+      </p>
+      <p>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        </button>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        </button>
+      </p>
+    </div>
+  </div>
+</div>"
+`;
+
 exports[`ButtonAction should render examples: ButtonAction 1`] = `
 "<div>
   <div>

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -70,11 +70,16 @@ $button
             position   relative
             top        -.0625rem
 
+
 /*------------------------------------*\
-  Variants
+  Themes
 \*------------------------------------*/
 $button--regular  // Deprecated
     @extend $button
+
+regularTheme = {
+    primaryColor: dodgerBlue, secondaryColor: dodgerBlue, activeColor: scienceBlue, contrastColor: white
+}
 
 highlightTheme = {
     primaryColor: emerald, secondaryColor: emerald, activeColor: malachite, contrastColor: white
@@ -422,3 +427,113 @@ $actionbtn-icon
 
     svg
         display block
+
+/*------------------------------------*\
+  Variants
+\*------------------------------------*/
+// We turn stylint off since without semicolons, stylus fails to
+// parse the following code block.
+// @stylint off
+themedBtnSubtle(theme)
+    color: theme['secondaryColor']
+
+    &:active
+    &:focus
+    &:hover
+        color: theme['activeColor']
+
+sizedBtnSubtle(size)
+    sizes = {
+        tiny: .6rem, small: .75rem, large: 1rem
+    }
+
+    min-height 0
+    min-width 0
+    padding 0
+    font-size sizes[size]
+
+$button-subtle
+    themedBtnSubtle(regularTheme)
+    min-height auto
+    min-width auto
+    border 0
+    margin 1rem 0
+    padding 0
+    vertical-align baseline
+    background transparent
+    cursor pointer
+    font-size .875rem
+    font-weight bold
+    text-transform uppercase
+
+    svg
+        fill         currentColor
+        margin-right .4rem
+
+        &:only-child
+            margin 0
+
+    > span
+        display          flex
+        align-items      center
+        justify-content  center
+        width            100%
+
+    &[disabled]
+    &[aria-disabled=true]
+        opacity  .5
+        cursor   not-allowed
+
+        &:hover
+            background transparent
+
+    &:active
+    &:hover
+    &:focus
+        color scienceBlue
+        background transparent
+
+    &[aria-busy=true] > span::after
+        @extend $icon-16
+        @extend $icon-spinner-blue
+        position relative
+        top -.0625rem
+
+    * + &
+        margin-left 1em
+
+$button-subtle--tiny
+    sizedBtnSubtle('tiny')
+
+$button-subtle--small
+    sizedBtnSubtle('small')
+
+$button-subtle--large
+    sizedBtnSubtle('large')
+
+$button-subtle--danger
+    themedBtnSubtle(dangerTheme)
+
+    &[aria-busy=true] > span::after
+        @extend $icon-spinner-red
+
+$button-subtle--highlight
+    themedBtnSubtle(highlightTheme)
+
+    &[aria-busy=true] > span::after
+        @extend $icon-spinner-grey
+
+$button-subtle--regular
+    themedBtnSubtle(regularTheme)
+
+$button-subtle--secondary
+    themedBtnSubtle(secondaryTheme)
+
+    &[aria-busy=true] > span::after
+        @extend $icon-spinner-grey
+
+    &:active
+    &:focus
+    &:hover
+        color coolGrey
+// @stylint on


### PR DESCRIPTION
WOOPS

First part of this feature was accidentaly (but safely) committed in 4a957d4, as I was working on it when feeling like it was time to add Prettier (#440).

~I started by encaspulating a regular `<Button />` but the CSS styles were too much specific, and the button text should be looking almost like something which is not a button. So I have been needing to inject a specific `baseClassName` into the <Button /> component.
The first solution was to add a prop, but exposing it was upsetting me. So I made an `abstractButton()` wrapper which encapsulate all the mechanism for styling a whole new button. I also guess it could be useful in the future.~

This PR adds a `<Button />` variant, named _subtle_ as discussed with @Claiw 
> un subtle button c'est un bouton qui se la ramene pas, il est discret et cool

This `<Button />` is rendered only with CSS by forcing a `subtle` attribute. 

```jsx
<Button subtle />
```
It renders like this :

![capture d ecran 2018-04-19 a 22 00 59](https://user-images.githubusercontent.com/776764/39015521-ebbb0468-441d-11e8-9e60-0c992377cb33.png)

The only thing I did not succeed with were the spinner for `secondary` and `highlight`, it simply did not work after a lot of tries and changes, and I cannot consider losing more hair anymore.