### PR TITLE
feat: add 3px margin on caption inside ListItemText

### DIFF
--- a/stylus/components/list.styl
+++ b/stylus/components/list.styl
@@ -5,3 +5,6 @@ $list-text
     flex-direction column
     justify-content center
     min-height 2.5rem
+
+    .g-caption
+        margin-top .1875rem


### PR DESCRIPTION
Following @joel-costa review, I added 3px top margin on the captions inside `ListItemText`