### PR TITLE
feat: add width and height to compact ButtonAction

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -382,8 +382,9 @@ $actionbtn--compact
     border 0
     background-color transparent
     padding 0
-    min-height 0
     margin 0
+    min-height 2rem
+    width 2.5rem
 
     > span
         justify-content center


### PR DESCRIPTION
There was previously some dimensions on `ButtonAction`, but I wrongly removed it. I re-added some dimensions that fits our needs.

See https://drazik.github.io/cozy-ui/react/#buttonaction