### PR TITLE
Fix toggle state return from onToggle + add tests

### DIFF
--- a/react/Toggle/index.jsx
+++ b/react/Toggle/index.jsx
@@ -4,9 +4,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 class Toggle extends Component {
-  onChange() {
+  onChange(e) {
     if (this.props.onToggle) {
-      this.props.onToggle(!this.props.checked)
+      this.props.onToggle(e.target.checked)
     }
   }
   render() {

--- a/react/Toggle/test/toggle.spec.js
+++ b/react/Toggle/test/toggle.spec.js
@@ -1,0 +1,26 @@
+'use strict'
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Toggle from '../'
+
+describe('Toggle component', () => {
+  it(`handles correctly onToggle function`, () => {
+    const handleOnToggle = jest.fn()
+    const component = shallow(
+      <Toggle id="mock-toggle-id" onToggle={handleOnToggle} />
+    )
+    component
+      .find('#mock-toggle-id')
+      .simulate('change', { target: { checked: true } })
+    expect(handleOnToggle.mock.calls.length).toBe(1)
+    expect(handleOnToggle.mock.calls[0][0]).toBe(true)
+    component
+      .find('#mock-toggle-id')
+      .simulate('change', { target: { checked: false } })
+    expect(handleOnToggle.mock.calls.length).toBe(2)
+    expect(handleOnToggle.mock.calls[1][0]).toBe(false)
+  })
+})


### PR DESCRIPTION
The toggle was always returning `!props.checked` instead of returning the real new toggle state.