### PR TITLE
chore: disable lint fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/cozy/cozy-ui",
   "scripts": {
     "lint": "npm-run-all 'lint:*'",
-    "lint:js": "eslint --fix 'react/**/*.jsx' 'react/**/*.js'",
+    "lint:js": "eslint 'react/**/*.jsx' 'react/**/*.js'",
     "lint:stylus": "stylint stylus --config .stylintrc",
     "watch:doc:react": "styleguidist server --config docs/styleguide.config.js",
     "build:doc": "npm-run-all 'build:doc:*'",


### PR DESCRIPTION
This PR disable the eslint '--fix' option, to detect incorrectly formatted code. It avoids to get a lot of changes in other unrelated PR due to changes on code format. See https://github.com/cozy/cozy-ui/commit/750df30a69ec74a986f4ff8cf71e2f148c0669eb