### PR TITLE
Expose I18n extend() method

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -74,4 +74,6 @@ export const translate = () => WrappedComponent => {
   return Wrapper
 }
 
+export { extend } from './translation'
+
 export default I18n

--- a/react/I18n/translation.jsx
+++ b/react/I18n/translation.jsx
@@ -33,3 +33,5 @@ export const initTranslation = (
 
   return _polyglot
 }
+
+export const extend = dict => _polyglot && _polyglot.extend(dict)


### PR DESCRIPTION
Expose an `extend(dict)` method to be able to extend locales dictionnary. It could be useful for adding locales related to an app or a konnector.

Usage:

```js
import { extend } from 'cozy-ui/react/I18n'

// [...]

extend({
  'such': {
    'useful': 'very i18n'
   }
 })

// [...]

console.log(t('such.useful'))
// very i18n
```

