### PR TITLE
🚀 perf: use require instead of import

### DIFF
--- a/react/SelectionBar/styles.styl
+++ b/react/SelectionBar/styles.styl
@@ -1,7 +1,7 @@
-@import '../../stylus/tools/mixins'
-@import '../../stylus/settings/palette'
-@import '../../stylus/components/button'
-@import '../../stylus/components/selectionbar'
+@require '../../stylus/tools/mixins'
+@require '../../stylus/settings/palette'
+@require '../../stylus/components/button'
+@require '../../stylus/components/selectionbar'
 
 [role=application]
   @extend $selectionbar

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -1,5 +1,5 @@
-@import '../../stylus/settings/palette'
-@import '../../stylus/settings/icons'
+@require '../../stylus/settings/palette'
+@require '../../stylus/settings/icons'
 
 .c-spinner
     display inline-block

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -1,4 +1,4 @@
-@import 'settings/palette'
+@require 'settings/palette'
 
 $chip-height=2.5rem
 $chip-font-size=1rem


### PR DESCRIPTION
No need to import twice ;)

> Disclaimer: In all places the @import is used with Stylus sheets, the @require could be used

> Along with @import, Stylus also has @require. It works almost in the same way, with the exception of importing any given file only once.

http://stylus-lang.com/docs/import.html