### PR TITLE
Fix examples jest and snapshots

### DIFF
--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -29,15 +29,9 @@ exports[`Avatar should render examples: Avatar 1`] = `
 exports[`Avatar should render examples: Avatar 2`] = `
 "<div>
   <div>
-    <div class=\\"c-avatar c-avatar--medium\\">
+    <div class=\\"c-avatar c-avatar--medium\\" style=\\"background-color: rgb(245, 45, 45); color: white;\\">
       <!-- react-text: 2 -->
-      <!-- /react-text -->
-      <!-- react-text: 3 -->
-      <!-- /react-text -->
-      <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\">
-        <use xlink:href=\\"test-file-stub\\"></use>
-      </svg>
-    </div>
+      <!-- /react-text --><span class=\\"c-avatar-initials\\">CD</span></div>
   </div>
 </div>"
 `;
@@ -46,13 +40,7 @@ exports[`Avatar should render examples: Avatar 3`] = `
 "<div>
   <div>
     <div class=\\"c-avatar c-avatar--medium\\">
-      <!-- react-text: 2 -->
-      <!-- /react-text -->
-      <!-- react-text: 3 -->
-      <!-- /react-text -->
-      <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\">
-        <use xlink:href=\\"test-file-stub\\"></use>
-      </svg>
+      <img src=\\"https://cozy.io/fr/images/cozy-logo_white.png\\" class=\\"c-avatar-image\\" alt=\\"\\">
     </div>
   </div>
 </div>"
@@ -61,14 +49,41 @@ exports[`Avatar should render examples: Avatar 3`] = `
 exports[`Avatar should render examples: Avatar 4`] = `
 "<div>
   <div>
-    <div class=\\"c-avatar c-avatar--medium\\">
-      <!-- react-text: 2 -->
-      <!-- /react-text -->
-      <!-- react-text: 3 -->
-      <!-- /react-text -->
-      <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\">
-        <use xlink:href=\\"test-file-stub\\"></use>
-      </svg>
+    <div>
+      <div>
+        <div class=\\"c-avatar c-avatar--small\\">
+          <!-- react-text: 4 -->
+          <!-- /react-text -->
+          <!-- react-text: 5 -->
+          <!-- /react-text -->
+          <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\">
+            <use xlink:href=\\"test-file-stub\\"></use>
+          </svg>
+        </div>
+        <div class=\\"c-avatar c-avatar--small\\" style=\\"background-color: rgb(245, 45, 45); color: white;\\">
+          <!-- react-text: 9 -->
+          <!-- /react-text --><span class=\\"c-avatar-initials\\">CD</span></div>
+        <div class=\\"c-avatar c-avatar--small\\">
+          <img src=\\"https://cozy.io/fr/images/cozy-logo_white.png\\" class=\\"c-avatar-image\\" alt=\\"\\">
+        </div>
+      </div>
+      <div>
+        <div class=\\"c-avatar c-avatar--medium\\">
+          <!-- react-text: 15 -->
+          <!-- /react-text -->
+          <!-- react-text: 16 -->
+          <!-- /react-text -->
+          <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\">
+            <use xlink:href=\\"test-file-stub\\"></use>
+          </svg>
+        </div>
+        <div class=\\"c-avatar c-avatar--medium\\" style=\\"background-color: rgb(245, 45, 45); color: white;\\">
+          <!-- react-text: 20 -->
+          <!-- /react-text --><span class=\\"c-avatar-initials\\">CD</span></div>
+        <div class=\\"c-avatar c-avatar--medium\\">
+          <img src=\\"https://cozy.io/fr/images/cozy-logo_white.png\\" class=\\"c-avatar-image\\" alt=\\"\\">
+        </div>
+      </div>
     </div>
   </div>
 </div>"
@@ -154,51 +169,19 @@ exports[`Button should render examples: Button 2`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--tiny\\"><span><span>Tiny</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--small\\"><span><span>Small</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Normal</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--large\\"><span><span>Large</span></span>
         </button>
       </p>
     </div>
@@ -211,51 +194,15 @@ exports[`Button should render examples: Button 3`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Normal</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--narrow\\"><span><span>N…</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--full\\"><span><span>Full width</span></span>
         </button>
       </p>
     </div>
@@ -266,56 +213,8 @@ exports[`Button should render examples: Button 3`] = `
 exports[`Button should render examples: Button 4`] = `
 "<div>
   <div>
-    <div>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-      </p>
-    </div>
+    <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>Show alert</span></span>
+    </button>
   </div>
 </div>"
 `;
@@ -323,114 +222,16 @@ exports[`Button should render examples: Button 4`] = `
 exports[`Button should render examples: Button 5`] = `
 "<div>
   <div>
-    <div>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-      </p>
-    </div>
+    <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Loading</span></span>
+    </button>
   </div>
 </div>"
 `;
 
 exports[`Button should render examples: Button 6`] = `
 "<div>
-  <div>
-    <div>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-      </p>
-    </div>
-  </div>
+  <div></div>
+  <div>ReferenceError: __setInitialState is not defined</div>
 </div>"
 `;
 
@@ -438,54 +239,10 @@ exports[`Button should render examples: Button 7`] = `
 "<div>
   <div>
     <div>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-      </p>
+      <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Loading</span></span>
+      </button>
+      <a aria-disabled=\\"true\\" href=\\"http://cozy.io\\" target=\\"\\" class=\\"c-btn\\"><span><span>Go to Cozy website</span></span>
+      </a>
     </div>
   </div>
 </div>"
@@ -495,54 +252,9 @@ exports[`Button should render examples: Button 8`] = `
 "<div>
   <div>
     <div>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-      </p>
+      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
+      </button>
+      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--narrow\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></button>
     </div>
   </div>
 </div>"
@@ -552,54 +264,8 @@ exports[`Button should render examples: Button 9`] = `
 "<div>
   <div>
     <div>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-      </p>
+      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: yellow;\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
+      </button>
     </div>
   </div>
 </div>"
@@ -610,52 +276,20 @@ exports[`Button should render examples: Button 10`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
+        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--tiny\\"><span><span>Link to Cozy.io</span></span>
+        </a>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
+        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--small\\"><span><span>Link to Cozy.io</span></span>
+        </a>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
+        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn\\"><span><span>Link to Cozy.io</span></span>
+        </a>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
-        </button>
+        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--large\\"><span><span>Link to Cozy.io</span></span>
+        </a>
       </p>
     </div>
   </div>
@@ -667,51 +301,35 @@ exports[`Button should render examples: Button 11`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--tiny c-btn--subtle\\"><span><span>Tiny text</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--small c-btn--subtle\\"><span><span>Small text</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Regular text</span></span>
         </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--large c-btn--subtle\\"><span><span>Large text</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--subtle\\"><span><span>Secondary theme</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight c-btn--subtle\\"><span><span>Highlight theme</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
+        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger c-btn--subtle\\"><span><span>DANGER theme</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Disabled</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Busy</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--subtle\\"><span><span>Busy secondary</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight c-btn--subtle\\"><span><span>Busy highlight</span></span>
+        </button>
+        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger c-btn--subtle\\"><span><span>Busy danger</span></span>
         </button>
       </p>
     </div>
@@ -751,21 +369,7 @@ exports[`ButtonAction should render examples: ButtonAction 2`] = `
   <div>
     <div>
       <p>
-        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Normal</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
-        </button>
-        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Normal</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
-        </button>
-      </p>
-      <p>
-        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--new\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">New</span></span>
-        </button>
-        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--new\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">New</span></span>
-        </button>
-      </p>
-      <p>
-        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--error\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Error</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
-        </button>
-        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--error\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Error</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
+        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Very long long long label</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
         </button>
       </p>
     </div>
@@ -778,21 +382,19 @@ exports[`ButtonAction should render examples: ButtonAction 3`] = `
   <div>
     <div>
       <p>
-        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Normal</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
-        </button>
-        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Normal</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
+        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal c-actionbtn--compact\\" title=\\"Normal\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Normal</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
         </button>
       </p>
       <p>
-        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--new\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">New</span></span>
-        </button>
-        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--new\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">New</span></span>
+        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--normal c-actionbtn--compact\\" title=\\"Disabled\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Disabled</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
         </button>
       </p>
       <p>
-        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--error\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Error</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
+        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--new c-actionbtn--compact\\" title=\\"New\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">New</span></span>
         </button>
-        <button disabled=\\"\\" type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--error\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Error</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
+      </p>
+      <p>
+        <button type=\\"button\\" role=\\"button\\" class=\\"c-actionbtn c-actionbtn--error c-actionbtn--compact\\" title=\\"Error\\"><span><span data-action=\\"label\\" class=\\"c-actionbtn-label\\">Error</span><span data-action=\\"icon\\" class=\\"c-actionbtn-icon\\"><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></span>
         </button>
       </p>
     </div>
@@ -816,12 +418,10 @@ exports[`Checkbox should render examples: Checkbox 1`] = `
 exports[`Checkbox should render examples: Checkbox 2`] = `
 "<div>
   <div>
-    <form>
-      <div>
-        <label class=\\"c-input-checkbox\\" aria-checked=\\"\\">
-          <input type=\\"checkbox\\" value=\\"\\" name=\\"\\"><span>This is a checkbox</span></label>
-      </div>
-    </form>
+    <div>
+      <label class=\\"c-input-checkbox is-error\\" aria-checked=\\"\\">
+        <input type=\\"checkbox\\" value=\\"\\" name=\\"\\"><span>This is a checkbox with an error</span></label>
+    </div>
   </div>
 </div>"
 `;
@@ -829,12 +429,10 @@ exports[`Checkbox should render examples: Checkbox 2`] = `
 exports[`Checkbox should render examples: Checkbox 3`] = `
 "<div>
   <div>
-    <form>
-      <div>
-        <label class=\\"c-input-checkbox\\" aria-checked=\\"\\">
-          <input type=\\"checkbox\\" value=\\"\\" name=\\"\\"><span>This is a checkbox</span></label>
-      </div>
-    </form>
+    <div>
+      <label class=\\"c-input-checkbox\\" aria-checked=\\"mixed\\">
+        <input type=\\"checkbox\\" value=\\"\\" name=\\"\\"><span>This is a mixed checkbox</span></label>
+    </div>
   </div>
 </div>"
 `;
@@ -857,8 +455,8 @@ exports[`Field should render examples: Field 2`] = `
   <div>
     <form>
       <div class=\\"o-field\\">
-        <label for=\\"\\" class=\\"c-label\\">I'm a label</label>
-        <textarea placeholder=\\"I'm a textarea\\" class=\\"c-textarea\\" id=\\"idField\\"></textarea>
+        <label for=\\"\\" class=\\"c-label\\">I'm an error label</label>
+        <input type=\\"text\\" id=\\"idFieldError\\" class=\\"c-input-text is-error\\" placeholder=\\"I'm an error input[type=text]\\" value=\\"\\">
       </div>
     </form>
   </div>
@@ -1141,235 +739,15 @@ exports[`Icon should render examples: Icon 1`] = `
 exports[`Icon should render examples: Icon 2`] = `
 "<div>
   <div>
-    <div style=\\"font-size: 2rem; display: grid;\\">
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">album</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">album-add</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">album-remove</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">back</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">bottom</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">calendar</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">check</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">check-circleless</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">clock</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">cozy</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">cross</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">delete</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">destroy</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">device-laptop</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">dots</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">download</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">file</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">file-none</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">folder</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">forward</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">gear</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">hourglass</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">image</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">moveto</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">openwith</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">paperplane</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">people</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">plus</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">rename</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">restore</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">share</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">small-arrow</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">spinner</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">top</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">trash</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">upload</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">warn</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">warning</p>
-      </div>
+    <div>
+      <svg class=\\"icon icon--spin\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #0bda51;\\">
+        <use xlink:href=\\"test-file-stub\\"></use>
+      </svg>
+      <!-- react-text: 4 -->&nbsp;
+      <!-- /react-text -->
+      <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #c30017;\\">
+        <use xlink:href=\\"test-file-stub\\"></use>
+      </svg>
     </div>
   </div>
 </div>"
@@ -1378,236 +756,10 @@ exports[`Icon should render examples: Icon 2`] = `
 exports[`Icon should render examples: Icon 3`] = `
 "<div>
   <div>
-    <div style=\\"font-size: 2rem; display: grid;\\">
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">album</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">album-add</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">album-remove</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">back</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">bottom</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">calendar</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">check</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">check-circleless</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">clock</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">cozy</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">cross</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">delete</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">destroy</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">device-laptop</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">dots</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">download</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">file</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">file-none</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">folder</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">forward</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">gear</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">hourglass</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">image</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">moveto</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">openwith</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">paperplane</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">people</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">plus</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">rename</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">restore</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">share</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">small-arrow</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">spinner</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #F52D2D;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">top</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #FF962F;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">trash</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #297EF2;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">upload</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #08b442;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">warn</p>
-      </div>
-      <div style=\\"text-align: center;\\">
-        <svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: #B449E7;\\">
-          <use xlink:href=\\"test-file-stub\\"></use>
-        </svg>
-        <p style=\\"font-size: 1rem;\\">warning</p>
-      </div>
-    </div>
+    <div>
+      <svg class=\\"icon\\" width=\\"32\\" height=\\"32\\" style=\\"fill: purple;\\">
+        <use xlink:href=\\"test-file-stub\\"></use>
+      </svg><span>← Click it</span></div>
   </div>
 </div>"
 `;
@@ -1630,8 +782,8 @@ exports[`Label should render examples: Label 2`] = `
   <div>
     <form>
       <div>
-        <label for=\\"idInput\\" class=\\"c-label\\">This is a label</label>
-        <input type=\\"text\\" id=\\"idInput\\" class=\\"c-input-text\\" placeholder=\\"Recherche\\">
+        <label for=\\"idInput2\\" class=\\"c-label is-error\\">This is an error label</label>
+        <input type=\\"text\\" id=\\"idInput2\\" class=\\"c-input-text is-error\\" placeholder=\\"Recherche\\">
       </div>
     </form>
   </div>
@@ -1652,7 +804,8 @@ exports[`ListItemText should render examples: ListItemText 2`] = `
 "<div>
   <div>
     <div class=\\"c-list-text\\">
-      <div class=\\"g-text u-ellipsis\\">I'm a list item text</div>
+      <div class=\\"g-text u-ellipsis\\">I'm a primary text</div>
+      <div class=\\"g-caption u-ellipsis\\">I'm a secondary text</div>
     </div>
   </div>
 </div>"
@@ -1660,11 +813,8 @@ exports[`ListItemText should render examples: ListItemText 2`] = `
 
 exports[`ListItemText should render examples: ListItemText 3`] = `
 "<div>
-  <div>
-    <div class=\\"c-list-text\\">
-      <div class=\\"g-text u-ellipsis\\">I'm a list item text</div>
-    </div>
-  </div>
+  <div></div>
+  <div>ReferenceError: content is not defined</div>
 </div>"
 `;
 
@@ -1681,7 +831,7 @@ exports[`Menu should render examples: Menu 1`] = `
 exports[`Menu should render examples: Menu 2`] = `
 "<div>
   <div>
-    <div class=\\"c-menu c-menu--left\\">
+    <div class=\\"c-menu c-menu--right\\">
       <button role=\\"button\\" class=\\"c-btn c-menu__btn\\">Click me !</button>
     </div>
   </div>
@@ -1692,7 +842,7 @@ exports[`Menu should render examples: Menu 3`] = `
 "<div>
   <div>
     <div class=\\"c-menu c-menu--left\\">
-      <button role=\\"button\\" class=\\"c-btn c-menu__btn\\">Click me !</button>
+      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><!-- react-text: 4 -->Greetings with custom component<!-- /react-text --></span></button>
     </div>
   </div>
 </div>"
@@ -1716,14 +866,10 @@ exports[`Radio should render examples: Radio 1`] = `
 exports[`Radio should render examples: Radio 2`] = `
 "<div>
   <div>
-    <form>
-      <div>
-        <label class=\\"c-input-radio\\">
-          <input type=\\"radio\\" value=\\"radioValue1\\" name=\\"radioForm\\"><span>This is a radio button</span></label>
-        <label class=\\"c-input-radio\\">
-          <input type=\\"radio\\" value=\\"radioValue2\\" name=\\"radioForm\\"><span>This is also a radio button</span></label>
-      </div>
-    </form>
+    <div>
+      <label class=\\"c-input-radio is-error\\">
+        <input type=\\"radio\\" value=\\"radioValue1\\" name=\\"radioForm\\"><span>This is a radio button</span></label>
+    </div>
   </div>
 </div>"
 `;
@@ -1760,22 +906,25 @@ exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
   <div>
     <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
-                style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
-              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+      <div>
+        <button>toggle options</button>
+        <div class=\\"select-control__input\\">
+          <div class=\\"react-select__value-container css-12sevwg\\">
+            <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
+            <div class=\\"css-16n6ap7\\">
+              <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
+                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+                  style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
+                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+              </div>
             </div>
           </div>
-        </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
-              <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
-            </svg>
+          <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
+            <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
+              <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+                <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -1789,7 +938,7 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
   <div>
     <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
       <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container css-12sevwg\\">
+        <div class=\\"react-select__value-container react-select__value-container--isMulti css-12sevwg\\">
           <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
           <div class=\\"css-16n6ap7\\">
             <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
@@ -1845,7 +994,23 @@ exports[`Spinner should render examples: Spinner 1`] = `
 exports[`Spinner should render examples: Spinner 2`] = `
 "<div>
   <div>
-    <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+    <div>
+      <!-- react-text: 2 -->blue (default):
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+      <!-- react-text: 4 -->or
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+      <!-- react-text: 6 -->grey:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--grey c-spinner--medium\\"></div>
+      <!-- react-text: 8 -->white:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--white c-spinner--medium\\"></div>
+      <!-- react-text: 10 -->red:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--red c-spinner--medium\\"></div>
+    </div>
   </div>
 </div>"
 `;
@@ -1853,7 +1018,9 @@ exports[`Spinner should render examples: Spinner 2`] = `
 exports[`Spinner should render examples: Spinner 3`] = `
 "<div>
   <div>
-    <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+    <div>
+      <div class=\\"c-spinner c-spinner--nomargin c-spinner--blue c-spinner--medium\\"></div>
+    </div>
   </div>
 </div>"
 `;
@@ -1861,7 +1028,34 @@ exports[`Spinner should render examples: Spinner 3`] = `
 exports[`Spinner should render examples: Spinner 4`] = `
 "<div>
   <div>
-    <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+    <div>
+      <!-- react-text: 2 -->tiny:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--tiny\\"></div>
+      <br>
+      <!-- react-text: 5 -->small:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--small\\"></div>
+      <br>
+      <!-- react-text: 8 -->medium (default):
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+      <!-- react-text: 10 -->or
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--medium\\"></div>
+      <br>
+      <!-- react-text: 13 -->large:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--large\\"></div>
+      <br>
+      <!-- react-text: 16 -->xlarge:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--xlarge\\"></div>
+      <br>
+      <!-- react-text: 19 -->xxlarge:
+      <!-- /react-text -->
+      <div class=\\"c-spinner c-spinner--blue c-spinner--xxlarge\\"></div>
+    </div>
   </div>
 </div>"
 `;
@@ -1877,7 +1071,7 @@ exports[`Text should render examples: Text 1`] = `
 exports[`Text should render examples: Text 2`] = `
 "<div>
   <div>
-    <div class=\\"g-text\\">This a standard text</div>
+    <div class=\\"g-caption\\">This a note text</div>
   </div>
 </div>"
 `;
@@ -1893,7 +1087,7 @@ exports[`Textarea should render examples: Textarea 1`] = `
 exports[`Textarea should render examples: Textarea 2`] = `
 "<div>
   <div>
-    <textarea placeholder=\\"Once upon a time…\\" class=\\"c-textarea\\"></textarea>
+    <textarea placeholder=\\"Once upon a time, there was an error…\\" class=\\"c-textarea is-error\\"></textarea>
   </div>
 </div>"
 `;
@@ -1901,7 +1095,14 @@ exports[`Textarea should render examples: Textarea 2`] = `
 exports[`Textarea should render examples: Textarea 3`] = `
 "<div>
   <div>
-    <textarea placeholder=\\"Once upon a time…\\" class=\\"c-textarea\\"></textarea>
+    <div>
+      <p>
+        <textarea placeholder=\\"I'm have a tiny size\\" class=\\"c-textarea c-textarea--tiny\\"></textarea>
+      </p>
+      <p>
+        <textarea placeholder=\\"I'm have a medium size\\" class=\\"c-textarea c-textarea--medium\\"></textarea>
+      </p>
+    </div>
   </div>
 </div>"
 `;
@@ -1909,7 +1110,11 @@ exports[`Textarea should render examples: Textarea 3`] = `
 exports[`Textarea should render examples: Textarea 4`] = `
 "<div>
   <div>
-    <textarea placeholder=\\"Once upon a time…\\" class=\\"c-textarea\\"></textarea>
+    <div>
+      <p>
+        <textarea placeholder=\\"I'm full width\\" class=\\"c-textarea c-textarea--fullwidth\\"></textarea>
+      </p>
+    </div>
   </div>
 </div>"
 `;
@@ -1917,7 +1122,9 @@ exports[`Textarea should render examples: Textarea 4`] = `
 exports[`Textarea should render examples: Textarea 5`] = `
 "<div>
   <div>
-    <textarea placeholder=\\"Once upon a time…\\" class=\\"c-textarea\\"></textarea>
+    <div>
+      <textarea placeholder=\\"\\" class=\\"c-textarea\\" name=\\"my-field\\"></textarea>
+    </div>
   </div>
 </div>"
 `;
@@ -1930,24 +1137,27 @@ exports[`Toggle should render examples: Toggle 1`] = `
 
 exports[`Toggle should render examples: Toggle 2`] = `
 "<div>
-  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"simple-toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"simple-toggle\\" class=\\"label\\"></label></span></div>
+  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"toggle\\" class=\\"label\\"></label></span></div>
 </div>"
 `;
 
 exports[`Toggle should render examples: Toggle 3`] = `
 "<div>
-  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"simple-toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"simple-toggle\\" class=\\"label\\"></label></span></div>
+  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"toggle\\" class=\\"label\\"></label></span></div>
 </div>"
 `;
 
 exports[`Toggle should render examples: Toggle 4`] = `
 "<div>
-  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"simple-toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"simple-toggle\\" class=\\"label\\"></label></span></div>
+  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"toggle\\" class=\\"label\\"></label></span></div>
 </div>"
 `;
 
 exports[`Toggle should render examples: Toggle 5`] = `
 "<div>
-  <div><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"simple-toggle\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"simple-toggle\\" class=\\"label\\"></label></span></div>
+  <div>
+    <div>
+      <label for=\\"0\\" style=\\"margin-right: 15px; color: gray;\\">Toggle is controlled and off</label><span class=\\"toggle\\"><input type=\\"checkbox\\" id=\\"0\\" class=\\"checkbox\\" value=\\"on\\"><label for=\\"0\\" class=\\"label\\"></label></span></div>
+  </div>
 </div>"
 `;

--- a/react/testFromStyleguidist.js
+++ b/react/testFromStyleguidist.js
@@ -160,9 +160,9 @@ const testFromStyleguidist = (name, markdown, require) => {
         })
         done()
       }
-      codes.forEach(() => {
+      codes.forEach(code => {
         const root = mount(
-          <Preview code={codes[0].content} evalInContext={evalInContext} />,
+          <Preview code={code.content} evalInContext={evalInContext} />,
           options
         )
         requestAnimationFrame(() => {


### PR DESCRIPTION
The test will pass when #486 will be merged.

Examples code chunks wer always rendered with the first code chunk https://github.com/cozy/cozy-ui/pull/485/files#diff-57b7a5e12d97c30c13de5396a4d16c89R163, so for example all Button examples were rendering the same.