### PR TITLE
Fix <ButtonLink /> className prop format

### DIFF
--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -71,14 +71,21 @@ export const ButtonLink = props => {
     children,
     label,
     icon,
-    onClick
+    onClick,
+    subtle
   } = props
   return (
     <a
       aria-disabled={disabled}
       href={href}
       target={target}
-      className={btnClass(theme, size, extension, className)}
+      className={btnClass({
+        className,
+        extension,
+        size,
+        theme,
+        variant: subtle && 'subtle'
+      })}
       onClick={disabled ? event => event.preventDefault() : onClick}
     >
       <span>


### PR DESCRIPTION
The call to `btnClass()` was still made with several arguments instead of an object. The tests did not spot this because of a bug in it, see #485.