### PR TITLE
feat(Chip): add className prop on Chip.Separator

### DIFF
--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -40,4 +40,6 @@ export class ChipButton extends React.PureComponent {
 
 Chip.Button = ChipButton
 Chip.Round = RoundChip
-Chip.Separator = () => <span className={styles.ChipSeparator} />
+Chip.Separator = ({ className }) => (
+  <span className={cx(styles.ChipSeparator, className)} />
+)


### PR DESCRIPTION
We may want to style the separator slightly differently from the original. In that case, the `className` prop is needed.
