### PR TITLE
feat: Button can render with a different Tag [breaking]

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prebuild:css": "mkdir dist/",
     "prebuild:css:app": "mkdir -p build/styleguide",
     "prebuild:doc:kss": "run-s clean:doc:kss build:css:app",
+    "prepush": "yarn lint",
     "test": "npm-run-all --serial lint test:jest",
     "test:jest": "jest --verbose --coverage",
     "watch:doc:react": "styleguidist server --config docs/styleguide.config.js"

--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -144,28 +144,33 @@ const { Button } = require('./index');
     <Button subtle theme='danger' label='DANGER theme' onClick={() => alert('Clicked on DANGER theme')} />
   </p>
   <p>
-    <Button subtle disabled='true' label='Disabled'  onClick={() => alert('Clicked on Disabled')} />
+    <Button subtle disabled label='Disabled'  onClick={() => alert('Clicked on Disabled')} />
   </p>
   <p>
-    <Button subtle busy='true' label='Busy'  onClick={() => alert('Clicked on Busy')} />
-    <Button subtle busy='true' theme='secondary' label='Busy secondary'  onClick={() => alert('Clicked on Busy secondary')} />
-    <Button subtle busy='true' theme='highlight' label='Busy highlight'  onClick={() => alert('Clicked on Busy highlight')} />
-    <Button subtle busy='true' theme='danger' label='Busy danger'  onClick={() => alert('Clicked on Busy danger')} />
+    <Button subtle busy label='Busy'  onClick={() => alert('Clicked on Busy')} />
+    <Button subtle busy theme='secondary' label='Busy secondary'  onClick={() => alert('Clicked on Busy secondary')} />
+    <Button subtle busy theme='highlight' label='Busy highlight'  onClick={() => alert('Clicked on Busy highlight')} />
+    <Button subtle busy theme='danger' label='Busy danger'  onClick={() => alert('Clicked on Busy danger')} />
   </p>
 </div>
 ```
 
-### AsButton
+### Changing the tag
 
-The `<AsButton />` component allow to pass button properties and behavior to a child component. This component is useful when we aim to use another component as button. A common case is for example when using `react-router`'s `<NavLink />` component. `<AsButton />` works as a <acronym title="High Order Component">HOC</acronym>. Only the child is rendered.
+Sometimes you want to change the tag or component used to render the Button. For example, when using `NavLinks` to get the `onClick` behavior.
+
+You can pass `tag={NavLink}` and `NavLink` will be used. Any props that you
+pass to the `Button` will be passed down to the component.
 
 ```
-const { AsButton } = require('./index');
+const Button = require('./').default
+const NavLink = props => (
+  <span onClick={() => alert(`Navigating to ${props.to}`)} {...props}>{
+    props.children
+  }</span>
+);
+
 <div>
-  <AsButton isLink>
-    <a href='#'>
-      <span>Child component</span>
-    </a>
-  </AsButton>
+  <Button tag={NavLink} to='/destination'>I'm a (false) NavLink</Button>
 </div>
 ```

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -6,111 +6,86 @@ import Icon from '../Icon'
 
 const btnClass = function(options) {
   const { className, extension, size, theme, variant } = options
-  return cx(
-    styles['c-btn'],
-    {
-      [styles[`c-btn--${theme}`]]: theme,
-      [styles[`c-btn--${size}`]]: size,
-      [styles[`c-btn--${variant}`]]: variant,
-      [styles[`c-btn--${extension}`]]: extension
-    },
-    className
-  )
+  return cx(className, styles['c-btn'], {
+    [styles[`c-btn--${theme}`]]: theme,
+    [styles[`c-btn--${size}`]]: size,
+    [styles[`c-btn--${variant}`]]: variant,
+    [styles[`c-btn--${extension}`]]: extension
+  })
 }
 
-const actualProps = (propTypes, props) => {
-  return Object.keys(props).reduce((filteredProps, key) => {
-    return propTypes[key]
-      ? { ...filteredProps, [key]: props[key] }
-      : filteredProps
-  }, {})
+const transformToAria = tag => props => {
+  const { busy, disabled, ...newProps } = props
+
+  if (busy) {
+    newProps['aria-busy'] = true
+  }
+  if (disabled) {
+    newProps['aria-disabled'] = true
+  }
+  if (tag === 'button' && disabled) {
+    newProps['disabled'] = true
+  }
+
+  return newProps
 }
 
-export const Button = props => {
-  const { busy, children, disabled, label, icon, onClick, subtle, type } = props
-  return (
-    <button
-      aria-busy={busy}
-      disabled={disabled}
-      type={type}
-      role="button"
-      className={btnClass({
-        ...props,
-        variant: subtle && 'subtle'
-      })}
-      onClick={onClick}
-    >
-      <span>
-        {Icon.isProperIcon(icon) ? <Icon icon={icon} /> : icon}
-        {label && <span>{label}</span>}
-        {children}
-      </span>
-    </button>
-  )
+const tagToTransformProps = {
+  button: transformToAria('button'),
+  a: transformToAria('a')
 }
 
-export default Button
+const identity = x => x
 
-export const AsButton = props => {
-  const { children } = props
-  const Wrapped = React.Children.only(children)
-  const buttonProps = props.isLink
-    ? {
-        ...ButtonLink.defaultProps,
-        ...actualProps(ButtonLink.propTypes, props)
-      }
-    : { ...Button.defaultProps, ...actualProps(Button.propTypes, props) }
-  return React.cloneElement(
-    Wrapped,
-    {
-      ...buttonProps,
-      ...Wrapped.props,
-      className: btnClass({
-        ...buttonProps,
-        variant: buttonProps.subtle && 'subtle'
-      })
-    },
-    Wrapped.children
-  )
-}
-
-export const ButtonLink = props => {
+const BaseButton = props => {
   const {
-    disabled,
-    theme,
-    size,
-    extension,
-    href,
-    target,
-    className,
     children,
-    label,
     icon,
-    onClick,
-    subtle
+    label,
+    subtle,
+    className,
+    extension,
+    size,
+    theme,
+    tag: Tag,
+    ...restProps
   } = props
+
+  const transformProps = tagToTransformProps[Tag] || identity
   return (
-    <a
-      aria-disabled={disabled}
-      href={href}
-      target={target}
+    <Tag
+      {...transformProps(restProps)}
       className={btnClass({
-        className,
         extension,
         size,
         theme,
+        className,
         variant: subtle && 'subtle'
       })}
-      onClick={disabled ? event => event.preventDefault() : onClick}
     >
       <span>
         {Icon.isProperIcon(icon) ? <Icon icon={icon} /> : icon}
         {label && <span>{label}</span>}
         {children}
       </span>
-    </a>
+    </Tag>
   )
 }
+
+const Button = props => <BaseButton {...props} />
+const ButtonLink = props => <BaseButton {...props} />
+
+export { Button, ButtonLink }
+
+const DefaultButton = props => {
+  if (!props.tag) {
+    return <Button {...props} />
+  } else {
+    return <BaseButton {...props} />
+  }
+}
+
+export default DefaultButton
 
 // Proptypes (unfortunately, Styleguidist does not pick
 // proptypes coming from a spread so we have to keep both
@@ -142,57 +117,15 @@ Button.propTypes = {
   subtle: PropTypes.bool
 }
 
-ButtonLink.propTypes = {
-  /** DEPRECATED: please use label and icon */
-  children: PropTypes.node,
-  /** Disables the button */
-  disabled: PropTypes.bool,
-  /** Label of the button */
-  label: PropTypes.node,
-  /** Icon identifier or `<Icon />` */
-  icon: PropTypes.node,
-  theme: PropTypes.string,
-  size: PropTypes.oneOf(['tiny', 'small', 'large']),
-  /** Spacing of the button */
-  extension: PropTypes.oneOf(['narrow', 'full']),
-  /** Extra class */
-  className: PropTypes.string,
-  /** What to do on click */
-  onClick: PropTypes.func,
-
-  // Only for ButtonLink
-  /** Where to go. Will be passed directly to the underlying `a` */
-  href: PropTypes.string.isRequired,
-  /** Target of the link. Will be passed directly to the underlying `a` */
-  target: PropTypes.string
-}
-
-// DefaultProps
-const commonDefaultProps = {
-  label: null,
-  icon: null,
-  theme: '',
-  className: '',
-  onClick: null
+BaseButton.defaultProps = {
+  role: 'button'
 }
 
 Button.defaultProps = {
-  ...commonDefaultProps,
-  busy: false,
-  disabled: false,
   type: 'submit',
-  subtle: false
+  tag: 'button'
 }
 
 ButtonLink.defaultProps = {
-  ...commonDefaultProps,
-  disabled: false,
-  target: '',
-  href: ''
+  tag: 'a'
 }
-
-AsButton.propTypes = {
-  ...ButtonLink.propTypes,
-  isLink: PropTypes.bool
-}
-AsButton.defaultProps = Button.defaultProps

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -112,51 +112,51 @@ exports[`Button should render examples: Button 1`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--regular\\"><span><span>regular</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
-        </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--danger\\"><span><span>danger</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--highlight\\"><span><span>highlight</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
         </button>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--secondary\\"><span><span>secondary</span></span>
+        </button>
+      </p>
+      <p>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>danger-outline</span></span>
+        </button>
+      </p>
+      <p>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--alpha\\"><span><span>alpha</span></span>
         </button>
       </p>
     </div>
@@ -169,19 +169,19 @@ exports[`Button should render examples: Button 2`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--tiny\\"><span><span>Tiny</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--tiny\\"><span><span>Tiny</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--small\\"><span><span>Small</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--small\\"><span><span>Small</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Normal</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Normal</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--large\\"><span><span>Large</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--large\\"><span><span>Large</span></span>
         </button>
       </p>
     </div>
@@ -194,15 +194,15 @@ exports[`Button should render examples: Button 3`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Normal</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Normal</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--narrow\\"><span><span>N…</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--narrow\\"><span><span>N…</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--full\\"><span><span>Full width</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--full\\"><span><span>Full width</span></span>
         </button>
       </p>
     </div>
@@ -213,7 +213,7 @@ exports[`Button should render examples: Button 3`] = `
 exports[`Button should render examples: Button 4`] = `
 "<div>
   <div>
-    <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>Show alert</span></span>
+    <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger-outline\\"><span><span>Show alert</span></span>
     </button>
   </div>
 </div>"
@@ -222,7 +222,7 @@ exports[`Button should render examples: Button 4`] = `
 exports[`Button should render examples: Button 5`] = `
 "<div>
   <div>
-    <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Loading</span></span>
+    <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn\\"><span><span>Loading</span></span>
     </button>
   </div>
 </div>"
@@ -239,9 +239,9 @@ exports[`Button should render examples: Button 7`] = `
 "<div>
   <div>
     <div>
-      <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Loading</span></span>
+      <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn\\"><span><span>Loading</span></span>
       </button>
-      <a aria-disabled=\\"true\\" href=\\"http://cozy.io\\" target=\\"\\" class=\\"c-btn\\"><span><span>Go to Cozy website</span></span>
+      <a href=\\"http://cozy.io\\" role=\\"button\\" aria-disabled=\\"true\\" class=\\"c-btn\\"><span><span>Go to Cozy website</span></span>
       </a>
     </div>
   </div>
@@ -252,9 +252,9 @@ exports[`Button should render examples: Button 8`] = `
 "<div>
   <div>
     <div>
-      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
+      <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
       </button>
-      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--narrow\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></button>
+      <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--narrow\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></button>
     </div>
   </div>
 </div>"
@@ -264,7 +264,7 @@ exports[`Button should render examples: Button 9`] = `
 "<div>
   <div>
     <div>
-      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: yellow;\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
+      <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" style=\\"fill: yellow;\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
       </button>
     </div>
   </div>
@@ -276,19 +276,19 @@ exports[`Button should render examples: Button 10`] = `
   <div>
     <div>
       <p>
-        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--tiny\\"><span><span>Link to Cozy.io</span></span>
+        <a href=\\"https://cozy.io\\" target=\\"_blank\\" role=\\"button\\" class=\\"c-btn c-btn--tiny\\"><span><span>Link to Cozy.io</span></span>
         </a>
       </p>
       <p>
-        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--small\\"><span><span>Link to Cozy.io</span></span>
+        <a href=\\"https://cozy.io\\" target=\\"_blank\\" role=\\"button\\" class=\\"c-btn c-btn--small\\"><span><span>Link to Cozy.io</span></span>
         </a>
       </p>
       <p>
-        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn\\"><span><span>Link to Cozy.io</span></span>
+        <a href=\\"https://cozy.io\\" target=\\"_blank\\" role=\\"button\\" class=\\"c-btn\\"><span><span>Link to Cozy.io</span></span>
         </a>
       </p>
       <p>
-        <a aria-disabled=\\"false\\" href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--large\\"><span><span>Link to Cozy.io</span></span>
+        <a href=\\"https://cozy.io\\" target=\\"_blank\\" role=\\"button\\" class=\\"c-btn c-btn--large\\"><span><span>Link to Cozy.io</span></span>
         </a>
       </p>
     </div>
@@ -301,35 +301,35 @@ exports[`Button should render examples: Button 11`] = `
   <div>
     <div>
       <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--tiny c-btn--subtle\\"><span><span>Tiny text</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--tiny c-btn--subtle\\"><span><span>Tiny text</span></span>
         </button>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--small c-btn--subtle\\"><span><span>Small text</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--small c-btn--subtle\\"><span><span>Small text</span></span>
         </button>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Regular text</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Regular text</span></span>
         </button>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--large c-btn--subtle\\"><span><span>Large text</span></span>
-        </button>
-      </p>
-      <p>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--subtle\\"><span><span>Secondary theme</span></span>
-        </button>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight c-btn--subtle\\"><span><span>Highlight theme</span></span>
-        </button>
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger c-btn--subtle\\"><span><span>DANGER theme</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--large c-btn--subtle\\"><span><span>Large text</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"false\\" disabled=\\"\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Disabled</span></span>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--subtle\\"><span><span>Secondary theme</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight c-btn--subtle\\"><span><span>Highlight theme</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger c-btn--subtle\\"><span><span>DANGER theme</span></span>
         </button>
       </p>
       <p>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--subtle\\"><span><span>Busy</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-disabled=\\"true\\" disabled=\\"\\" class=\\"c-btn c-btn--subtle\\"><span><span>Disabled</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--secondary c-btn--subtle\\"><span><span>Busy secondary</span></span>
+      </p>
+      <p>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--subtle\\"><span><span>Busy</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--highlight c-btn--subtle\\"><span><span>Busy highlight</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--secondary c-btn--subtle\\"><span><span>Busy secondary</span></span>
         </button>
-        <button aria-busy=\\"true\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn c-btn--danger c-btn--subtle\\"><span><span>Busy danger</span></span>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--highlight c-btn--subtle\\"><span><span>Busy highlight</span></span>
+        </button>
+        <button type=\\"submit\\" role=\\"button\\" aria-busy=\\"true\\" class=\\"c-btn c-btn--danger c-btn--subtle\\"><span><span>Busy danger</span></span>
         </button>
       </p>
     </div>
@@ -340,8 +340,7 @@ exports[`Button should render examples: Button 11`] = `
 exports[`Button should render examples: Button 12`] = `
 "<div>
   <div>
-    <div>
-      <a href=\\"#\\" class=\\"c-btn\\" target=\\"\\"></a>
+    <div><span to=\\"/destination\\" role=\\"button\\" class=\\"c-btn\\"><span><!-- react-text: 4 -->I'm a (false) NavLink<!-- /react-text --></span></span>
     </div>
   </div>
 </div>"
@@ -502,7 +501,7 @@ exports[`Hero should render examples: Hero 1`] = `
         </div>
       </div>
       <p class=\\" Hero-cta\\">
-        <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><!-- react-text: 22 -->Connect your bank accounts<!-- /react-text --></span></button>
+        <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><!-- react-text: 22 -->Connect your bank accounts<!-- /react-text --></span></button>
       </p>
     </div>
   </div>
@@ -852,7 +851,7 @@ exports[`Menu should render examples: Menu 3`] = `
 "<div>
   <div>
     <div class=\\"c-menu c-menu--left\\">
-      <button aria-busy=\\"false\\" type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><!-- react-text: 4 -->Greetings with custom component<!-- /react-text --></span></button>
+      <button type=\\"submit\\" role=\\"button\\" class=\\"c-btn\\"><span><!-- react-text: 4 -->Greetings with custom component<!-- /react-text --></span></button>
     </div>
   </div>
 </div>"

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,6 +430,12 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async-stream-flow@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/async-stream-flow/-/async-stream-flow-1.0.2.tgz#42db63525c5d116267ea68b0369d9b35caa384db"
+  dependencies:
+    through3 "~1.1.5"
+
 async@1.5.2, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -3391,6 +3397,13 @@ fs-extra@^2.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
+fs-flow@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fs-flow/-/fs-flow-1.0.2.tgz#6b7133d1435a4a94f3dca624d086df2936a533e7"
+  dependencies:
+    async-stream-flow "~1.0.1"
+    through3 "~1.1.5"
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -3961,6 +3974,53 @@ humanize-ms@^1.2.1:
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
   dependencies:
     ms "^2.0.0"
+
+husk-async@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/husk-async/-/husk-async-1.0.3.tgz#b5a5cae27b3e2641126de07b246ae2a6477fa382"
+  dependencies:
+    async-stream-flow "~1.0.1"
+
+husk-core@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/husk-core/-/husk-core-1.0.4.tgz#870b2619c0283d6a1262b98a9a4b76612292e47d"
+  dependencies:
+    husk-print "~1.0.2"
+    husk-through "~1.0.2"
+
+husk-exec@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/husk-exec/-/husk-exec-1.0.4.tgz#f81eaffd1580b91da3a13c07ce568fc8a72ce9b4"
+  dependencies:
+    process-flow "~1.0.2"
+
+husk-fs@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/husk-fs/-/husk-fs-1.0.3.tgz#3c32a96e561753d631b1a8ee5c4a236d1d89e138"
+  dependencies:
+    fs-flow "~1.0.1"
+
+husk-print@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/husk-print/-/husk-print-1.0.3.tgz#3dd134b46bc701ccbe8113c8d6cbeb8305656697"
+  dependencies:
+    print-flow "~1.0.2"
+
+husk-through@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/husk-through/-/husk-through-1.0.2.tgz#f7d668be267e1deeb8e285a8687bef391695cabc"
+  dependencies:
+    through-flow "~1.0.1"
+
+husk@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/husk/-/husk-0.5.3.tgz#8693aa0b164ccb6314dc7cd3478de4f796691458"
+  dependencies:
+    husk-async "~1.0.2"
+    husk-core "~1.0.4"
+    husk-exec "~1.0.4"
+    husk-fs "~1.0.2"
+    zephyr "~1.2.6"
 
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
@@ -6693,9 +6753,21 @@ pretty@^2.0.0:
     extend-shallow "^2.0.1"
     js-beautify "^1.6.12"
 
+print-flow@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/print-flow/-/print-flow-1.0.2.tgz#28753a4e6aea5122397bb5bc85b67f50548b9c67"
+  dependencies:
+    through3 "~1.1.5"
+
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
+
+process-flow@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/process-flow/-/process-flow-1.0.2.tgz#ed024b2cdf7004193d46103650ca9393067e7ec0"
+  dependencies:
+    through3 "~1.1.5"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -8301,12 +8373,22 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+through-flow@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/through-flow/-/through-flow-1.0.2.tgz#3e47b310257762e3e9e0f97137432fbe7893bc0c"
+  dependencies:
+    through3 "~1.1.5"
+
 through2@^2.0.0, through2@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
+
+through3@~1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/through3/-/through3-1.1.6.tgz#504aa5175efd54d9c6957784c890664b8685cf77"
 
 through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
@@ -9139,3 +9221,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zephyr@~1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/zephyr/-/zephyr-1.2.8.tgz#af734a97dbbd368e2b73597c7e6054dbcbd69a6c"


### PR DESCRIPTION
It is useful for a Button to render with a different tag.

Another solution for #484 that does not extend the API of Cozy UI.

For example if you want a Button to render with a NavLink : 

```
<Button tag={NavLink} to='/toto' />
```

It is a breaking change since `<AsButton />` is removed.