### PR TITLE
fix: add padding for cross in modals

### DIFF
--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -146,6 +146,11 @@ For more complex modals, you can use individual components.
 
 ```
 const { ModalDescription, ModalHeader, ModalFooter } = Modal;
+const headerStyle = {
+  background: 'linear-gradient(to right, #005c97, #363795)',
+  color: 'white',
+  paddingBottom: '1.5rem'
+};
 
 <div>
   <button onClick={()=>setState({ modalDisplayed: !state.modalDisplayed })}>
@@ -153,11 +158,10 @@ const { ModalDescription, ModalHeader, ModalFooter } = Modal;
   </button>
   {state.modalDisplayed &&
     <Modal
+        crossColor='white'
         overflowHidden={true}
         dismissAction={()=>setState({ modalDisplayed: false})} >
-      <div style={{background: 'black', color: 'white'}}>
-        <ModalHeader title="Yo ho ho !" />
-      </div>
+      <ModalHeader style={headerStyle} title="Augusta Ada King-Noel, Countess of Lovelace" />
       <ModalDescription className='u-mt-half'>
         { content.ada.short }
       </ModalDescription>

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -36,10 +36,10 @@ const ModalBrandedHeader = ({ logo, bg, className, style = {} }) => (
   </h2>
 )
 
-const ModalHeader = ({ title, children, className }) => {
+const ModalHeader = ({ title, children, className, style }) => {
   const isTitle = typeof children === 'string'
   return (
-    <div className={cx(styles['c-modal-header'], className)}>
+    <div className={cx(styles['c-modal-header'], className)} style={style}>
       {title && <h2>{title}</h2>}
       {isTitle ? <h2>{children}</h2> : children}
     </div>

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -161,7 +161,8 @@ class Modal extends Component {
                 {
                   [styles['c-modal--overflowHidden']]: overflowHidden,
                   [styles[`c-modal--${spacing}-spacing`]]: spacing,
-                  [styles['c-modal--fullscreen']]: mobileFullscreen
+                  [styles['c-modal--fullscreen']]: mobileFullscreen,
+                  [styles['c-modal--closable']]: closable
                 }
               )}
             >

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -38,6 +38,9 @@
 .c-modal-header
     @extend $modal-header
 
+    .c-modal--closable &
+        @extend $modal-header--closable
+
 .c-modal-header--branded
     @extend $modal-header--branded
 

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -186,6 +186,8 @@ $modal-footer--button
 $modal-section
     border-top 1px solid silver
 
+cross-size=2.5rem
+
 $modal-close
     position absolute
     top 1.5rem
@@ -196,8 +198,8 @@ $modal-close
     background-color transparent
     cursor pointer
     display block
-    width 2.5rem
-    height 2.5rem
+    width cross-size
+    height cross-size
 
     +tiny-screen()
         top .8rem
@@ -210,6 +212,9 @@ $modal-close--small
     +tiny-screen()
         top .3rem
         right .5rem
+
+$modal-header--closable
+    padding-right cross-size + 2rem
 
 
 $modal-close--large


### PR DESCRIPTION
fix https://github.com/cozy/cozy-ui/issues/491

The cross is positioned absolutely so it has no effect on the layout of the header. For the header not to overflow on the cross, I added right padding on the header when the modal is showing the cross (= when it is closable). 

View on https://ptbrowne.github.io/cozy-ui/react/, the complex modal has a long title.

![image](https://user-images.githubusercontent.com/465582/39966781-b7cf9aaa-56b1-11e8-8ee9-3c5e83d0d36d.png)
