### PR TITLE
Add 'button' value for 'type' in Button

### DIFF
--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -137,7 +137,7 @@ Button.propTypes = {
   /** Disables the button */
   disabled: PropTypes.bool,
   /** Type of the underlying `<button />` */
-  type: PropTypes.oneOf(['reset', 'submit']),
+  type: PropTypes.oneOf(['button', 'reset', 'submit']),
   /** Use the `subtle` alternative look for the Button  */
   subtle: PropTypes.bool
 }


### PR DESCRIPTION
Edit: Let's just add the `button` value for prop `type` in `<Button />`.

~~Default type should be `button`, to avoid having several button with type `submit` in the same form, for example. The type `submit` is supposed to send form data.~~

From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button:
> The type of the button. Possible values are:
> * `submit`: The button submits the form data to the server. This is the default if the attribute is not specified, or if the attribute is dynamically changed to an empty or invalid value.
> * `reset`: The button resets all the controls to their initial values.
> * `button`: The button has no default behavior. It can have client-side scripts associated with the element's events, which are triggered when the events occur.