### PR TITLE
fix: close button in selection bar

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -46,7 +46,9 @@ const SelectionBar = ({ t, actions, selected, hideSelectionBar }) => {
           onClick={() => actions[actionName].action(selected)}
         >
           <Icon icon={actionName.toLowerCase()} />
-          <span>{t('SelectionBar.' + actionName)}</span>
+          <span className={styles['coz-selectionbar-label']}>
+            {t('SelectionBar.' + actionName)}
+          </span>
         </button>
       ))}
       <Button

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -82,6 +82,6 @@ $selectionbar
             .coz-selectionbar-separator
                 margin   0 0 0 1rem
 
-            button
-                span
-                    @extend $visuallyhidden-mobile
+
+            .coz-selectionbar-separator
+                @extend $visuallyhidden-mobile


### PR DESCRIPTION
On mobile, the button to close the selection bar was hidden.

This is because there was a rule hiding `span` inside `button`, which was meant to target the text labels in the selection bar, but accidentally also targeted the `span` inside our `Button` component.

I hope I'm somewhat clear? Anyway, it's fixed.