### PR TITLE
Remove IntentModal width CSS property

### DIFF
--- a/react/IntentModal/styles.styl
+++ b/react/IntentModal/styles.styl
@@ -1,11 +1,6 @@
 @require 'settings/breakpoints'
 
-// TODO remove the second selector when specificity
-// of cozy-ui selectors has decreased
-.intentModal.intentModal
-    // takes 80% of the screen on desktop
-    max-width unset
-    width 80vw
+.intentModal
     height 80vh
 
     // takes 100% of the screen on mobile
@@ -22,8 +17,6 @@
         // we can remove this code
         max-width unset !important
 
-// TODO remove the second selector when specificity
-// of cozy-ui selectors has decreased
-.intentModal__cross.intentModal__cross
+.intentModal__cross
     top .25rem
     right .5rem


### PR DESCRIPTION
Edit : Potentially breaking for [cozy-store](http://github.com/cozy/cozy-store/) and [cozy-interapp-sandbox](http://github.com/cozy/cozy-interapp-sandbox/)

These are the only two applications using `<IntentModal />`, which is relatively new, at this time.

A CSS `width` property is overriding default modal sizes.