### PR TITLE
🐝 fix: use oneOfType

### DIFF
--- a/react/Badge/index.jsx
+++ b/react/Badge/index.jsx
@@ -20,7 +20,7 @@ export const Badge = ({ children, content, type, ...props }) => {
 
 Badge.propTypes = {
   /** The content of the badge */
-  content: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The type of the badge */
   type: PropTypes.oneOf(['normal', 'new', 'error'])
 }


### PR DESCRIPTION
oneOf is used to check the prop against values whereas oneOfType is
to check the type of the variable.