### PR TITLE
🐝 fix: reset white-space so the tick is well placed in Firefox

### DIFF
--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -11,6 +11,7 @@
     border-left 4px solid transparent
     color charcoalGrey
     transition all .2s ease-out
+    white-space normal /* otherwise the tick can be wrongly placed in Firefox */
 
     &:hover
         background-color paleGrey


### PR DESCRIPTION
## Problem

In the selectBox, the checkmark is placed too far below in Firefox.


## Reason

When a node is floated and one of the ancestor has `whitespace: word-wrap`, in Firefox the float element is wrapped.

## Solution 

By resetting the value to whitespace value to normal in the select-box `option`, the correct behavior (check mark on the same line as
the label) is ensured.