### PR TITLE
fix: hide selection bar labels on mobile

### DIFF
--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -83,5 +83,5 @@ $selectionbar
                 margin   0 0 0 1rem
 
 
-            .coz-selectionbar-separator
+            .coz-selectionbar-label
                 @extend $visuallyhidden-mobile


### PR DESCRIPTION
I made a typo in #497 …