### PR TITLE
feat: configure modal through IntentOpener

### DIFF
--- a/react/IntentOpener/IntentOpener.jsx
+++ b/react/IntentOpener/IntentOpener.jsx
@@ -48,7 +48,8 @@ class IntentOpener extends React.Component {
       closable,
       create,
       tag,
-      into
+      into,
+      ...modalProps
     } = this.props
     const { modalOpened } = this.state
 
@@ -71,6 +72,7 @@ class IntentOpener extends React.Component {
           onComplete={this.handleComplete}
           create={create}
           into={into}
+          {...modalProps}
         />
       )
     }

--- a/react/IntentOpener/IntentOpener.md
+++ b/react/IntentOpener/IntentOpener.md
@@ -7,6 +7,8 @@
   // you would not pass create normally as it defaults to
   // cozy.client.intents.create
   create={utils.fakeIntentCreate}
+  //extra props will be passed to the modal
+  size={'xlarge'}
 >
   <button>Launch Intent OPEN for doctype io.cozy.files</button>
 </IntentOpener>


### PR DESCRIPTION
The `IntentOpener` uses `IntentModal`, and since #499 the default size of the `IntentModal` has changed.
This change allows to configure the `IntentModal` through the `IntentOpener` component.