### PR TITLE
WIP feat(SelectBox): show an Overlay on mobile

### DIFF
--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -1,4 +1,5 @@
 @require '../../stylus/settings/palette'
+@require '../../stylus/settings/z-index'
 
 .select-control__input
     width 0
@@ -30,3 +31,10 @@
 
 .select-option--checkmark
     float right
+
+.select__overlay
+    background-color transparent
+
+:export {
+    focusedZIndex: $overlay-index + 1
+}

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -886,43 +886,14 @@ exports[`Radio should render examples: Radio 2`] = `
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
-                style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
-              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-            </div>
-          </div>
-        </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
-              <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 2`] = `
-"<div>
-  <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
-      <div>
-        <button>toggle options</button>
-        <div class=\\"select-control__input\\">
+    <div>
+      <div class=\\"react-select__container css-1n88ulj\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
+        <div class=\\"react-select__control css-a83eig\\">
           <div class=\\"react-select__value-container css-12sevwg\\">
             <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
             <div class=\\"css-16n6ap7\\">
               <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
                   style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
@@ -942,26 +913,61 @@ exports[`SelectBox should render examples: SelectBox 2`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 3`] = `
+exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container react-select__value-container--isMulti css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
-                style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
-              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+    <div>
+      <div class=\\"react-select__container css-1n88ulj\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
+        <div>
+          <button>toggle options</button>
+          <div class=\\"select-control__input\\">
+            <div class=\\"react-select__value-container css-12sevwg\\">
+              <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
+              <div class=\\"css-16n6ap7\\">
+                <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
+                  <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+                    style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
+                  <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+                </div>
+              </div>
+            </div>
+            <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
+              <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
+                <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+                  <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
+                </svg>
+              </div>
             </div>
           </div>
         </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
-              <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
-            </svg>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 3`] = `
+"<div>
+  <div>
+    <div>
+      <div class=\\"react-select__container css-1n88ulj\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
+        <div class=\\"react-select__control css-a83eig\\">
+          <div class=\\"react-select__value-container react-select__value-container--isMulti css-12sevwg\\">
+            <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
+            <div class=\\"css-16n6ap7\\">
+              <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
+                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+                  style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
+                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+              </div>
+            </div>
+          </div>
+          <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
+            <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
+              <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+                <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -973,135 +979,137 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 exports[`SelectBox should render examples: SelectBox 4`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">26 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\" aria-owns=\\"react-select-5--listbox\\"
-                role=\\"combobox\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
-              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+    <div>
+      <div class=\\"react-select__container css-1n88ulj\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">26 results available.</span>
+        <div class=\\"react-select__control css-a83eig\\">
+          <div class=\\"react-select__value-container css-12sevwg\\">
+            <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
+            <div class=\\"css-16n6ap7\\">
+              <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
+                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\" aria-owns=\\"react-select-5--listbox\\"
+                  role=\\"combobox\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
+                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+              </div>
+            </div>
+          </div>
+          <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
+            <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
+              <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+                <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
+              </svg>
             </div>
           </div>
         </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
-              <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
-            </svg>
+        <div>
+          <div class=\\"react-select__menu css-1hfb4uo\\">
+            <div aria-multiselectable=\\"false\\" id=\\"react-select-5--listbox\\" role=\\"listbox\\" class=\\"react-select__menu-list css-1ooxlwn\\">
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 20 -->A
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 22 -->B
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 24 -->C
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 26 -->D
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 28 -->E
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 30 -->F
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 32 -->G
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 34 -->H
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 36 -->I
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 38 -->J
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 40 -->K
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 42 -->L
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 44 -->M
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 46 -->N
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 48 -->O
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 50 -->P
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 52 -->Q
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 54 -->R
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 56 -->S
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 58 -->T
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 60 -->U
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 62 -->V
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 64 -->W
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 66 -->X
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-24\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 68 -->Y
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5--option-25\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 70 -->Z
+                <!-- /react-text -->
+              </div>
+            </div>
+            <div style=\\"border-top: 1px solid #D6D8Da; background: white; position: relative;\\"></div>
           </div>
-        </div>
-      </div>
-      <div>
-        <div class=\\"react-select__menu css-1hfb4uo\\">
-          <div aria-multiselectable=\\"false\\" id=\\"react-select-5--listbox\\" role=\\"listbox\\" class=\\"react-select__menu-list css-1ooxlwn\\">
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 19 -->A
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 21 -->B
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 23 -->C
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 25 -->D
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 27 -->E
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 29 -->F
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 31 -->G
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 33 -->H
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 35 -->I
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 37 -->J
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 39 -->K
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 41 -->L
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 43 -->M
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 45 -->N
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 47 -->O
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 49 -->P
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 51 -->Q
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 53 -->R
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 55 -->S
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 57 -->T
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 59 -->U
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 61 -->V
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 63 -->W
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 65 -->X
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-24\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 67 -->Y
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-25\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 69 -->Z
-              <!-- /react-text -->
-            </div>
-          </div>
-          <div style=\\"border-top: 1px solid #D6D8Da; background: white; position: relative;\\"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
On banks we use the `SelectBox` for our date selector component. We found it's tricky to close it without clicking on another element of the page that does another action (a transaction row that opens a modal, for example).

That's why we propose to add a transparent overlay when a `SelectBox` is focused. This way, we can click everywhere outside the select to close it, without misclicking on another element and do something unexpected.

https://drazik.github.io/cozy-ui/react/#selectbox
