### PR TITLE
fix: enables only overflow-y on small screen

### DIFF
--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -43,7 +43,7 @@ body
     overflow-y  auto
 
     +medium-screen()
-        overflow visible
+        overflow-y visible
 
 // COLORS
 html,


### PR DESCRIPTION
To avoid horizontal scrollbar on Windows' browsers, especially inside intent modals.

The horizontal scrollbar appears because there's a vertical one. In WIndows OS, the scrollbar adds itself to the element it scrolls so it increases the element's width. Why ? Because fuck you, that's why.

![](https://trello-attachments.s3.amazonaws.com/595b647084372adc283e4e5b/5b0e75852746a2b529ce1556/846cde00c9d2c85b46f05a6e394cff5e/image.png)