### PR TITLE
fix(action button): fix focus styles

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -384,7 +384,9 @@ actionbtnVariant(bgColor, txtColor, bdColor)
         border-color bdColor
 
     &:hover
+    &:focus
         background-color bdColor
+        border-color txtColor
 
     &[disabled]:hover
     &[aria-disabled=true]:hover


### PR DESCRIPTION
There was a problem when these buttons were focused and/or hovered : 

![actionbtnbug](https://user-images.githubusercontent.com/1606068/41025922-772578ec-6973-11e8-8d50-0d7aa5bf33c9.gif)

This fixes it:

![actionbtngood](https://user-images.githubusercontent.com/1606068/41026015-b62c8666-6973-11e8-8d43-8db3c5f49dca.gif)