### PR TITLE
feat: add global utility classes

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -56,10 +56,7 @@
     "error": true
   },
   "mixins": ["hide","reset"],
-  "namingConvention": {
-    "expect": "lowercase-dash",
-    "error": true
-  },
+  "namingConvention": false,
   "namingConventionStrict": false,
   "none": {
     "expect": "never",

--- a/react/MidEllipsis/index.jsx
+++ b/react/MidEllipsis/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import styles from './styles.styl'
 
 const MidEllipsis = props => {
   const { text, className } = props
@@ -10,7 +9,7 @@ const MidEllipsis = props => {
   const lastPart = text.substr(partLength, text.length)
 
   return (
-    <div className={cx(styles['u-midellipsis'], className)}>
+    <div className={cx('u-midellipsis', className)}>
       <span>{firstPart}</span>
       <span>{lastPart}</span>
     </div>

--- a/react/MidEllipsis/styles.styl
+++ b/react/MidEllipsis/styles.styl
@@ -1,4 +1,0 @@
-@require '../../stylus/utilities/text'
-
-.u-midellipsis
-    @extend $midellipsis

--- a/react/Text/index.jsx
+++ b/react/Text/index.jsx
@@ -11,7 +11,7 @@ const mkText = baseClass => props => {
       className={cx(
         baseClass,
         {
-          [styles['u-ellipsis']]: ellipsis
+          ['u-ellipsis']: ellipsis
         },
         className
       )}

--- a/react/Text/styles.styl
+++ b/react/Text/styles.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/generic/typography'
-@require '../../stylus/utilities/text'
 
 .g-title-h1
     @extend $title-h1
@@ -19,5 +18,3 @@
 .g-caption
     @extend $caption
 
-.u-ellipsis
-    @extend $ellipsis

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -48,3 +48,19 @@ $hide--desk
     +gt-mobile()
         display none !important // @stylint ignore
 
+
+// Global classes
+:global(.u-visuallyhidden)
+    @extend $visuallyhidden
+
+:global(.u-hide)
+    @extend $hide
+
+:global(.u-hide--mob)
+    @extend $hide--mob
+
+:global(.u-hide--tablet)
+    @extend $hide--tablet
+
+:global(.u-hide--desk)
+    @extend $hide--desk

--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -31,15 +31,25 @@ for kType, vType in types
             if vDir == all
                 ${kType}-{kSize}
                     {vType}: vSize
+                :global(.u-{kType}-{kSize})
+                    {vType}: vSize
             else if vDir == vertical
                 ${kType}{kDir}-{kSize}
+                    {vType}-top: vSize
+                    {vType}-bottom: vSize
+                :global(.u-{kType}{kDir}-{kSize})
                     {vType}-top: vSize
                     {vType}-bottom: vSize
             else if vDir == horizontal
                 ${kType}{kDir}-{kSize}
                     {vType}-left: vSize
                     {vType}-right: vSize
+                :global(.u-{kType}{kDir}-{kSize})
+                    {vType}-left: vSize
+                    {vType}-right: vSize
             else
                 ${kType}{kDir}-{kSize}
+                    {vType}-{vDir}: vSize
+                :global(.u-{kType}{kDir}-{kSize})
                     {vType}-{vDir}: vSize
 // @stylint on

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -29,6 +29,9 @@ for color in keys(colors)
     $color-{color}
         color: lookup(color) !important // @stylint ignore
 
+    :global(.u-{color})
+        color: lookup(color) !important // @stylint ignore
+
 $ellipsis
     display block
     width 100%
@@ -56,3 +59,22 @@ $midellipsis
     @supports(text-overflow: '[...]')
         > :first-child
             text-overflow '[...]'
+
+// Global classes
+:global(.u-error)
+    @extend $error
+
+:global(.u-error--warning)
+    @extend $error-warning
+
+:global(.u-valid)
+    @extend $valid
+
+:global(.u-warn)
+    @extend $warn
+
+:global(.u-ellipsis)
+    @extend $ellipsis
+
+:global(.u-midellipsis)
+    @extend $midellipsis


### PR DESCRIPTION
Made utility classes global so you don't have to create classes and extend them anymore. You can just use the class without CSS-Modules now.

Before:

```jsx
<Element className={styles['u-ellipsis']}>
      {children}
</Element>
```

After:

```jsx
<Element className='u-ellipsis'>
      {children}
</Element>
```
📌  [previous merge](https://github.com/cozy/cozy-ui/pull/524) 