### PR TITLE
Fix hover/focus styles on ButtonAction

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -333,6 +333,7 @@ $actionbtn
     padding-right .5rem
     text-align left
     line-height 1.3
+    outline 0
 
     > span
         justify-content flex-start

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -386,7 +386,7 @@ actionbtnVariant(bgColor, txtColor, bdColor)
     &:hover
     &:focus
         background-color bdColor
-        border-color txtColor
+        border-color bdColor
 
     &[disabled]:hover
     &[aria-disabled=true]:hover


### PR DESCRIPTION
In https://github.com/cozy/cozy-ui/pull/523 I fixed a part of a problem we had with ButtonAction hover/focus styles, but it was not totally in sync with what was designed.

Also, we had a focus ring on chrome, which we can remove since we handle focus state properly.
