### PR TITLE
feat: add cursor utility classes

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -659,15 +659,24 @@ Display an avatar of a user or contact with initials or an image
 */
 
 /*
-    Display
+    Cursor
 
-    Utilities that change the box model of an element or its visibility.
+    Utilities that change cursor when hovering an element.
 
-    Styleguide utilities.display
+     Markup:
+    <a href="https://cozy.io" class="{{modifier_class}}">I'm a link</a>
+
+    .u-c-default - Force default cursor
+    .u-c-help - help cursor for help and/or tips
+    .u-c-pointer - pointer cursor showing the element is clickable
+    .u-c-wait - wait cursor to express that an action is pending
+    .u-c-not-allowed - not allowed cursor, often used on a disabled element, to express your inhability to make an action
+
+    Styleguide utilities.cursor
 */
 
 /*
-    Visibility
+    Display
 
     Utilities that show or hide an element for a giving viewport size.
 
@@ -679,7 +688,7 @@ Display an avatar of a user or contact with initials or an image
     .u-hide--desk - Element is hidden on desktop (>768px)
     .u-hide--mob - Element is hidden on mobile (<1023px)
 
-    Styleguide utilities.visibility
+    Styleguide utilities.display
 */
 
 /*

--- a/stylus/utilities/cursor.styl
+++ b/stylus/utilities/cursor.styl
@@ -1,0 +1,27 @@
+@require '../tools/mixins'
+/*------------------------------------*\
+  Cursor utilities
+\*------------------------------------*/
+
+$cursor-default
+    cursor default
+
+$cursor-help
+    cursor help
+
+$cursor-pointer
+    cursor pointer
+
+$cursor-wait
+    cursor wait
+
+$cursor-not-allowed
+    cursor not-allowed
+
+// Global classes
+global('.u-c-default', $cursor-default)
+global('.u-c-help', $cursor-help)
+global('.u-c-pointer', $cursor-pointer)
+global('.u-c-wait', $cursor-wait)
+global('.u-c-not-allowed', $cursor-not-allowed)
+


### PR DESCRIPTION
Add several utility classes for cursor.

- `.u-c-default` - Force default cursor
- `.u-c-help` - help cursor for help and/or tips
- `.u-c-pointer` - pointer cursor showing the element is clickable
- `.u-c-wait` - wait cursor to express that an action is pending
- `.u-c-not-allowed` - not allowed cursor, often used on a disabled element, to express your inhability to make an action

Fixes issue #478 
