### PR TITLE
Update react select

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,10 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "scope-case": [0]
+    }
   },
   "release": {
     "prepare": [

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "normalize.css": "^7.0.0",
     "preact-portal": "^1.1.2",
     "pretty": "^2.0.0",
-    "react-select": "2.0.0-alpha.7",
+    "react-select": "^2.0.0-beta.6",
     "stylus": "^0.54.5"
   },
   "peerDependencies": {

--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -69,3 +69,29 @@ options[options.length - 1].fixed = true;
   menuIsOpen={isTesting ? true : undefined}
   options={options} />
 ```
+
+### Customize ReactSelect components
+
+Do not directly install another version of react-select, cozy-ui exports the components
+from `react-select` for you to further customize the components.
+
+Here a custom class is applied to the `ValueContainer`.
+
+```
+const { default: SelectBox, components } = require('.')
+
+const ValueContainer = props => {
+  return (
+    <components.ValueContainer {...props} className='needsclick' />
+  );
+};
+
+<SelectBox
+  components={{ ValueContainer }}
+  options={[
+    {value: 1, label: 1},
+    {value: 2, label: 2},
+    {value: 3, label: 3}]}
+
+/>
+```

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -118,5 +118,7 @@ SelectBox.defaultProps = {
   styles: {}
 }
 
+const components = ReactSelect.components
+
 export default SelectBox
-export { Option, CheckboxOption, reactSelectControl }
+export { Option, CheckboxOption, reactSelectControl, components }

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -892,21 +892,21 @@ exports[`Radio should render examples: Radio 2`] = `
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+    <div class=\\"css-1h8pu2y\\"><span class=\\"css-1uvvha\\" aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\">3 results available.</span>
+      <div class=\\"css-1scqv3c\\">
+        <div class=\\"css-nfppcf\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-rsyb7x\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\">
+              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
                 style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+        <div class=\\"css-1wy0on6\\"><span role=\\"presentation\\" class=\\"css-1hyfx7x\\"></span>
+          <div role=\\"button\\" class=\\"css-1j9smtq\\">
+            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" class=\\"css-19bqh2r\\" focusable=\\"false\\" role=\\"presentation\\">
               <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
             </svg>
           </div>
@@ -920,23 +920,23 @@ exports[`SelectBox should render examples: SelectBox 1`] = `
 exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
+    <div class=\\"css-1h8pu2y\\"><span class=\\"css-1uvvha\\" aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\">3 results available.</span>
       <div>
         <button>toggle options</button>
         <div class=\\"select-control__input\\">
-          <div class=\\"react-select__value-container css-12sevwg\\">
-            <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-            <div class=\\"css-16n6ap7\\">
-              <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+          <div class=\\"css-nfppcf\\">
+            <div class=\\"css-1492t68\\">Select...</div>
+            <div class=\\"css-rsyb7x\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\">
+                <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
                   style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
           </div>
-          <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-            <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-              <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+          <div class=\\"css-1wy0on6\\"><span role=\\"presentation\\" class=\\"css-1hyfx7x\\"></span>
+            <div role=\\"button\\" class=\\"css-1j9smtq\\">
+              <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" class=\\"css-19bqh2r\\" focusable=\\"false\\" role=\\"presentation\\">
                 <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
               </svg>
             </div>
@@ -951,21 +951,21 @@ exports[`SelectBox should render examples: SelectBox 2`] = `
 exports[`SelectBox should render examples: SelectBox 3`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">3 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container react-select__value-container--isMulti css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+    <div class=\\"css-1h8pu2y\\"><span class=\\"css-1uvvha\\" aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\">3 results available.</span>
+      <div class=\\"css-1scqv3c\\">
+        <div class=\\"css-nfppcf\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-rsyb7x\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\">
+              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
                 style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+        <div class=\\"css-1wy0on6\\"><span role=\\"presentation\\" class=\\"css-1hyfx7x\\"></span>
+          <div role=\\"button\\" class=\\"css-1j9smtq\\">
+            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" class=\\"css-19bqh2r\\" focusable=\\"false\\" role=\\"presentation\\">
               <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
             </svg>
           </div>
@@ -979,135 +979,165 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 exports[`SelectBox should render examples: SelectBox 4`] = `
 "<div>
   <div>
-    <div class=\\"react-select__container css-13t81xe\\"><span aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\" class=\\"css-17l7ekz\\">26 results available.</span>
-      <div class=\\"react-select__control css-a83eig\\">
-        <div class=\\"react-select__value-container css-12sevwg\\">
-          <div class=\\"react-select__placeholder css-16ucli7\\">Select...</div>
-          <div class=\\"css-16n6ap7\\">
-            <div class=\\"react-select__input\\" style=\\"display: inline-block;\\">
-              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5--input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\" aria-owns=\\"react-select-5--listbox\\"
+    <div class=\\"css-1h8pu2y\\"><span class=\\"css-1uvvha\\" aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\">26 results available.</span>
+      <div class=\\"css-1scqv3c\\">
+        <div class=\\"css-nfppcf\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-rsyb7x\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\">
+              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\" aria-owns=\\"react-select-5-listbox\\"
                 role=\\"combobox\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"react-select__indicators css-1lfa1d8\\"><span role=\\"presentation\\" class=\\"react-select__indicator-separator css-1hq2z0s\\"></span>
-          <div role=\\"button\\" class=\\"react-select__indicator react-select__dropdown-indicator css-1k2060c\\">
-            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" focusable=\\"false\\" role=\\"presentation\\" class=\\"react-select__icon react-select__down-icon css-qyb9b\\">
+        <div class=\\"css-1wy0on6\\"><span role=\\"presentation\\" class=\\"css-1hyfx7x\\"></span>
+          <div role=\\"button\\" class=\\"css-1j9smtq\\">
+            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" class=\\"css-19bqh2r\\" focusable=\\"false\\" role=\\"presentation\\">
               <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
             </svg>
           </div>
         </div>
       </div>
       <div>
-        <div class=\\"react-select__menu css-1hfb4uo\\">
-          <div aria-multiselectable=\\"false\\" id=\\"react-select-5--listbox\\" role=\\"listbox\\" class=\\"react-select__menu-list css-1ooxlwn\\">
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 19 -->A
-              <!-- /react-text -->
+        <div>
+          <div class=\\"css-2msmlm\\">
+            <div class=\\"css-11unzgr\\" aria-multiselectable=\\"false\\" id=\\"react-select-5-listbox\\" role=\\"listbox\\">
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 20 -->A
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 22 -->B
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 24 -->C
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 26 -->D
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 28 -->E
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 30 -->F
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 32 -->G
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 34 -->H
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 36 -->I
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 38 -->J
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 40 -->K
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 42 -->L
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 44 -->M
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 46 -->N
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 48 -->O
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 50 -->P
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 52 -->Q
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 54 -->R
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 56 -->S
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 58 -->T
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 60 -->U
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 62 -->V
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 64 -->W
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 66 -->X
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-24\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 68 -->Y
+                <!-- /react-text -->
+              </div>
+              <div aria-selected=\\"false\\" id=\\"react-select-5-option-25\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
+                <!-- react-text: 70 -->Z
+                <!-- /react-text -->
+              </div>
             </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 21 -->B
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 23 -->C
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 25 -->D
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 27 -->E
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 29 -->F
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 31 -->G
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 33 -->H
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 35 -->I
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 37 -->J
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 39 -->K
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 41 -->L
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 43 -->M
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 45 -->N
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 47 -->O
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 49 -->P
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 51 -->Q
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 53 -->R
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 55 -->S
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 57 -->T
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 59 -->U
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 61 -->V
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 63 -->W
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 65 -->X
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-24\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 67 -->Y
-              <!-- /react-text -->
-            </div>
-            <div aria-selected=\\"false\\" id=\\"react-select-5--option-25\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"select-option\\">
-              <!-- react-text: 69 -->Z
-              <!-- /react-text -->
+            <div style=\\"border-top: 1px solid #D6D8Da; background: white; position: relative;\\"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 5`] = `
+"<div>
+  <div>
+    <div class=\\"css-1h8pu2y\\"><span class=\\"css-1uvvha\\" aria-atomic=\\"true\\" aria-live=\\"polite\\" role=\\"status\\">3 results available.</span>
+      <div class=\\"css-1scqv3c\\">
+        <div class=\\"css-nfppcf needsclick\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-rsyb7x\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\">
+              <input type=\\"text\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-6-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-busy=\\"false\\" aria-expanded=\\"false\\" aria-haspopup=\\"false\\" role=\\"combobox\\"
+                style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
-          <div style=\\"border-top: 1px solid #D6D8Da; background: white; position: relative;\\"></div>
+        </div>
+        <div class=\\"css-1wy0on6\\"><span role=\\"presentation\\" class=\\"css-1hyfx7x\\"></span>
+          <div role=\\"button\\" class=\\"css-1j9smtq\\">
+            <svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" class=\\"css-19bqh2r\\" focusable=\\"false\\" role=\\"presentation\\">
+              <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
+            </svg>
+          </div>
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,13 @@
   dependencies:
     "@babel/types" "7.0.0-beta.41"
 
+"@babel/helper-module-imports@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.40.tgz#251cbb6404599282e8f7356a5b32c9381bef5d2d"
+  dependencies:
+    "@babel/types" "7.0.0-beta.40"
+    lodash "^4.2.0"
+
 "@babel/helper-split-export-declaration@7.0.0-beta.41":
   version "7.0.0-beta.41"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.41.tgz#8a0a67ded225ab7abeb4ad1fc138b4e0e882abee"
@@ -83,6 +90,14 @@
     globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.40.tgz#25c3d7aae14126abe05fcb098c65a66b6d6b8c14"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@7.0.0-beta.41", "@babel/types@^7.0.0-beta.40":
   version "7.0.0-beta.41"
@@ -213,6 +228,26 @@
   resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-6.1.3.tgz#126dcb6de1676342c69cd42261483f4478547299"
   dependencies:
     find-up "^2.1.0"
+
+"@emotion/babel-utils@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.5.3.tgz#6be6dd7a480fdbdfb6cbba7f4f6d9361744b8d6e"
+
+"@emotion/hash@^0.6.2":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.3.tgz#0e7a5604626fc6c6d4ac4061a2f5ac80d50262a4"
+
+"@emotion/memoize@^0.6.1":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.2.tgz#138e00b332d519b4e307bded6159e5ba48aba3ae"
+
+"@emotion/stylis@^0.6.5":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.6.8.tgz#6ad4e8d32b19b440efa4481bbbcb98a8c12765bb"
+
+"@emotion/unitless@^0.6.2":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.3.tgz#65682e68a82701c70eefb38d7f941a2c0bfa90de"
 
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
@@ -982,6 +1017,23 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-emotion@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.0.tgz#43543dd02c7b5cd89d464aeedef864edb754b852"
+  dependencies:
+    "@babel/helper-module-imports" "7.0.0-beta.40"
+    "@emotion/babel-utils" "^0.5.3"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.6.5"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^1.0.0"
+
 babel-plugin-istanbul@^4.1.5:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -994,6 +1046,12 @@ babel-plugin-istanbul@^4.1.5:
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+
+babel-plugin-macros@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.2.2.tgz#049c93f4b934453688a6ec38bba529c55bf0fa1f"
+  dependencies:
+    cosmiconfig "^4.0.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1011,7 +1069,7 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
 
-babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
@@ -1563,10 +1621,6 @@ boom@5.x.x:
 bottleneck@^2.0.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.3.1.tgz#16292092ff040ccbf2d05d0a09d69eab7b1c46bc"
-
-bowser@^1.7.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.3.tgz#6643ae4d783f31683f6d23156976b74183862162"
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -2503,6 +2557,18 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-emotion@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.1.tgz#1316189d53bf65cf191a59d3ac6ecb6f4e13e020"
+  dependencies:
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.6.5"
+    "@emotion/unitless" "^0.6.2"
+    csstype "^2.5.2"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -2593,12 +2659,6 @@ crypto-random-string@^1.0.0:
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
-
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
-  dependencies:
-    hyphenate-style-name "^1.0.2"
 
 css-loader@^0.28.4, css-loader@^0.28.7:
   version "0.28.7"
@@ -2701,6 +2761,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.5.2:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.3.tgz#2504152e6e1cc59b32098b7f5d6a63f16294c1f7"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -3131,6 +3195,13 @@ elliptic@^6.0.0:
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+
+emotion@^9.1.2:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.1.tgz#d2aa77b22945d9f40ea9b5ac6bdac42cec35610a"
+  dependencies:
+    babel-plugin-emotion "^9.2.0"
+    create-emotion "^9.2.1"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -3839,6 +3910,10 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -4138,13 +4213,6 @@ github-slugger@^1.1.3:
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.1.3.tgz#314a6e759a18c2b0cc5760d512ccbab549c549a7"
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
-
-glam@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/glam/-/glam-5.0.1.tgz#b965a46f1a7f9ba3a23d16430b2e706f63c80ee8"
-  dependencies:
-    fbjs "^0.8.16"
-    inline-style-prefixer "^3.0.8"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -4685,10 +4753,6 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-hyphenate-style-name@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -4796,13 +4860,6 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-style-prefixer@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
-  dependencies:
-    bowser "^1.7.3"
-    css-in-js-utils "^2.0.0"
 
 inquirer@3.2.1:
   version "3.2.1"
@@ -6734,6 +6791,12 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
+
 nopt@~3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -8027,10 +8090,6 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
-react-node-resolver@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-node-resolver/-/react-node-resolver-1.0.1.tgz#1798a729c0e218bf2f0e8ddf79c550d4af61d83a"
-
 react-redux@^5.0.3:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
@@ -8042,22 +8101,15 @@ react-redux@^5.0.3:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
-react-scroll-captor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-scroll-captor/-/react-scroll-captor-1.0.1.tgz#3f912df72ab8e7f46d4fa27d8707131ffe59b353"
-  dependencies:
-    react-node-resolver "^1.0.1"
-
-react-select@2.0.0-alpha.7:
-  version "2.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.0.0-alpha.7.tgz#a806863af7e03e98adc79869cd0ae8042ae43d38"
+react-select@^2.0.0-beta.6:
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.0.0-beta.6.tgz#87ac27831f348cb9535dfd825534934adcfb7e97"
   dependencies:
     classnames "^2.2.5"
-    glam "^5.0.1"
+    emotion "^9.1.2"
     prop-types "^15.6.0"
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
-    react-scroll-captor "^1.0.1"
     react-transition-group "^2.2.1"
 
 react-styleguidist@^6.0.24:
@@ -9309,6 +9361,14 @@ stylint@^1.5.9:
     user-home "2.0.0"
     yargs "4.7.1"
 
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
+
 stylus-loader@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/stylus-loader/-/stylus-loader-3.0.1.tgz#77f4b34fd030d25b2617bcf5513db5b0730c4089"
@@ -9559,6 +9619,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 toposort@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.3.tgz#f02cd8a74bd8be2fc0e98611c3bacb95a171869c"
+
+touch@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-1.0.0.tgz#449cbe2dbae5a8c8038e30d71fa0ff464947c4de"
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
   version "2.3.4"


### PR DESCRIPTION

`react-select` new version enables `className` customization for each component.

I exported the components from `react-select` because if the host application has another version of `react-select` and start passing components from a newer version of `react-select` to "our" `react-select`, it causes very hard to debug problems.