### PR TITLE
Feat/title classes

### DIFF
--- a/react/Text/index.jsx
+++ b/react/Text/index.jsx
@@ -22,12 +22,12 @@ const mkText = baseClass => props => {
   )
 }
 
-export const Text = mkText(styles['g-text'])
-export const MainTitle = mkText(styles['g-title-h1'])
-export const Title = mkText(styles['g-title-h2'])
-export const SubTitle = mkText(styles['g-title-h3'])
-export const Bold = mkText(styles['g-title-h4'])
-export const Caption = mkText(styles['g-caption'])
+export const Text = mkText(styles['u-text'])
+export const MainTitle = mkText(styles['u-title-h1'])
+export const Title = mkText(styles['u-title-h2'])
+export const SubTitle = mkText(styles['u-title-h3'])
+export const Bold = mkText(styles['u-title-h4'])
+export const Caption = mkText(styles['u-caption'])
 
 // Props
 const commonProps = {

--- a/react/Text/styles.styl
+++ b/react/Text/styles.styl
@@ -1,20 +1,20 @@
 @require '../../stylus/generic/typography'
 
-.g-title-h1
+.u-title-h1
     @extend $title-h1
 
-.g-title-h2
+.u-title-h2
     @extend $title-h2
 
-.g-title-h3
+.u-title-h3
     @extend $title-h3
 
-.g-title-h4
+.u-title-h4
     @extend $title-h4
 
-.g-text
+.u-text
     @extend $text
 
-.g-caption
+.u-caption
     @extend $caption
 

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -809,7 +809,7 @@ exports[`ListItemText should render examples: ListItemText 1`] = `
 "<div>
   <div>
     <div class=\\"c-list-text\\">
-      <div class=\\"g-text u-ellipsis\\">I'm a list item text</div>
+      <div class=\\"u-text u-ellipsis\\">I'm a list item text</div>
     </div>
   </div>
 </div>"
@@ -819,8 +819,8 @@ exports[`ListItemText should render examples: ListItemText 2`] = `
 "<div>
   <div>
     <div class=\\"c-list-text\\">
-      <div class=\\"g-text u-ellipsis\\">I'm a primary text</div>
-      <div class=\\"g-caption u-ellipsis\\">I'm a secondary text</div>
+      <div class=\\"u-text u-ellipsis\\">I'm a primary text</div>
+      <div class=\\"u-caption u-ellipsis\\">I'm a secondary text</div>
     </div>
   </div>
 </div>"
@@ -1247,7 +1247,7 @@ exports[`Spinner should render examples: Spinner 4`] = `
 exports[`Text should render examples: Text 1`] = `
 "<div>
   <div>
-    <div class=\\"g-text\\">This a standard text</div>
+    <div class=\\"u-text\\">This a standard text</div>
   </div>
 </div>"
 `;
@@ -1255,7 +1255,7 @@ exports[`Text should render examples: Text 1`] = `
 exports[`Text should render examples: Text 2`] = `
 "<div>
   <div>
-    <div class=\\"g-caption\\">This a note text</div>
+    <div class=\\"u-caption\\">This a note text</div>
   </div>
 </div>"
 `;

--- a/stylus/components/list.styl
+++ b/stylus/components/list.styl
@@ -6,5 +6,5 @@ $list-text
     justify-content center
     min-height 2.5rem
 
-    .g-caption
+    .u-caption
         margin-top .1875rem

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -777,6 +777,26 @@ Display an chip that represents complex identity
 */
 
 /*
+ Typography
+
+ Titles & texts styles.
+ NB: You can use any class with any HTML tag.
+
+ Markup:
+ <h1 class="u-title-h1">Heading 1</h1>
+ <h2 class="u-title-h2">Heading 2</h2>
+ <h3 class="u-title-h3">Heading 3</h3>
+ <h4 class="u-title-h4">Heading 4</h4>
+ <p class="u-text">Basic text</p>
+ <p class="u-caption">Caption text</p>
+
+ Weight: -1
+
+ Styleguide utilities.typography
+*/
+@require '../../react/Text/styles.styl'
+
+/*
     Margins
 
     Classes to add margins on top, bottom, right, left or all of them based on

--- a/stylus/generic/typography.styl
+++ b/stylus/generic/typography.styl
@@ -1,4 +1,5 @@
 @require '../settings/palette'
+@require '../settings/breakpoints'
 
 /*------------------------------------*\
   Typography
@@ -13,23 +14,29 @@ $title-default
     color charcoalGrey
 
 $title-h1
-    font-size 1.5rem
-    line-height 2.5
-    letter-spacing -.0125rem
     @extend $title-default
+    font-size 1.5rem
+    letter-spacing -.125rem
+    +small-screen()
+        font-size 1.25rem
 
 $title-h2
-    font-size 1.125rem
-    letter-spacing -.0125rem
     @extend $title-default
+    font-size 1.25rem
+    +small-screen()
+        font-size 1.125rem
 
 $title-h3
-    font-size 1.25rem
     @extend $title-default
+    font-size 1.125rem
+    +small-screen()
+        font-size 1rem
 
 $title-h4
-    font-size 1rem
     @extend $title-default
+    font-size 1rem
+    +small-screen()
+        color slateGrey
 
 /*------------------------------------*\
   Text content


### PR DESCRIPTION
Add utility classes to handle title & comon text.

- `u-title-h1`: level 1 heading
- `u-title-h2`: level 2 heading
- `u-title-h3`: level 3 heading
- `u-title-h4`: level 4 heading
- `u-text`: basic text, not really useful as this is also the default rendering for a text, but it could be used to force, overwrite or to put on `<hn>` tags for example.
- `u-caption`: caption text, for a legend for example.