### PR TITLE
feat: add rem() mixin

### DIFF
--- a/react/Hero/styles.styl
+++ b/react/Hero/styles.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints.styl'
+@require 'tools/mixins'
 
 .Hero
     margin-left auto
@@ -6,13 +7,13 @@
 
     &-title
         text-align center
-        margin 3rem 0
+        margin rem(48) 0
 
     &-subtitle
         margin-bottom 0
 
         +small-screen()
-            margin-top .5rem
+            margin-top rem(8)
 
     p
         line-height 1.25
@@ -26,12 +27,12 @@
             align-items center
 
     &-section
-        max-width 18.75rem
+        max-width rem(300)
         text-align center
 
         +small-screen()
             max-width auto
-            margin-bottom 2rem
+            margin-bottom rem(32)
 
     &-cta
         text-align center

--- a/react/IntentHeader/styles.styl
+++ b/react/IntentHeader/styles.styl
@@ -1,10 +1,11 @@
 @require 'settings/palette.styl'
+@require 'tools/mixins'
 
 .intentHeader
     display flex
     align-items center
-    height 2rem
-    padding .5rem 1rem
+    height rem(32)
+    padding rem(8 16)
     background-color paleGrey
     margin 0
     // Keep its height in a flex configuration
@@ -14,12 +15,12 @@
 .intentHeader-title
     display flex
     align-items center
-    font-size 1.25rem
+    font-size rem(20)
     color charcoalGrey
 
     span
         font-weight normal
 
 .intentHeader-icon
-    height 1.125rem
-    margin-right .5rem
+    height rem(18)
+    margin-right rem(8)

--- a/react/IntentModal/styles.styl
+++ b/react/IntentModal/styles.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints'
+@require 'tools/mixins'
 
 .intentModal
     height 80vh
@@ -18,5 +19,5 @@
         max-width unset !important
 
 .intentModal__cross
-    top .25rem
-    right .5rem
+    top rem(4)
+    right rem(8)

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -1,5 +1,6 @@
 @require 'settings/palette.styl'
 @require 'components/popover.styl'
+@require 'tools/mixins'
 
 .c-menu
     position relative
@@ -10,8 +11,8 @@
     display    none
     position   absolute
     margin     0
-    margin-top 1px
-    min-width  220px
+    margin-top rem(1)
+    min-width  rem(220)
     // cuts the hover background properly (border-radius)
     overflow   hidden
     border     0
@@ -29,7 +30,7 @@
     display block
 
 .c-menu__btn
-    font-size 1rem
+    font-size rem(16)
     border 0
     cursor pointer
 
@@ -38,18 +39,18 @@
 .c-menu__btn:not([disabled]):not([aria-disabled=true]):focus
     background transparent
 
-$paddingItem = .5rem
+$paddingItem = rem(8)
 
 .c-menu__item
     cursor pointer
     padding   $paddingItem
 
 .c-menu__item-icon
-    $marginIcon = .75rem
+    $marginIcon = rem(12)
     margin-right $marginIcon
     // we need to compensate for the already present margin
     margin-left $marginIcon - $paddingItem
-    font-size 1.0625rem
+    font-size rem(17)
 
 .c-menu__item:hover
 .c-menu__item:focus

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -79,4 +79,4 @@
     @extend $modal--hidden
 
 .c-modal-close + .c-modal-content
-    margin-top 4rem
+    margin-top rem(64)

--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -1,4 +1,5 @@
 @require '../../stylus/settings/palette'
+@require '../../stylus/tools/mixins'
 
 .select-control__input
     width 0
@@ -7,8 +8,8 @@
 
 .select-option
     display block
-    padding .5rem
-    border-left 4px solid transparent
+    padding rem(8)
+    border-left rem(4) solid transparent
     color charcoalGrey
     transition all .2s ease-out
     white-space normal /* otherwise the tick can be wrongly placed in Firefox */
@@ -29,7 +30,7 @@
     cursor not-allowed
 
 .select-option__checkbox
-    margin-right .5rem
+    margin-right rem(8)
     vertical-align top
 
 .select-option--checkmark

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -1,15 +1,16 @@
 @require '../../stylus/settings/palette'
 @require '../../stylus/settings/icons'
+@require '../../stylus/tools/mixins'
 
 .c-spinner
     display inline-block
-    margin 0 .5rem
+    margin 0 rem(8)
 
     &:before
         content ''
 
     p
-        margin-top  .9375rem
+        margin-top  rem(15)
         color       coolGrey
         line-height 1.5
 

--- a/react/Toggle/styles.styl
+++ b/react/Toggle/styles.styl
@@ -1,9 +1,10 @@
 @require '../../stylus/settings/palette'
+@require '../../stylus/tools/mixins'
 
 .toggle
     display inline-block
-    width   40px
-    height  24px
+    width   rem(40)
+    height  rem(24)
 
 .checkbox
     display none
@@ -13,7 +14,7 @@
     display       inline-block
     width         100%
     height        100%
-    border-radius 1em
+    border-radius rem(16)
     background    silver
     transition    all .2s ease-out
     cursor        pointer
@@ -22,10 +23,10 @@
     position      absolute
     top           0
     bottom        0
-    left          2px
+    left          rem(2)
     display       inline-block
-    width         20px
-    height        20px
+    width         rem(20)
+    height        rem(20)
     margin        auto
     border-radius 50%
     content       ''
@@ -36,4 +37,4 @@
     background emerald
 
     &:before
-        left 18px
+        left rem(18)

--- a/stylus/components/action-menu.styl
+++ b/stylus/components/action-menu.styl
@@ -1,15 +1,16 @@
 @require './popover.styl'
+@require '../tools/mixins'
 
 $actionmenu
     .c-actionmenu
         @extend        $popover
         z-index        $file-action-menu
         position       fixed
-        bottom         .5625rem
+        bottom         rem(9)
         left           0
-        width          'calc(100% - %s)' % 1rem
-        margin         0 .5rem
-        padding-bottom .3125rem
+        width          'calc(100% - %s)' % rem(16)
+        margin         0 rem(8)
+        padding-bottom rem(5)
         box-sizing border-box
 
         &.with-transition

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -1,5 +1,6 @@
 @require '../settings/z-index'
 @require '../components/button'
+@require '../tools/mixins'
 /*!
  * NOTIFICATIONS
  * =============
@@ -7,13 +8,13 @@
  * This file contains all needs for alerts
  */
 
-alert-width = 40rem
+alert-width = rem(640)
 
 $alert
     position fixed
     z-index $alert-index-mobile
     right 0
-    bottom 3rem
+    bottom rem(48)
     left 0
     color white
     opacity 1
@@ -22,7 +23,7 @@ $alert
 
     @media all and (min-width alert-width)
         z-index $alert-index
-        top 1rem
+        top rem(16)
         bottom auto
         text-align center
 
@@ -33,31 +34,31 @@ $alert-wrapper
     justify-content center
     box-sizing border-box
     width 100%
-    box-shadow 0 .375rem 1.125rem 0 rgba(50, 54, 63, .23)
+    box-shadow 0 rem(6) rem(18) 0 rgba(50, 54, 63, .23)
     background-color emerald
-    padding .8rem 1rem
+    padding rem(13 16)
 
     p
         margin 0
         line-height 1.5
 
     p + button
-        margin-left 1.5rem
+        margin-left rem(24)
 
     @media all and (min-width alert-width)
         width auto
         max-width alert-width
-        padding 1rem 1.5rem
-        border-radius .625rem
+        padding rem(16 24)
+        border-radius rem(10)
         text-align left
 
 $alert--hidden
-    transform translateY(5rem)
+    transform translateY(rem(80))
     opacity 0
     transition-timing-function ease-out
 
     @media all and (min-width alert-width)
-        transform translateY(-5rem)
+        transform translateY(rem(-80))
 
 $alert-title
     font-weight bold

--- a/stylus/components/avatar.styl
+++ b/stylus/components/avatar.styl
@@ -1,4 +1,6 @@
+@require '../tools/mixins'
 @require '../settings/palette'
+@require '../tools/mixins'
 
 $avatar
     display inline-flex
@@ -10,18 +12,18 @@ $avatar
     color silver
 
 $avatar--small
-    width 2rem
-    height 2rem
-    font-size 1rem
+    width rem(32)
+    height rem(32)
+    font-size rem(16)
 
 $avatar--medium
-    width 4rem
-    height 4rem
-    font-size 2rem
+    width rem(64)
+    height rem(64)
+    font-size rem(32)
 
     svg
-        width 1.5rem
-        height 1.5rem
+        width rem(24)
+        height rem(24)
 
 $avatar-initials
     font-weight bold

--- a/stylus/components/badge.styl
+++ b/stylus/components/badge.styl
@@ -1,6 +1,7 @@
 @require '../settings/palette'
+@require '../tools/mixins'
 
-size = .875rem
+size = rem(14)
 
 $badge-root
     position relative
@@ -22,8 +23,8 @@ $badge
     justify-content center
     align-content center
     align-items center
-    font-size .625rem
-    border .0625rem solid white
+    font-size rem(10)
+    border rem(1) solid white
     cursor inherit
 
 $badge--new

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -56,16 +56,16 @@ themedBtn(theme)
 $button
     box-sizing       border-box
     display          inline-flex
-    margin           0 .25em
-    border-width     1px
+    margin           0 rem(4)
+    border-width     rem(1)
     border-style     solid
-    border-radius    2px
-    min-height       2.5rem
-    min-width        7rem
-    padding          .2rem 1rem
+    border-radius    rem(2)
+    min-height       rem(40)
+    min-width        rem(112)
+    padding          rem(3 16)
     vertical-align   top
     text-align       center
-    font-size        .875rem
+    font-size        rem(14)
     line-height      1
     text-transform   uppercase
     text-decoration  none
@@ -73,7 +73,7 @@ $button
 
     svg
         fill         currentColor
-        margin-right .4rem
+        margin-right rem(6)
 
         &:only-child
             margin 0
@@ -100,7 +100,7 @@ $button
             @extend    $icon-16
             @extend    $icon-spinner-white
             position   relative
-            top        -.0625rem
+            top        rem(-1)
 
     themedBtn(regularTheme)
 
@@ -138,18 +138,18 @@ $button--secondary
 
 $link--upload
     background-image     embedurl('../assets/icons/ui/icon-upload-grey08.svg')
-    background-position  1rem center
+    background-position  rem(16) center
     background-repeat    no-repeat
 
 $link--delete
     background-image     embedurl('../assets/icons/ui/icon-delete-grey08.svg')
-    background-position  1rem center
+    background-position  rem(16) center
     background-repeat    no-repeat
 
 $button--action
     @extend $button--alpha
     border-color transparent
-    padding .5rem
+    padding rem(8)
     opacity     .5
 
     svg
@@ -164,7 +164,7 @@ $button--action
 $button--close
     @extend $button--alpha
     border-color transparent
-    padding .5rem
+    padding rem(8)
 
     svg
         margin 0
@@ -178,10 +178,10 @@ $button--close
 $button-alert
     border       0
     height       auto
-    padding      .5rem 1rem
+    padding      rem(8 16)
     background-color white
     font-weight  bold
-    font-size .9rem
+    font-size rem(14)
     text-decoration none
 
 $button-alert--error
@@ -236,11 +236,11 @@ $button-client
     align-items       center
     height            auto
     margin            0
-    padding-left      1rem
-    padding-right     1rem
+    padding-left      rem(16)
+    padding-right     rem(16)
     background-color  transparent
     text-align        left
-    font-size         .8125rem
+    font-size         rem(13)
     font-weight       bold
     line-height       1.3
     color             slateGrey
@@ -250,9 +250,9 @@ $button-client
 
     &:before
         content           ''
-        flex              0 0 2rem
-        height            2rem
-        margin-right      .75rem
+        flex              0 0 rem(32)
+        height            rem(32)
+        margin-right      rem(12)
         background        embedurl('../assets/icons/ui/icon-device-laptop.svg') 0 0 / contain no-repeat
 
     span
@@ -265,8 +265,8 @@ $button-client-mobile
     background-color dodgerBlue
     border           0
     border-radius    0
-    padding          .5em 3em .5em 1em
-    font-size        1rem
+    padding          rem(8 48 8 16)
+    font-size        rem(16)
     font-weight      normal
     color            white
     text-decoration  none
@@ -286,30 +286,30 @@ $button-client-mobile
         background-color dodgerBlue
 
     &:before
-        flex                0 0 2.75rem
-        height              2.75rem
-        border-radius       .5em
-        border              .3em solid white
+        flex                0 0 rem(44)
+        height              rem(44)
+        border-radius       rem(8)
+        border              rem(5) solid white
         background          white embedurl('../assets/icons/ui/icon-cozy.svg') 0 0 / contain no-repeat
 
 /*------------------------------------*\
   Sizes
 \*------------------------------------*/
 $button--tiny
-    min-height 1.5rem
-    min-width 5rem
-    padding .15rem 1rem
+    min-height rem(24)
+    min-width rem(80)
+    padding rem(2 16)
 
 $button--small
-    min-height 2rem
-    min-width 6rem
-    padding .2rem .5rem
+    min-height rem(32)
+    min-width rem(96)
+    padding rem(3 8)
 
 $button--large
-    min-height 3rem
-    min-width 10rem
-    padding .5rem 1.5rem
-    font-size 1rem
+    min-height rem(48)
+    min-width rem(160)
+    padding rem(8 24)
+    font-size rem(16)
 
 /*------------------------------------*\
   Extensions
@@ -328,10 +328,10 @@ $actionbtn
     @extend $button
     border-color silver
     text-transform none
-    max-width 12.5rem
-    min-height 2rem
+    max-width rem(200)
+    min-height rem(32)
     width 100%
-    padding-right .5rem
+    padding-right rem(8)
     text-align left
     line-height 1.3
     outline 0
@@ -341,7 +341,7 @@ $actionbtn
         flex-wrap nowrap
 
     [data-action='icon']
-        border-left .0625rem solid silver
+        border-left rem(1) solid silver
 
     &:not([disabled]):hover
     &:not([disabled]):focus
@@ -355,8 +355,8 @@ $actionbtn--compact
     background-color transparent
     padding 0
     margin 0
-    min-height 2rem
-    width 2.5rem
+    min-height rem(32)
+    width rem(40)
 
     > span
         justify-content center
@@ -402,7 +402,7 @@ $actionbtn--error
 
 $actionbtn--new
     actionbtnVariant(zircon, dodgerBlue, frenchPass)
-    border-width .0625rem
+    border-width rem(1)
     border-style dashed
 
     &:hover:not([disabled])
@@ -411,12 +411,12 @@ $actionbtn--new
 
 $actionbtn-label
     @extend $ellipsis
-    padding-right .5rem
+    padding-right rem(8)
 
 $actionbtn-icon
     display block
     margin-left auto
-    padding-left .5rem
+    padding-left rem(8)
 
     svg
         display block
@@ -437,7 +437,7 @@ themedBtnSubtle(theme)
 
 sizedBtnSubtle(size)
     sizes = {
-        tiny: .6rem, small: .75rem, large: 1rem
+        tiny: rem(9), small: rem(12), large: rem(16)
     }
 
     min-height 0
@@ -450,18 +450,18 @@ $button-subtle
     min-height auto
     min-width auto
     border 0
-    margin 1rem 0
+    margin rem(16) 0
     padding 0
     vertical-align baseline
     background transparent
     cursor pointer
-    font-size .875rem
+    font-size rem(14)
     font-weight bold
     text-transform uppercase
 
     svg
         fill         currentColor
-        margin-right .4rem
+        margin-right rem(6)
 
         &:only-child
             margin 0
@@ -490,10 +490,10 @@ $button-subtle
         @extend $icon-16
         @extend $icon-spinner-blue
         position relative
-        top -.0625rem
+        top rem(-1)
 
     * + &
-        margin-left 1em
+        margin-left rem(1)
 
 $button-subtle--tiny
     sizedBtnSubtle('tiny')

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -1,7 +1,8 @@
 @require 'settings/palette'
+@require 'tools/mixins'
 
-$chip-height=2.5rem
-$chip-font-size=1rem
+$chip-height = rem(40)
+$chip-font-size = rem(16)
 
 $chip
     border-radius ($chip-height / 2)
@@ -12,8 +13,8 @@ $chip
     line-height 1
     display inline-flex
     align-items center
-    margin-right .25rem
-    margin-bottom .25rem
+    margin-right rem(4)
+    margin-bottom rem(4)
 
 $round-chip
     width $chip-height
@@ -21,12 +22,12 @@ $round-chip
     justify-content center
 
 $chip-separator
-    width 1px
-    border-left 1px solid silver
+    width rem(1)
+    border-left rem(1) solid silver
     display inline-block
     height 100%
-    margin-left .5rem
-    margin-right .5rem
+    margin-left rem(8)
+    margin-right rem(8)
 
 $chip-button
     cursor pointer

--- a/stylus/components/empty.styl
+++ b/stylus/components/empty.styl
@@ -1,5 +1,6 @@
 @require '../settings/palette'
 @require '../settings/breakpoints'
+@require '../tools/mixins'
 
 $empty
     display          flex
@@ -7,7 +8,7 @@ $empty
     justify-content  center
     flex             1 0 auto
     align-self       center
-    padding          1rem 0
+    padding          rem(16) 0
     text-align       center
 
     +medium-screen()
@@ -20,25 +21,25 @@ $empty
 
 $empty-img
     display              block
-    margin               0 auto 2rem
-    height               8.75rem
+    margin               0 auto rem(32)
+    height               rem(140)
 
     +medium-screen()
-        height  6.5625rem
+        height  rem(105)
 
 $empty-title
     margin       0 auto
-    max-width    63rem
+    max-width    rem(1008)
     line-height  1.3
 
     +medium-screen()
-        margin  0 1.5em
+        margin  0 rem(24)
 
 $empty-text
-    margin   .3125rem auto 0
-    max-width    63rem
+    margin   rem(5) auto 0
+    max-width    rem(1008)
     color        coolGrey
     line-height  1.5
 
     +medium-screen()
-        margin  .3125rem 1.5em 0
+        margin  rem(5 24 0)

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -7,12 +7,13 @@
 
 @require '../settings/palette'
 @require '../components/button'
+@require '../tools/mixins'
 
-checkbox-size = 1rem
+checkbox-size = rem(16)
 
 $form
     .coz-form
-        margin  1em 0 .5em
+        margin  rem(16 0 8)
 
         a,
         a:visited
@@ -31,16 +32,16 @@ $form
         flex-direction  column
 
     .coz-form-desc
-        margin-bottom  .5em
+        margin-bottom  rem(8)
         line-height    1.5
 
     .coz-form-label // Deprecated
         display         block
         text-transform  uppercase
         color           coolGrey
-        font-size       .75rem
-        padding         .55em 0
-        margin-top      1em
+        font-size       rem(12)
+        padding         rem(9) 0
+        margin-top      rem(16)
 
     .coz-form-label--error // Deprecated
         display  none
@@ -54,20 +55,20 @@ $form-button
         display          flex
         flex-direction   row
         justify-content  flex-end
-        margin           1em 0 .5em
+        margin           rem(16 0 8)
 
         a
         button
         input[type=submit]
             flex    0 0 auto
-            margin  0 0 .5em .5em
+            margin  rem(0 0 8 8)
 
     .coz-form-controls--full
         a
         button
         input[type=submit]
             flex           0 0 100%
-            margin-bottom  .5em
+            margin-bottom  rem(8)
 
     .coz-form-controls--dispatch
         justify-content  space-between
@@ -76,7 +77,7 @@ $form-button
         button
         input[type=submit]
             flex  0 0 49%
-            margin 0 0 .5em
+            margin 0 0 rem(8)
 
             &:last-child
                 margin-left auto
@@ -88,65 +89,65 @@ $form-text
     input[type=email]
     input[type=url]
         display        inline-block
-        padding        .9em .75em .75em .9em
+        padding        rem(14) rem(12) rem(12) rem(14)
         box-sizing     border-box
-        border-radius  2px
-        border         1px solid silver
+        border-radius  rem(2)
+        border         rem(1) solid silver
         background     white
         color          black
 
         &::placeholder
             color      coolGrey
-            font-size  1rem
+            font-size  rem(16)
 
         &:focus
-            border      1px solid dodgerBlue
+            border      rem(1) solid dodgerBlue
             outline     0
 
         &:hover
-            border  1px solid coolGrey
+            border  rem(1) solid coolGrey
 
         &.error
-            border      1px solid pomegranate
+            border      rem(1) solid pomegranate
 
 
 $form-textarea
     textarea
         display        inline-block
-        padding        .9em .75em .75em .9em
+        padding        rem(14 12 12 14)
         box-sizing     border-box
-        border-radius  2px
-        border         1px solid silver
+        border-radius  rem(2)
+        border         rem(1) solid silver
         background     white
         color          black
 
         &::placeholder
             color      coolGrey
-            font-size  1rem
+            font-size  rem(16)
 
         &:focus
-            border      1px solid dodgerBlue
+            border      rem(1) solid dodgerBlue
             outline     0
 
         &:hover
-            border  1px solid coolGrey
+            border  rem(1) solid coolGrey
 
         &.error
-            border      1px solid pomegranate
+            border      rem(1) solid pomegranate
 
 
 $form-select
     select
         display              inline-block
-        padding              .75em .75em .9em
-        border-radius        4px
+        padding              rem(12 12 14)
+        border-radius        rem(4)
         box-sizing           border-box
-        border               1px solid silver
+        border               rem(1) solid silver
         background           white
         color                black
         appearance           none
         background-image     embedurl('../../assets/icons/ui/arrow.svg')
-        background-position  right 8px center
+        background-position  right rem(8) center
         background-repeat    no-repeat
 
         &::-ms-expand
@@ -154,16 +155,16 @@ $form-select
 
         &::placeholder
             color      slateGrey
-            font-size  1.05rem
+            font-size  rem(17)
 
         &:focus
-            border      1px solid dodgerBlue
+            border      rem(1) solid dodgerBlue
 
         &:hover
-            border  1px solid coolGrey
+            border  rem(1) solid coolGrey
 
         &.error
-            border      1px solid pomegranate
+            border      rem(1) solid pomegranate
             background  none
 
 
@@ -203,36 +204,36 @@ $form-checkbox
 
 $form-progress
     progress
-        margin         .5em 0
+        margin         rem(8) 0
         width          100%
-        height         .5em
+        height         rem(8)
         color          dodgerBlue
         background     paleGrey
         border         0
-        border-radius  1.25rem
+        border-radius  rem(18)
 
         // chrome and safari
         &::-webkit-progress-bar
             background     paleGrey
-            border-radius  1.25rem
+            border-radius  rem(18)
 
         &::-webkit-progress-value
             background     charcoalGrey
-            border-radius  1.25rem
+            border-radius  rem(18)
 
         // firefox
         &::-moz-progress-bar
             background     charcoalGrey
-            border-radius  1.25rem
+            border-radius  rem(18)
 
 // New styles
 $label
     display block
     text-transform uppercase
     color coolGrey
-    font-size .75rem
-    padding .55em 0
-    margin-top 1em
+    font-size rem(12)
+    padding rem(9) 0
+    margin-top rem(16)
 
     &.is-error
         color pomegranate
@@ -240,39 +241,39 @@ $label
 $input-text
     display inline-block
     width 100%
-    max-width 30rem
-    padding .8125rem 1rem
+    max-width rem(480)
+    padding rem(13 16)
     box-sizing border-box
-    border-radius .1875rem
-    border .0625rem solid silver
+    border-radius rem(3)
+    border rem(1) solid silver
     background white
-    font-size 1rem
+    font-size rem(16)
     line-height 1.25
     color black
     outline 0
 
     &::placeholder
         color coolGrey
-        font-size 1rem
+        font-size rem(16)
 
     &:focus
-        border .0625rem solid dodgerBlue
+        border rem(1) solid dodgerBlue
         outline 0
 
     &:hover
-        border .0625rem solid coolGrey
+        border rem(1) solid coolGrey
 
     &.is-error
     &:invalid
-        border .0625rem solid pomegranate
+        border rem(1) solid pomegranate
 
 $input-text--tiny
-    border-radius .125rem
-    padding .225rem .5rem .4rem
+    border-radius rem(2)
+    padding rem(4 8 6)
 
 $input-text--medium
-    border-radius .125rem
-    padding .485rem 1rem .64rem
+    border-radius rem(2)
+    padding rem(8 16 10)
 
 $input-text--fullwidth
     max-width 100%
@@ -280,14 +281,14 @@ $input-text--fullwidth
 $checkbox
     // To make sure that checkbox's wrapper have the height of the checkbox
     display flex
-    margin-bottom .5rem
+    margin-bottom rem(8)
 
     span
         position relative
         display inline-block
         height checkbox-size
         padding-left checkbox-size * 1.4
-        line-height 1rem
+        line-height rem(16)
         cursor pointer
 
         &::before
@@ -299,15 +300,15 @@ $checkbox
             box-sizing border-box
             width checkbox-size
             height checkbox-size
-            border-radius .125rem
+            border-radius rem(2)
 
         &::before
             transition box-shadow 350ms cubic-bezier(0, .89, .44, 1)
-            box-shadow inset 0 0 0 .125rem alpha(charcoalGrey, .25)
+            box-shadow inset 0 0 0 rem(2) alpha(charcoalGrey, .25)
             background-color white
 
         &:hover::before
-            box-shadow inset 0 0 0 .125rem dodgerBlue
+            box-shadow inset 0 0 0 rem(2) dodgerBlue
 
         &::after
             background-image embedurl('../../assets/icons/ui/check.svg')
@@ -338,7 +339,7 @@ $checkbox
         color pomegranate
 
         &::before
-            box-shadow inset 0 0 0 .125rem pomegranate
+            box-shadow inset 0 0 0 rem(2) pomegranate
             background-color alpha(pomegranate, .25)
 
 $radio
@@ -352,8 +353,8 @@ $radio
             content '•'
             color white
             text-align center
-            font-size 1rem
-            line-height .8125rem
+            font-size rem(16)
+            line-height rem(13)
 
 
 
@@ -361,16 +362,16 @@ $textarea
     @extend $input-text
     display block
     width 100%
-    min-height 7.5rem
+    min-height rem(120)
     resize vertical
 
 $textarea--tiny
     @extend $input-text--tiny
-    min-height 3rem
+    min-height rem(48)
 
 $textarea--medium
     @extend $input-text--medium
-    min-height 5rem
+    min-height rem(80)
 
 $textarea--fullwidth
     @extend $input-text--fullwidth
@@ -378,7 +379,8 @@ $textarea--fullwidth
 $select
     @extend $input-text
     appearance none
-    background embedurl('../../assets/icons/ui/icon-bottom-select.svg') right 1.25rem center / .875rem no-repeat
+    background embedurl('../../assets/icons/ui/icon-bottom-select.svg') right rem(20) center no-repeat
+    background-size rem(14)
 
     &::-ms-expand
         display  none
@@ -396,4 +398,4 @@ $field
     position relative
     display flex
     flex-direction column
-    margin .5rem 0 1rem
+    margin rem(8 0 16)

--- a/stylus/components/list.styl
+++ b/stylus/components/list.styl
@@ -1,10 +1,11 @@
 @require '../settings/palette'
+@require '../tools/mixins'
 
 $list-text
     display flex
     flex-direction column
     justify-content center
-    min-height 2.5rem
+    min-height rem(40)
 
     .u-caption
-        margin-top .1875rem
+        margin-top rem(3)

--- a/stylus/components/menu.styl
+++ b/stylus/components/menu.styl
@@ -1,4 +1,5 @@
 @require './popover'
+@require '../tools/mixins'
 
 $menu
     // These styles are needed for the menu to work and come directly from bosonic's source
@@ -22,7 +23,7 @@ $menu
     .coz-menu
         @extend $popover
         right 0
-        padding 5px 0
+        padding rem(5) 0
         margin 0
-        margin-top 1px
-        min-width 220px
+        margin-top rem(1)
+        min-width rem(220)

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -2,6 +2,7 @@
 @require '../settings/z-index'
 @require '../settings/breakpoints'
 @require '../objects/layouts'
+@require '../tools/mixins'
 
 /*------------------------------------*\
   Modals
@@ -11,26 +12,26 @@
 \*------------------------------------*/
 
 // Modal sizes
-small-width = 34rem
-medium-width = 36rem
-large-width = 40rem
-xlarge-width = 50rem
-xxlarge-width = 60rem
+small-width = rem(544)
+medium-width = rem(576)
+large-width = rem(640)
+xlarge-width = rem(800)
+xxlarge-width = rem(960)
 
 // Modal margins
-small-margin = .5rem
-medium-margin = 1.5rem
-large-margin = 3rem
-xlarge-margin = 3rem
-xxlarge-margin = 3rem
+small-margin = rem(8)
+medium-margin = rem(24)
+large-margin = rem(48)
+xlarge-margin = rem(48)
+xxlarge-margin = rem(48)
 
 // Modal paddings
-tiny-padding = 1rem
-small-padding = 1.5rem
-medium-padding = 2rem
-large-padding = 3rem
-xlarge-padding = 3rem
-xxlarge-padding = 3rem
+tiny-padding = rem(16)
+small-padding = rem(24)
+medium-padding = rem(32)
+large-padding = rem(48)
+xlarge-padding = rem(48)
+xxlarge-padding = rem(48)
 
 
 $modals
@@ -60,7 +61,7 @@ $modal-wrapper
 $modal
     @extend $elastic
     position relative
-    border-radius .5rem
+    border-radius rem(8)
     max-height 100%
     background-color white
     color charcoalGrey
@@ -85,42 +86,42 @@ $modal--fullscreen
 
 $modal-header
     @extend $elastic-bar
-    margin 0 0 1rem
-    padding 'calc(%s - .3rem)' % medium-padding 3rem 0 medium-padding
+    margin 0 0 rem(16)
+    padding 'calc(%s - rem(5))' % medium-padding rem(48) 0 medium-padding
     overflow visible
-    min-height 2.5rem
+    min-height rem(40)
 
     h2
         margin 0
         font-weight bold
 
     +tiny-screen()
-        margin-bottom .5rem
-        padding 'calc(%s - .3rem)' % small-padding 2rem 0 small-padding
+        margin-bottom rem(8)
+        padding 'calc(%s - rem(5))' % small-padding rem(32) 0 small-padding
 
         h2
-            font-size 1.25rem
+            font-size rem(20)
 
 $modal-header--branded
     @extend $modal-header
-    padding 1rem 3rem
+    padding rem(16 48)
 
     img
         display block
-        max-height 3.5rem
+        max-height rem(56)
         margin 0 auto
 
 $modal-header--small
-    padding 'calc(%s - .3rem)' % small-padding 3rem 0 small-padding
+    padding 'calc(%s - rem(5))' % small-padding rem(48) 0 small-padding
 
     +tiny-screen()
-        padding 'calc(%s - .3rem)' % tiny-padding 2rem 0 tiny-padding
+        padding 'calc(%s - rem(5))' % tiny-padding rem(32) 0 tiny-padding
 
 $modal-header--large
-    padding 'calc(%s - .3rem)' % large-padding 3rem 0 large-padding
+    padding 'calc(%s - rem(5))' % large-padding rem(48) 0 large-padding
 
     +small-screen()
-        padding 'calc(%s - .3rem)' % medium-padding 2rem 0 medium-padding
+        padding 'calc(%s - rem(5))' % medium-padding rem(32) 0 medium-padding
 
 $modal-content
     @extend $elastic-content
@@ -128,8 +129,8 @@ $modal-content
 
     &:last-child
         padding-bottom medium-padding
-        border-bottom-right-radius .5rem
-        border-bottom-left-radius .5rem
+        border-bottom-right-radius rem(8)
+        border-bottom-left-radius rem(8)
 
     +tiny-screen()
         padding 0 small-padding
@@ -181,20 +182,20 @@ $modal-footer--button
 
             // since the order is reverse we target the first-child
             &:not(:first-child)
-                margin-bottom .25rem
+                margin-bottom rem(4)
 
 $modal-section
-    border-top 1px solid silver
+    border-top rem(1) solid silver
 
-cross-size=2.5rem
+cross-size=rem(40)
 
 $modal-close
     position absolute
-    top 1.5rem
-    right 1.5rem
+    top rem(24)
+    right rem(24)
     margin 0
     padding 0
-    background-size 1.75rem
+    background-size rem(28)
     background-color transparent
     cursor pointer
     display block
@@ -202,28 +203,28 @@ $modal-close
     height cross-size
 
     +tiny-screen()
-        top .8rem
-        right 1rem
+        top rem(13)
+        right rem(16)
 
 $modal-close--small
-    top 1rem
-    right 1rem
+    top rem(16)
+    right rem(16)
 
     +tiny-screen()
-        top .3rem
-        right .5rem
+        top rem(5)
+        right rem(8)
 
 $modal-header--closable
-    padding-right cross-size + 2rem
+    padding-right cross-size + rem(32)
 
 
 $modal-close--large
-    top 2.5rem
-    right 2.5rem
+    top rem(40)
+    right rem(40)
 
     +small-screen()
-        top 1.3rem
-        right 1.5rem
+        top rem(21)
+        right rem(24)
 
 $modal--hidden
     overflow hidden

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -1,36 +1,37 @@
 @require '../settings/breakpoints'
 @require '../settings/z-index'
 @require '../settings/palette'
+@require '../tools/mixins'
 
 /*------------------------------------*\
   Navigation
 \*------------------------------------*/
 
 $nav
-    margin     1.5rem 0
+    margin     rem(24) 0
     padding    0
     list-style none
 
     +medium-screen()
         display          flex
         justify-content  space-around
-        margin           .3125rem 0 .25rem
+        margin           rem(5 0 4)
         padding-right    0
 
 
 $nav-item
     position        relative
     z-index         $app-index
-    height          3rem
+    height          rem(48)
 
     &:hover::before
         content        ''
         position       absolute
         z-index        $below-index
-        border-radius  0 3px 3px 0
+        border-radius  rem(0 3 3 0)
         top 0
         left 0
-        right 1rem
+        right rem(16)
         bottom 0
         background     silver
 
@@ -39,10 +40,10 @@ $nav-item
             content none
 
     +medium-screen()
-        margin 0 .75rem
+        margin 0 rem(12)
         height        auto
         display       block
-        flex          0 0 2.5rem
+        flex          0 0 rem(40)
         padding-right 0
         &:hover::before
             content  none
@@ -50,7 +51,7 @@ $nav-item
 
 $nav-item-icon
     display inline-block
-    margin-right .6875rem
+    margin-right rem(11)
     color coolGrey
     fill currentColor
 
@@ -62,13 +63,13 @@ $nav-item-icon
 
     +medium-screen()
         display block
-        font-size 1.5rem
+        font-size rem(24)
         margin-right 0
         text-align center
 
         svg
-            width 1.5rem
-            height 1.5rem
+            width rem(24)
+            height rem(24)
 
 $nav-item-text
     +medium-screen()
@@ -78,8 +79,8 @@ $nav-item-text
 
 $nav-link
     display              flex
-    padding-left         1.5rem
-    padding-right        1rem
+    padding-left         rem(24)
+    padding-right        rem(16)
     line-height          1.5
     text-decoration      none
     color                slateGrey
@@ -87,7 +88,7 @@ $nav-link
     align-items          center
     flex                 1
     background-repeat    no-repeat
-    background-position  1.5rem center
+    background-position  rem(24) center
 
     &:visited
         color  slateGrey
@@ -97,7 +98,7 @@ $nav-link
 
     &.active // deprecated
     &.is-active
-        box-shadow   inset 4px 0 0 0 dodgerBlue
+        box-shadow   inset rem(4) 0 0 0 dodgerBlue
         font-weight  bold
 
         .c-nav-icon
@@ -109,10 +110,10 @@ $nav-link
         padding              0
         text-align           center
         color                slateGrey
-        font-size            .625rem
+        font-size            rem(10)
         line-height          1
         background-position  center top
-        background-size      1.5rem
+        background-size      rem(24)
 
         &.active // deprecated
         &.is-active

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -1,5 +1,6 @@
 @require '../settings/palette'
 @require '../settings/z-index'
+@require '../tools/mixins'
 
 /*------------------------------------*\
   Pop over
@@ -10,9 +11,9 @@
 
 $popover
     z-index           $popover-index
-    border            1px solid silver
-    border-radius     4px
-    box-shadow        0 1px 3px 0 rgba(50, 54, 63, .19), 0 6px 18px 0 rgba(50, 54, 63, .19)
+    border            rem(1) solid silver
+    border-radius     rem(4)
+    box-shadow        rem(0 1 3 0) rgba(50, 54, 63, .19), rem(0 6 18 0) rgba(50, 54, 63, .19)
     background-color  white
     // @stylint off
     // because Stylint doesn't support custom elements
@@ -23,15 +24,15 @@ $popover
     // @stylint on
 
     hr
-        margin      .3125rem 0
+        margin      rem(5) 0
         border      0
-        border-top  1px solid silver
+        border-top  rem(1) solid silver
 
     a
     button
     [role=button]
         display          block
-        padding          .5rem 2rem .5rem 2.5rem
+        padding          rem(8 32 8 40)
         color            charcoalGrey
         text-decoration  none
         white-space      nowrap

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -1,6 +1,7 @@
 @require '../settings/breakpoints'
 @require '../settings/z-index'
 @require '../utilities/display'
+@require '../tools/mixins'
 
 
 /*------------------------------------*\
@@ -21,32 +22,32 @@ $selectionbar
         justify-content   center
         align-items       center
         width             100%
-        height            3.25rem
+        height            rem(52)
         background-color  slateGrey
         color             white
         font-weight       bold
 
         .coz-selectionbar-separator
-            margin            0 .5rem 0 2rem
-            width             .25rem
-            height            .25rem
+            margin            rem(0 8 0 32)
+            width             rem(4)
+            height            rem(4)
             border-radius     50%
             background-color  black
 
         button
             border              0
-            padding-left        1rem
+            padding-left        rem(16)
             color               white
             background-color    transparent
-            line-height         2.5rem
-            font-size           .875rem
+            line-height         rem(40)
+            font-size           rem(14)
             text-transform      uppercase
             cursor              pointer
 
             svg
                 position relative
-                top .125rem
-                margin-right .5rem
+                top rem(2)
+                margin-right rem(8)
                 fill currentColor
 
             &:disabled
@@ -68,9 +69,9 @@ $selectionbar
             top              auto
             bottom           0
             justify-content  flex-start
-            height           3rem
-            padding-left     1rem
-            padding-right    1rem
+            height           rem(48)
+            padding-left     rem(16)
+            padding-right    rem(16)
 
             .coz-selectionbar-count span
             .coz-action-moveto
@@ -80,7 +81,7 @@ $selectionbar
                 display block
 
             .coz-selectionbar-separator
-                margin   0 0 0 1rem
+                margin   0 0 0 rem(16)
 
 
             .coz-selectionbar-label

--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -1,5 +1,6 @@
 @require '../settings/breakpoints'
 @require '../settings/palette'
+@require '../tools/mixins'
 
 $table
     position relative
@@ -11,7 +12,7 @@ $table
     color coolGrey
 
 $table-head
-    flex 0 0 2rem
+    flex 0 0 rem(32)
 
     +small-screen()
         display none
@@ -31,9 +32,9 @@ $table-row
     flex-direction row
     align-items center
     flex 0 0 auto
-    height 3rem
+    height rem(48)
     width 100%
-    border-bottom 1px solid silver
+    border-bottom rem(1) solid silver
 
     &:hover
         background-color paleGrey
@@ -57,20 +58,20 @@ $table-row-selected
 
 $table-cell
     box-sizing border-box
-    padding .875rem 1rem
-    font-size .875rem
+    padding rem(14 16)
+    font-size rem(14)
     line-height 1.3
 
 
 $table-header
     @extend $table-cell
-    padding .5rem 1rem
-    font-size .75rem
+    padding rem(8 16)
+    font-size rem(12)
     font-weight bold
     text-transform uppercase
 
 $table-cell--primary
-    font-size 1rem
+    font-size rem(16)
     line-height 1.15
     white-space nowrap
     overflow hidden
@@ -84,9 +85,9 @@ $table-divider
     position sticky
     top 0
     background-color white
-    text-indent 2rem
+    text-indent rem(32)
     font-weight bold
-    font-size .75rem
+    font-size rem(12)
     line-height 1.33
     color coolGrey
 
@@ -101,4 +102,4 @@ $table-divider
 
 
     +small-screen()
-        text-indent 1rem
+        text-indent rem(16)

--- a/stylus/components/tabs.styl
+++ b/stylus/components/tabs.styl
@@ -1,14 +1,15 @@
 @require '../settings/palette'
+@require '../tools/mixins'
 
 $tabs-base
     .coz-tab-list
-        border-bottom  1px solid silver
+        border-bottom  rem(1) solid silver
 
     .coz-tab
         display        inline-block
-        padding        .625rem 1rem
+        padding        rem(10 16)
         text-transform uppercase
-        font-size      .8rem
+        font-size      rem(13)
         cursor         pointer
         color          coolGrey
 
@@ -16,8 +17,8 @@ $tabs-base
             text-decoration none
 
     .coz-tab--active
-        border-bottom 2px solid dodgerBlue
+        border-bottom rem(2) solid dodgerBlue
         color         dodgerBlue
 
     .coz-tab-panel
-        padding-top 1.25rem
+        padding-top rem(20)

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -3,9 +3,13 @@
 // FONTS
 @require '../settings/fontstack'
 @require '../settings/breakpoints'
+@require '../tools/mixins'
+
+html
+    font-size 100%
 
 body
-    font 1em/1.5
+    font 100%/1.5
     -moz-osx-font-smoothing grayscale
     -webkit-font-smoothing antialiased
     @extend $font-labor
@@ -59,11 +63,11 @@ body
 
     label::before
         border-radius 50%
-        border        2px solid coolGrey
+        border        rem(2) solid coolGrey
         box-shadow    inset 0 0 0 checkbox-size transparent
 
     input[type=radio]:checked + label::before
-        box-shadow inset 0 0 0 3px paleGrey, inset 0 0 0 checkbox-size dodgerBlue
+        box-shadow inset 0 0 0 rem(3) paleGrey, inset 0 0 0 checkbox-size dodgerBlue
 
 
 [data-input=checkbox]
@@ -72,14 +76,14 @@ body
     label
         &::before
         &::after
-            border-radius 2px
+            border-radius rem(2)
 
         &::before
-            box-shadow        inset 0 0 0 2px alpha(charcoalGrey, 0.25)
+            box-shadow        inset 0 0 0 rem(2) alpha(charcoalGrey, 0.25)
             background-color  white
 
             &:hover
-                box-shadow inset 0 0 0 2px dodgerBlue
+                box-shadow inset 0 0 0 rem(2) dodgerBlue
 
         &::after
             background-image  embedurl('../../assets/icons/ui/check.svg')

--- a/stylus/generic/typography.styl
+++ b/stylus/generic/typography.styl
@@ -15,26 +15,26 @@ $title-default
 
 $title-h1
     @extend $title-default
-    font-size 1.5rem
-    letter-spacing -.125rem
+    font-size rem(24)
+    letter-spacing rem(-.2)
     +small-screen()
-        font-size 1.25rem
+        font-size rem(20)
 
 $title-h2
     @extend $title-default
-    font-size 1.25rem
+    font-size rem(20)
     +small-screen()
-        font-size 1.125rem
+        font-size rem(18)
 
 $title-h3
     @extend $title-default
-    font-size 1.125rem
+    font-size rem(18)
     +small-screen()
-        font-size 1rem
+        font-size rem(16)
 
 $title-h4
     @extend $title-default
-    font-size 1rem
+    font-size rem(16)
     +small-screen()
         color slateGrey
 
@@ -43,11 +43,11 @@ $title-h4
 \*------------------------------------*/
 
 $text
-    font-size 1rem
+    font-size rem(16)
     line-height 1.3
     color charcoalGrey
 
 $caption
-    font-size .75rem
+    font-size rem(12)
     line-height 1.2
     color coolGrey

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -55,7 +55,7 @@ $elastic-content
                 linear-gradient(alpha(white, 0) 0, alpha(white, 0) 74%, alpha(coolGrey, .25) 75%, alpha(coolGrey, .25) 100%) 0 100%
     background-repeat no-repeat
     background-color white
-    background-size 100% 2rem, 100% 2rem, 100% .5rem, 100% .5rem
+    background-size 100% rem(32), 100% rem(32), 100% rem(8), 100% rem(8)
     background-attachment local, local, scroll, scroll
     background-clip padding-box
     overflow auto
@@ -100,7 +100,7 @@ $app
         &:after
             content ''
             display block
-            height 3rem
+            height rem(48)
 
 // STICKY layout
 // When you want a sidebar and you want it to act like a sticky footer on mobile

--- a/stylus/objects/sidebar.styl
+++ b/stylus/objects/sidebar.styl
@@ -6,13 +6,13 @@
 \*------------------------------------*/
 
 $sidebar
-    width 13.75rem
-    border-right 1px solid silver
+    width rem(220)
+    border-right rem(1) solid silver
     background-color paleGrey
 
     +medium-screen()
         justify-content space-between
         border 0
-        border-top 1px solid silver
-        height 3rem
+        border-top rem(1) solid silver
+        height rem(48)
         width 100%

--- a/stylus/settings/breakpoints.styl
+++ b/stylus/settings/breakpoints.styl
@@ -45,7 +45,7 @@ size-helper(direction, size)
     Styleguide Settings.breakpoints.tiny
 */
 tiny-screen(direction='max')
-    @media ({direction}-width: (size-helper(direction, BP-tiny)/basefont)rem)
+    @media ({direction}-width: rem(size-helper(direction, BP-tiny)))
         {block}
 
 /*
@@ -59,7 +59,7 @@ tiny-screen(direction='max')
     Styleguide Settings.breakpoints.small
 */
 small-screen(direction='max')
-    @media ({direction}-width: (size-helper(direction, BP-small)/basefont)rem)
+    @media ({direction}-width: rem(size-helper(direction, BP-small)))
         {block}
 
 /*
@@ -73,7 +73,7 @@ small-screen(direction='max')
     Styleguide Settings.breakpoints.medium
 */
 medium-screen(direction='max')
-    @media ({direction}-width: (size-helper(direction, BP-medium)/basefont)rem)
+    @media ({direction}-width: rem(size-helper(direction, BP-medium)))
         {block}
 
 /*
@@ -87,7 +87,7 @@ medium-screen(direction='max')
     Styleguide Settings.breakpoints.large
 */
 large-screen(direction='max')
-    @media ({direction}-width: (size-helper(direction, BP-large)/basefont)rem)
+    @media ({direction}-width: rem(size-helper(direction, BP-large)))
         {block}
 
 /*
@@ -101,7 +101,7 @@ large-screen(direction='max')
     Styleguide Settings.breakpoints.extra-large
 */
 extra-large-screen(direction='max')
-    @media ({direction}-width: (size-helper(direction, BP-extra-large)/basefont)rem)
+    @media ({direction}-width: rem(size-helper(direction, BP-extra-large)))
         {block}
 
 // mixins named
@@ -116,7 +116,7 @@ extra-large-screen(direction='max')
     Styleguide Settings.breakpoints.desktop
 */
 desktop()
-    @media (min-width: (size-helper('min', BP-medium)/basefont)rem)
+    @media (min-width: rem(size-helper('min', BP-medium)))
         {block}
 
 /*
@@ -129,7 +129,7 @@ desktop()
     Styleguide Settings.breakpoints.tablet
 */
 tablet()
-    @media (min-width: (size-helper('min', BP-small)/basefont)rem) and (max-width: (size-helper('max', BP-medium)/basefont)rem)
+    @media (min-width: rem(size-helper('min', BP-small))) and (max-width: rem(size-helper('max', BP-medium)))
         {block}
 
 /*
@@ -155,7 +155,7 @@ mobile()
     Styleguide Settings.breakpoints.gt-mobile
 */
 gt-mobile()
-    @media (min-width: (size-helper('min', BP-small)/basefont)rem)
+    @media (min-width: rem(size-helper('min', BP-small)))
         {block}
 
 /*
@@ -168,7 +168,7 @@ gt-mobile()
     Styleguide Settings.breakpoints.gt-tablet
 */
 gt-tablet()
-    @media (min-width: (size-helper('min', BP-medium)/basefont)rem)
+    @media (min-width: rem(size-helper('min', BP-medium)))
         {block}
 
 /*

--- a/stylus/settings/icons.styl
+++ b/stylus/settings/icons.styl
@@ -1,4 +1,5 @@
 @require '../generic/animations'
+@require '../tools/mixins'
 
 /*------------------------------------*\
   Icons
@@ -20,7 +21,7 @@ $icon
     content              ''
     display              inline-block
     vertical-align       middle
-    margin-left          .5em
+    margin-left          rem(8)
     background-position  center
     background-repeat    no-repeat
     background-size      cover
@@ -49,28 +50,28 @@ $icon
     Styleguide Settings.icons.sizes
 */
 $icon-8
-    width   .5rem // 8px
-    height  .5rem
+    width   rem(8)
+    height  rem(8)
 
 $icon-12
-    width   .75rem // 12px
-    height  .75rem
+    width   rem(12)
+    height  rem(12)
 
 $icon-16
-    width   1rem // 16px
-    height  1rem
+    width   rem(16)
+    height  rem(16)
 
 $icon-24
-    width   1.5rem // 24px
-    height  1.5rem
+    width   rem(24)
+    height  rem(24)
 
 $icon-36
-    width   2.25rem // 36px
-    height  2.25rem
+    width   rem(36)
+    height  rem(36)
 
 $icon-80
-    width   5rem // 80px
-    height  5rem
+    width   rem(80)
+    height  rem(80)
 
 
 /*------------------------------------*\

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -26,11 +26,39 @@ use('../scripts/split.js')
 use('../scripts/deprecate.js')
 // @stylint on
 
+// Default Font-size
+$basefont ?= 16px
 
-// We need a base font-size for _px to em_ computation. We assume those size to
-// be 16px (as default desktop browsers), but it really don't care as well as
-// all relative units should be expressed in `em`
-basefont = 16px
+rem($value, $base = $basefont)
+    $max = length($value)
+
+    $remValues = ()
+    for $i in (0...$max)
+        push($remValues, _convert-to-rem($value[$i], $base))
+
+    return $remValues
+
+_convert-to-rem($px, $base)
+    if (typeof($px) == 'unit')
+        if ((unit($px) == '' || unit($px) == 'px') && ($px != 0))
+            return (round($px / $base, 3))rem
+        else
+            return 0
+
+/*
+    rem($value, $basefont)
+
+    rem() takes one or more numeric values in pixel and calculates the rem values from it.
+
+    NB: you don't have to explicitly write the `px` unit.
+
+    $value - The value in pixel you want to translate in rem. For multiple values you can use `rem(14 12)` for shorthand properties such as `margin`. ⚠ Multiples values should be separated by spaces.
+    $basefont - If you need to overwrite the default `$basefont` value of `16`
+
+    Weight: 1
+
+    Styleguide Tools.mixins.rem
+*/
 
 /*
     hide()

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -15,12 +15,12 @@ hidden()
     // @stylint off
     position     absolute !important
     border       0 !important
-    width        1px !important
-    height       1px !important
+    width        rem(1) !important
+    height       rem(1) !important
     overflow     hidden !important
     padding      0 !important
     white-space  nowrap !important
-    clip         rect(1px, 1px, 1px, 1px) !important
+    clip         rect(rem(1), rem(1), rem(1), rem(1)) !important
     clip-path    inset(50%) !important
     // @stylint on
 

--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -1,6 +1,7 @@
 /*------------------------------------*\
   Space utilities
 \*------------------------------------*/
+@require '../tools/mixins'
 
 // @stylint off
 types = {
@@ -9,12 +10,12 @@ types = {
 }
 sizes = {
     '0': 0,
-    'half': .5rem,
-    '1': 1rem,
-    '1-half': 1.5rem,
-    '2': 2rem,
-    '2-half': 2.5rem,
-    '3': 3rem
+    'half': rem(8),
+    '1': rem(16),
+    '1-half': rem(24),
+    '2': rem(32),
+    '2-half': rem(40),
+    '3': rem(48)
 }
 directions = {
     '': all,

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -12,9 +12,9 @@ $error-warning
     &:before
         content         ''
         display         inline-block
-        margin-right    .5rem
-        width           1rem
-        height          .875rem
+        margin-right    rem(8)
+        width           rem(16)
+        height          rem(14)
         background      embedurl('../assets/icons/ui/icon-warning.svg') center center / contain no-repeat
         vertical-align  text-bottom
 


### PR DESCRIPTION
Adding `rem($value, $basefont)` mixin to ease rem calculation.
`$value`: The value in pixel you want to translate in rem. For multiple values you can use `rem(14 12)` for shorthand properties such as `margin`. ⚠ Multiples values should be separated by spaces.
 `$basefont`: If you need to overwrite the default `$basefont` value of `16`

The interesting part to review is [this one](https://github.com/cozy/cozy-ui/compare/master...GoOz:feat/remMixin?expand=1#diff-efc2168eed258d98c3b2ee3aa64e5c04), every other files is just using the mixin.