### PR TITLE
fix: Select box bottom border on fixed element 🐛

### DIFF
--- a/react/SelectBox/SelectBoxWithFixedOptions.jsx
+++ b/react/SelectBox/SelectBoxWithFixedOptions.jsx
@@ -8,6 +8,8 @@ import { silver } from '../../stylus/settings/palette.json'
 const optionPadding = 0.25
 
 const fixedOptionsStyle = {
+  borderBottomLeftRadius: '4px',
+  borderBottomRightRadius: '4px',
   paddingTop: optionPadding + 'rem',
   paddingBottom: optionPadding + 'rem',
   borderTop: `1px solid ${silver}`,

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1108,7 +1108,7 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
                 <!-- /react-text -->
               </div>
             </div>
-            <div style=\\"border-top: 1px solid #D6D8Da; background: white; position: relative;\\"></div>
+            <div style=\\"border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; border-top: 1px solid #D6D8Da; background: white; position: relative;\\"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Radius is now on fixed elements too !

Before | After
-------|------
![capture d ecran 2018-06-13 a 09 15 53](https://user-images.githubusercontent.com/1135513/41336321-3693d0ac-6eec-11e8-8d47-681e50454a47.png) | ![capture d ecran 2018-06-13 a 09 15 34](https://user-images.githubusercontent.com/1135513/41336335-3cf065aa-6eec-11e8-8d92-024c415f11fc.png)
