### PR TITLE
fix: border on table divider

### DIFF
--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -34,7 +34,7 @@ $table-row
     flex 0 0 auto
     height rem(48)
     width 100%
-    border-bottom rem(1) solid silver
+    border-top rem(1) solid silver
 
     &:hover
         background-color paleGrey
@@ -47,6 +47,7 @@ $table-row
 
 $table-row-head
     @extend $table-row
+    border 0
 
     &:hover
         background-color transparent
@@ -99,6 +100,9 @@ $table-divider
         width 100%
         height 100%
         background-color alpha(dodgerBlue, .05)
+
+    & + * // @stylint ignore
+        border 0
 
 
     +small-screen()


### PR DESCRIPTION
There shouldn't be a border between a `table-row` & a `table-divider`.

Preview: https://gooz.github.io/cozy-ui/styleguide/section-components.html#kssref-components-table

Fixes #515 