### PR TITLE
fix: modal width which can exceed the window 🌽

### DIFF
--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -62,6 +62,7 @@ $modal
     position relative
     border-radius .5rem
     max-height 100%
+    max-width 100%
     background-color white
     color charcoalGrey
 


### PR DESCRIPTION
Before | After
-------|------
<img width="295" alt="capture d ecran 2018-06-13 a 12 29 38" src="https://user-images.githubusercontent.com/1135513/41346123-e518c1e6-6f05-11e8-84d8-9310e093ff89.png"> | <img width="293" alt="capture d ecran 2018-06-13 a 12 29 47" src="https://user-images.githubusercontent.com/1135513/41346128-eba852d8-6f05-11e8-9530-0688f8fad6f1.png">

