### PR TITLE
fix: Use % instead of vh unit in modal-wrapper

### DIFF
--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -47,7 +47,7 @@ $modal-wrapper
     align-items center
     box-sizing border-box
     width 100vw
-    height 100vh
+    height 100%
     overflow-y scroll
     padding large-margin
 


### PR DESCRIPTION
Because `100vh` unit **is not** 100% of the viewport's height on mobile devices but more than that and we don't want that behaviour.