### PR TITLE
fix: Allow capital letters in git messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,7 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   parserPreset: parserPreset,
   rules: {
-    'scope-case': [0]
+    'scope-case': [0],
+    'subject-case': [0]
   }
 }


### PR DESCRIPTION
Small fix to allow capital letters anywhere in the git commit message. 
You can actually use lowercase, camelCase, or whatever case you want.