### PR TITLE
Handle width/height in Modal:wq

### DIFF
--- a/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
+++ b/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
@@ -8,6 +8,7 @@ exports[`IntentModal component renders as expected 1`] = `
   crossColor={undefined}
   description={undefined}
   dismissAction={[Function]}
+  height={undefined}
   into={undefined}
   mobileFullscreen={false}
   overflowHidden={true}
@@ -21,6 +22,7 @@ exports[`IntentModal component renders as expected 1`] = `
   size="small"
   spacing={undefined}
   title={undefined}
+  width={undefined}
   wrapperClassName={undefined}
 >
   <IntentIframe

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -131,6 +131,8 @@ class Modal extends Component {
       crossColor,
       into,
       size,
+      height,
+      width,
       spacing,
       mobileFullscreen,
       overlayClassName,
@@ -144,6 +146,7 @@ class Modal extends Component {
       secondaryAction,
       secondaryType
     } = this.props
+    const style = Object.assign({}, height && { height }, width && { width })
     const maybeWrapInPortal = children =>
       into ? <Portal into={into}>{children}</Portal> : children
     return maybeWrapInPortal(
@@ -160,6 +163,7 @@ class Modal extends Component {
               },
               wrapperClassName
             )}
+            style={style}
             onClick={closable && this.handleOutsideClick}
           >
             <div
@@ -237,6 +241,8 @@ Modal.propTypes = {
    to control the rendering destination of the Modal */
   into: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'xxlarge']),
+  height: PropTypes.string,
+  width: PropTypes.string,
   spacing: PropTypes.oneOf(['small', 'large']),
   /** If you want your modal taking all the screen on mobile */
   mobileFullscreen: PropTypes.bool,


### PR DESCRIPTION
Add two new props to the Modal component: `height` and `width`. The need was to be able to customise an interapp Modal.