### PR TITLE
[Do not merge] fix: Only hide action menu on overlay click

### DIFF
--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -124,13 +124,15 @@ class ActionMenu extends Component {
   }
 
   handleMenuRef = menu => {
-    // FIXME
     this.menuNode = ReactDOM.findDOMNode(menu) // eslint-disable-line react/no-find-dom-node
   }
 
   handleWrapperRef = wrapper => {
-    // FIXME
     this.wrapperNode = ReactDOM.findDOMNode(wrapper) // eslint-disable-line react/no-find-dom-node
+  }
+
+  handleOverlayRef = overlay => {
+    this.overlayNode = ReactDOM.findDOMNode(overlay) // eslint-disable-line react/no-find-dom-node
   }
 
   render() {
@@ -143,7 +145,8 @@ class ActionMenu extends Component {
       >
         <Overlay
           style={{ opacity: closing ? 0 : 1 }}
-          onClick={this.animateClose}
+          ref={this.handleOverlayRef}
+          onClick={e => e.target === this.overlayNode && this.animateClose()}
           onEscape={this.animateClose}
         >
           <div className={styles['c-actionmenu']} ref={this.handleMenuRef}>


### PR DESCRIPTION
- What we expect: when single-taping the overlay, the menu disappears.
- What actually happens: tap any menu item — the event bubbles to the overlay and the menu is closed.

I consider this a bug fix, but it's possible that people were relying on this bug to close the menu, intentionally or not. Should be label this as a breaking change? 

In cozy-drive, we're good.
