### PR TITLE
Animated header fixes

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -33,6 +33,20 @@ class ModalContent extends Component {
       : children
   }
 
+  componentWillUpdate() {
+    const { children } = this.props
+    // extract the animated header component
+    this.animatedHeader = React.Children.toArray(children).find(
+      child => child.nodeName === AnimatedContentHeader
+    )
+    this.childrenToRender = this.animatedHeader
+      ? React.Children.map(
+          children,
+          child => (child.nodeName !== AnimatedContentHeader ? child : null)
+        )
+      : children
+  }
+
   componentDidMount() {
     this.scrollingContent.addEventListener('scroll', this.handleScroll, {
       passive: true

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -15,6 +15,19 @@ class AnimatedContentHeader extends Component {
   }
 }
 
+function _getChildrenToRender(children) {
+  return React.Children.map(
+    children,
+    child => (child && child.nodeName !== AnimatedContentHeader ? child : null)
+  )
+}
+
+function _getAnimatedHeader(children) {
+  return React.Children.toArray(children).find(
+    child => child && child.nodeName === AnimatedContentHeader
+  )
+}
+
 class ModalContent extends Component {
   constructor(props) {
     super(props)
@@ -22,28 +35,18 @@ class ModalContent extends Component {
 
     const { children } = this.props
     // extract the animated header component
-    this.animatedHeader = React.Children.toArray(children).find(
-      child => child.nodeName === AnimatedContentHeader
-    )
+    this.animatedHeader = _getAnimatedHeader(children)
     this.childrenToRender = this.animatedHeader
-      ? React.Children.map(
-          children,
-          child => (child.nodeName !== AnimatedContentHeader ? child : null)
-        )
+      ? _getChildrenToRender(children)
       : children
   }
 
   componentWillUpdate() {
     const { children } = this.props
     // extract the animated header component
-    this.animatedHeader = React.Children.toArray(children).find(
-      child => child.nodeName === AnimatedContentHeader
-    )
+    this.animatedHeader = _getAnimatedHeader(children)
     this.childrenToRender = this.animatedHeader
-      ? React.Children.map(
-          children,
-          child => (child.nodeName !== AnimatedContentHeader ? child : null)
-        )
+      ? _getChildrenToRender(children)
       : children
   }
 

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -90,7 +90,7 @@ class ModalContent extends Component {
       >
         {this.animatedHeader && (
           <div
-            className={this.animatedHeader.className}
+            className={this.animatedHeader.attributes.className}
             ref={div => {
               this.contentHeader = div
             }}
@@ -99,9 +99,13 @@ class ModalContent extends Component {
               {this.animatedHeader.children}
             </h2>
             <div
-              className={cx(styles['c-modal-illu-header--ghost'], {
-                [styles['is-active']]: displayGhostHeader
-              })}
+              className={cx(
+                styles['c-modal-illu-header--ghost'],
+                this.animatedHeader.attributes.activeClassName,
+                {
+                  [styles['is-active']]: displayGhostHeader
+                }
+              )}
             >
               {this.animatedHeader.children}
             </div>

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -100,4 +100,4 @@
     @extend $modal--hidden
 
 .c-modal-close--notitle + .c-modal-content
-    margin-top rem(64)
+    margin-top rem(48)

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -127,7 +127,7 @@ $modal-header-icon--ghost
     position absolute
     left 0
     right 0
-    top rem(24)
+    top rem(16)
     margin rem(8) 0
     opacity 0
     max-height rem(32)
@@ -137,7 +137,7 @@ $modal-header-icon--ghost
         max-height inherit
 
 $modal-header-icon--ghost-active
-    top rem(8)
+    top 0
     opacity 1
     transition opacity 150ms 50ms ease-in, top 150ms ease-in
 
@@ -270,8 +270,8 @@ $modal-close--large
         right rem(24)
 
 $modal-close--notitle
-    top rem(12)
-    right rem(12)
+    top rem(6)
+    right rem(6)
 
 $modal--hidden
     overflow hidden


### PR DESCRIPTION
Global modal fixes to better handle animated header

* Issue on ModalComponent component udpdate
* Class handling with `activeClassName`
* header size was 4rem instead of 3rem
* Fix issue when undefined child provided in ModalContent