### PR TITLE
fix: layout overflowing on tablet and smaller

### DIFF
--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -47,7 +47,7 @@ body
     overflow-y  auto
 
     +medium-screen()
-        overflow-y visible
+        overflow visible
 
 // COLORS
 html,


### PR DESCRIPTION
Fix a layout issue on menu that occured when the content is not long enough on tablet.

![before](https://user-images.githubusercontent.com/1280069/43407910-455a689a-9420-11e8-80fc-351f1cb0f43b.png)