### PR TITLE
perf: no usage/code in styleguide

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -92,8 +92,8 @@ module.exports = {
     path.join(__dirname, './style.styl'),
     path.join(__dirname, './styleguide.setup')
   ],
-  showCode: true,
-  showUsage: true,
+  showCode: false,
+  showUsage: false,
   context: {
     utils: path.resolve(__dirname, 'utils'),
     isTesting: path.resolve(__dirname, 'false'),


### PR DESCRIPTION
Since we start to have a lot components in the styleguide, it takes
a lot of time to load. Not showing code blocks simplifies greatly
the loading and feels much smoother.