### PR TITLE
Revert "Add t or nothing helper in I18n", already handled by t()

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -30,11 +30,6 @@ export class I18n extends Component {
   getChildContext() {
     return {
       t: this.translation.t.bind(this.translation),
-      tn: (key, options, fallback = null) => {
-        return this.translation.has(key)
-          ? this.translation.t(key, options)
-          : fallback || ''
-      },
       f: this.format,
       lang: this.props.lang
     }
@@ -77,7 +72,6 @@ export const translate = () => WrappedComponent => {
     <WrappedComponent
       {...props}
       t={context.t}
-      tn={context.tn}
       f={context.f}
       lang={context.lang}
     />


### PR DESCRIPTION
Reverts cozy/cozy-ui#581

Finally the needed feature is now handled by `t` using the `{ _: ""}` option.
See the [`t()` documentation](http://airbnb.io/polyglot.js/#polyglotprototypetkey-interpolationoptions) :

> If you like, you can provide a default value in case the phrase is missing. Use the special option key “_” to specify a default.