### PR TITLE
Check for animated header for scrolling event

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -64,6 +64,7 @@ class ModalContent extends Component {
   }
 
   handleScroll = () => {
+    if (!this.contentHeader) return
     const { headerHeight } = this
     if (!headerHeight && this.contentHeader.clientHeight) {
       this.headerHeight = this.contentHeader.clientHeight


### PR DESCRIPTION
It doesn't broke the modal but we have an error in the console saying that the contentHeader doesn't exist if we don't use the animated header here.