### PR TITLE
feat: Make Button component more accessible

### DIFF
--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -88,12 +88,13 @@ const { Button, ButtonLink } = require('./index');
 #### Create a button with an icon
 
 The color of the icon is taken care of by the button style, there's no need to specify it.
+If you want a button with only an icon as content, you must set the `iconOnly` prop.
 
 ```
 const { Button } = require('./index');
 <div>
   <Button theme="danger" icon='delete' label='delete' />
-  <Button theme="secondary" icon='dots' extension='narrow' />
+  <Button theme="secondary" icon='dots' iconOnly label="See more" extension='narrow' />
 </div>
 ```
 
@@ -111,8 +112,8 @@ const { Button } = require('./index');
 ```
 const { Button } = require('.');
 <div>
-  <Button icon='plus' round />
-  <Button theme="secondary" icon='cross' round />
+  <Button icon='plus' label='Add' iconOnly round />
+  <Button theme="secondary" icon='cross' label='Delete' iconOnly round />
 </div>
 ```
 

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -42,6 +42,7 @@ const BaseButton = props => {
   const {
     children,
     icon,
+    iconOnly,
     label,
     subtle,
     className,
@@ -54,6 +55,9 @@ const BaseButton = props => {
   } = props
 
   const transformProps = tagToTransformProps[Tag] || identity
+  const tooltip = iconOnly ? label : null
+  const iconOnlyClass = iconOnly ? 'u-visuallyhidden' : null
+
   return (
     <Tag
       {...transformProps(restProps)}
@@ -65,10 +69,15 @@ const BaseButton = props => {
         className,
         variant: subtle && 'subtle'
       })}
+      title={tooltip}
     >
       <span>
-        {Icon.isProperIcon(icon) ? <Icon icon={icon} /> : icon}
-        {label && <span>{label}</span>}
+        {Icon.isProperIcon(icon) ? (
+          <Icon icon={icon} aria-hidden focusable="false" />
+        ) : (
+          icon
+        )}
+        {label && <span className={iconOnlyClass}>{label}</span>}
         {children}
       </span>
     </Tag>
@@ -97,9 +106,11 @@ Button.propTypes = {
   /** DEPRECATED: please use label and icon */
   children: PropTypes.node,
   /** Label of the button */
-  label: PropTypes.node,
+  label: PropTypes.node.isRequired,
   /** Icon of the button */
   icon: PropTypes.node,
+  /** Displays only the icon, not the label */
+  iconOnly: PropTypes.bool,
   theme: PropTypes.string,
   size: PropTypes.oneOf(['tiny', 'small', 'large']),
   /** Spacing of the button */

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -252,9 +252,10 @@ exports[`Button should render examples: Button 8`] = `
 "<div>
   <div>
     <div>
-      <button type=\\"submit\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
+      <button type=\\"submit\\" class=\\"c-btn c-btn--danger\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>delete</span></span>
       </button>
-      <button type=\\"submit\\" class=\\"c-btn c-btn--secondary c-btn--narrow\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></button>
+      <button type=\\"submit\\" class=\\"c-btn c-btn--secondary c-btn--narrow\\" title=\\"See more\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span class=\\"u-visuallyhidden\\">See more</span></span>
+      </button>
     </div>
   </div>
 </div>"
@@ -275,8 +276,10 @@ exports[`Button should render examples: Button 10`] = `
 "<div>
   <div>
     <div>
-      <button type=\\"submit\\" class=\\"c-btn c-btn--round\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></button>
-      <button type=\\"submit\\" class=\\"c-btn c-btn--secondary c-btn--round\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg></span></button>
+      <button type=\\"submit\\" class=\\"c-btn c-btn--round\\" title=\\"Add\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span class=\\"u-visuallyhidden\\">Add</span></span>
+      </button>
+      <button type=\\"submit\\" class=\\"c-btn c-btn--secondary c-btn--round\\" title=\\"Delete\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span class=\\"u-visuallyhidden\\">Delete</span></span>
+      </button>
     </div>
   </div>
 </div>"
@@ -319,7 +322,7 @@ exports[`Button should render examples: Button 11`] = `
         </button>
       </p>
       <p>
-        <button type=\\"submit\\" class=\\"c-btn c-btn--subtle\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>Cozy</span></span>
+        <button type=\\"submit\\" class=\\"c-btn c-btn--subtle\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>Cozy</span></span>
         </button>
       </p>
     </div>
@@ -348,7 +351,7 @@ exports[`Button should render examples: Button 12`] = `
         </a>
       </p>
       <p>
-        <a href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--subtle\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>Link to Cozy.io</span></span>
+        <a href=\\"https://cozy.io\\" target=\\"_blank\\" class=\\"c-btn c-btn--subtle\\"><span><svg class=\\"icon\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"test-file-stub\\"></use></svg><span>Link to Cozy.io</span></span>
         </a>
       </p>
     </div>

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -73,10 +73,9 @@ $button
 
     svg
         fill         currentColor
-        margin-right rem(6)
 
-        &:only-child
-            margin 0
+        & + span
+            margin-left rem(6)
 
     input
         cursor pointer
@@ -152,9 +151,6 @@ $button--action
     padding rem(8)
     opacity     .5
 
-    svg
-        margin 0
-
     &:active
     &:hover
     &:focus
@@ -165,9 +161,6 @@ $button--close
     @extend $button--alpha
     border-color transparent
     padding rem(8)
-
-    svg
-        margin 0
 
     &:active
     &:hover
@@ -374,9 +367,6 @@ $actionbtn--compact
     > span
         justify-content center
 
-    svg
-        margin 0
-
     [data-action='label']
         @extend $hide
 
@@ -471,13 +461,6 @@ $button-subtle
     font-size rem(14)
     font-weight bold
     text-transform uppercase
-
-    svg
-        fill         currentColor
-        margin-right rem(6)
-
-        &:only-child
-            margin 0
 
     > span
         display          flex

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -33,7 +33,6 @@ $visuallyhidden
         hidden()
 
 $hide
-[aria-hidden=true]
     hide()
 
 $hide--mob


### PR DESCRIPTION
Refs  #601

**BREAKING CHANGE:**
- `label` props is now required
- `iconOnly` props is required if you want to get a button with only an icon

So allow me to explain a little bit.

### What we need

We need buttons to always, in any way, display a label explicitely describing what the actions of the button does.

### How to do it
There's two cases when you consider having an icon in your button, and either way the icon must be hidden with `aria-hidden` set to `true`, but there's some differences:
1. The Icon is with a text. Nothing special to do here. It's like before. 
2. The Icon is on its own. In this case, as the icon is hidden, we must add some label for screen readers by using the same DOM for a normal button except we're hiding it visually; then you should also have a `title` on your button so people that don't recognize the icon can read the tooltip by hovering it and understand what the action does. Also, as the `label` is always needed and therefore mandatory, we have no way of knowing when we want to display a button with only an icon, hence the addition of the `iconOnly` props.

I couldn't find another way to achieve that. If any of you has another suggestion, I'm all ears.
