### PR TITLE
Fix use of CozyClient in AppIcon documentation

### DIFF
--- a/react/AppIcon/Readme.md
+++ b/react/AppIcon/Readme.md
@@ -1,15 +1,10 @@
-`<AppIcon />` loads asynchronously an app's icon directly from the stack. The stack returns the icon as a blob.
+`<AppIcon />` uses a `fetchIcon` prop to load asynchronously an app icon.
 
-This component needs to be encapsulated into a `<CozyProvider />` component, see [Cozy Client documentation](https://github.com/cozy/cozy-client/blob/master/README.md#creating-a-provider).
-
-It uses the `client` object provided by the `context`.
-
+## Example with a fake instance of cozyClient
 ```
-<CozyProvider client={cozyClient} />
   <div>
     <p>
-      <AppIcon app={app} />
+      <AppIcon app={app} fetchIcon={() => client.fetch(...)} />
     </p>
   </div>
-</CozyProvider>
 ```


### PR DESCRIPTION
The first implementation of the component was using directly an instance of CozyClient, but in the final version it only needs a `fetchIcon` method.