### PR TITLE
Catch context locales missing error

### DIFF
--- a/react/I18n/translation.jsx
+++ b/react/I18n/translation.jsx
@@ -27,8 +27,12 @@ export const initTranslation = (
 
   // Load context locales
   if (context) {
-    const dict = dictRequire(lang, context)
-    _polyglot.extend(dict)
+    try {
+      const dict = dictRequire(lang, context)
+      _polyglot.extend(dict)
+    } catch (e) {
+      console.warn(`The context ${context} cannot be loaded for lang ${lang}`)
+    }
   }
 
   return _polyglot


### PR DESCRIPTION
Since `cozy-home` is using context with the `I18n` component, a missing locales file was not caught correctly and was breaking the whole application (blank page).
It should be fixed by this PR.