### PR TITLE
fix(Modal): 💄 Modal width 100% on small screens

### DIFF
--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -73,7 +73,7 @@ for size in 'small' 'medium' 'large' 'xlarge' 'xxlarge'
 
         $max-width=lookup(size + '-width') + lookup(size + '-margin') * 2
         @media (max-width: $max-width)
-            width auto
+            width 100%
 
 $modal-wrapper--fullscreen
     +small-screen()


### PR DESCRIPTION
Even if the content of a Modal is not long enough, a Modal will take 100% of the available space until it reaches its own max width

Fixes #490

