### PR TITLE
Avoid conflict with c-app-icon

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -170,7 +170,9 @@ const ModalHeader = ({
       {isTitle ? <h2>{children}</h2> : children}
       {appName && (
         <h2 className={styles['c-modal-app']}>
-          {appIcon && <img className={styles['c-app-icon']} src={appIcon} />}
+          {appIcon && (
+            <img className={styles['c-modal-app-icon']} src={appIcon} />
+          )}
           {appEditor && (
             <span className={styles['c-app-editor']}>{appEditor}&nbsp;</span>
           )}

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -59,7 +59,7 @@
 .c-app-editor
     @extend $modal-header-app-editor
 
-.c-app-icon
+.c-modal-app-icon
     @extend $modal-header-app-icon
 
 .c-modal-footer


### PR DESCRIPTION
`c-app-icon` class used in Modal was causing conflict issue and visual regression on cozy-home and bar.

Surprisingly, this issue just appeared recently, and everything was working well at the date of the different commits related to this bug.

![capture d ecran 2018-09-26 a 18 39 51](https://user-images.githubusercontent.com/776764/46095054-e59b3780-c1bb-11e8-88d8-ffc4641290f6.png)
