### PR TITLE
Prevent flex side effects

### DIFF
--- a/react/AppIcon/styles.styl
+++ b/react/AppIcon/styles.styl
@@ -26,6 +26,9 @@
 .c-app-icon svg {
     height 100%
     width 100%
+    // Prevent flex-grow and flex-shrink
+    flex-grow 0
+    flex-shrink 0
 }
 
 .c-app-icon-default {


### PR DESCRIPTION
The goal is to ensure that App icons are keeping their dimensions, even in a flex context.

This also fix this litte gap between labels in the cozy-bar.

![capture d ecran 2018-09-27 a 17 09 05](https://user-images.githubusercontent.com/776764/46155718-3cfedd80-c278-11e8-9e51-c77809b6f98e.png)
