### PR TITLE
fix: Alerter not compatible with React

### DIFF
--- a/react/Alerter/index.jsx
+++ b/react/Alerter/index.jsx
@@ -70,6 +70,7 @@ class Alert extends Component {
     const { hidden } = this.state
     return (
       <div
+        ref={c => (this.base = c)}
         className={classNames(
           styles['c-alert'],
           hidden ? styles['c-alert--hidden'] : ''


### PR DESCRIPTION
this.base is specific to Preact and was undefined with React
