### PR TITLE
fix(MenuButton): Hover background

### DIFF
--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -37,7 +37,7 @@
 .c-menu__btn:not([disabled]):not([aria-disabled=true]):hover
 .c-menu__btn:not([disabled]):not([aria-disabled=true]):active
 .c-menu__btn:not([disabled]):not([aria-disabled=true]):focus
-    background transparent
+    background-color transparent
 
 $paddingItem = rem(8)
 


### PR DESCRIPTION
Reseting the complete background property means you also loose any background images, positions, etc. Which isn't what we want.