### PR TITLE
fix(Menu): Added padding

### DIFF
--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -12,6 +12,7 @@
     position   absolute
     margin     0
     margin-top rem(1)
+    padding rem(8 0)
     min-width  rem(220)
     // cuts the hover background properly (border-radius)
     overflow   hidden


### PR DESCRIPTION
No big deal, it will only affect every menu out there.

But seriously, talked this over with @Claiw today — `MenuItems` need a but of breathing room at the top and the bottoms of list, so this should become the new normal.