### PR TITLE
fix(Portal): Import the main module

### DIFF
--- a/react/Portal/index.jsx
+++ b/react/Portal/index.jsx
@@ -6,7 +6,7 @@ if (process.env.USE_REACT) {
     return ReactDOM.createPortal(children, targetElement)
   }
 } else {
-  Portal = require('preact-portal').default
+  Portal = require('preact-portal')
 }
 
 export default Portal


### PR DESCRIPTION
@CPatchane I wouldn't mind a second check for this PR — for me, `require('preact-portal')` gives me the module right away, whereas `require('preact-portal').default` returns `undefined`.

(The alerts still worked but weren't portal anymore.)