### PR TITLE
fix: Make tabs work with React

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -64,7 +64,8 @@ module.exports = {
       name: 'Navigation',
       components: () => [
         '../react/ActionMenu/index.jsx',
-        '../react/Menu/index.jsx'
+        '../react/Menu/index.jsx',
+        '../react/Tabs/index.jsx'
       ]
     },
     {

--- a/react/Tabs/Readme.md
+++ b/react/Tabs/Readme.md
@@ -1,0 +1,23 @@
+
+```
+const { Tabs, TabList, Tab, TabPanels, TabPanel } = require('.');
+
+<Tabs initialActiveTab='general'>
+  <TabList>
+    <Tab name='general'>General</Tab>
+    <Tab name='details'>Details</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel name='general'>
+      Grace Murray Hopper, née le 9 décembre 1906 à New York et morte le 1er janvier 1992 dans le comté d'Arlington, est une informaticienne américaine et Rear admiral (lower half) de la marine américaine. Elle est la conceptrice du premier compilateur en 1951 (A-0 System) et du langage COBOL en 1959.
+    </TabPanel>
+    <TabPanel name='details'>
+      <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non, soluta. Voluptas ipsa ullam a totam veniam itaque, iusto ducimus, sequi eveniet debitis recusandae incidunt, fugiat architecto et distinctio, optio! Deserunt.</div>
+      <div>Velit neque, repellendus explicabo voluptates veritatis itaque saepe nemo et! Impedit veniam, voluptates. Aliquid laborum voluptate, non commodi magnam, soluta perferendis sapiente nemo harum, eligendi saepe beatae cum quam fugiat.</div>
+      <div>Quam tempora, similique pariatur, vitae atque ducimus. Quidem tempore, nulla est. Dolor quisquam quia placeat molestiae, nulla beatae voluptatem labore sit mollitia repudiandae animi iure maxime maiores quidem delectus ad.</div>
+      <div>Iste reiciendis reprehenderit et similique, rem. Architecto quasi debitis hic, voluptatum in possimus soluta sit, praesentium nisi provident pariatur culpa mollitia repellendus earum reiciendis animi. Sunt voluptates, assumenda esse perspiciatis.</div>
+      <div>Alias quae sequi aliquid sed, nobis veniam magnam rerum amet velit dignissimos dicta a dolorem! Dolorem soluta perferendis error, voluptate dolorum quas, fuga ad repellendus tenetur amet sit assumenda dignissimos.</div>
+    </TabPanel>
+  </TabPanels>
+</Tabs>
+```

--- a/react/Tabs/index.jsx
+++ b/react/Tabs/index.jsx
@@ -78,9 +78,7 @@ export class Tabs extends Component {
   constructor(props) {
     super(props)
     this.changeTab = this.changeTab.bind(this)
-  }
-  getInitialState() {
-    return { activeTab: this.props.initialActiveTab }
+    this.state = { activeTab: props.initialActiveTab }
   }
 
   changeTab(tabName) {


### PR DESCRIPTION
`getInitialState` does not work in newer versions of React. Replaced with state in constructor. Added example.