### PR TITLE
fix(Alerts): Default cursor

### DIFF
--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -19,7 +19,7 @@ $alert
     color white
     opacity 1
     transition transform .2s ease-out, opacity .2s ease-out
-    cursor pointer
+    cursor default
     pointer-events none
 
     @media all and (min-width alert-width)


### PR DESCRIPTION
Alert messages are not clickable, so the cursor here was wrong.