### PR TITLE
[WIP] feat: Add Tooltip component

### DIFF
--- a/react/Popover/Popover.jsx
+++ b/react/Popover/Popover.jsx
@@ -8,7 +8,8 @@ export default class Popover extends Component {
     this.defaultStyle = {
       display: 'block',
       visibility: 'hidden',
-      position: 'fixed'
+      position: 'fixed',
+      zIndex: 100
     }
   }
 
@@ -25,16 +26,28 @@ export default class Popover extends Component {
     const menuElement = domItem.parentNode
     const scrollTop = getScrollParent(menuElement)
     const coordinates = menuElement.getBoundingClientRect()
-
     // If we have don't have enough space => maths
     const hasNotEnoughSpace =
       domItemCoordinates.bottom - scrollTop > window.innerHeight
+    let left = ''
+    switch (this.props.align) {
+      case 'center':
+        left =
+          coordinates.left +
+          coordinates.width / 2 -
+          domItemCoordinates.width / 2
+        break
+      case 'right':
+      default:
+        left = coordinates.left + coordinates.width - domItemCoordinates.width
+        break
+    }
     this.setState({
       style: {
         top: hasNotEnoughSpace
           ? coordinates.top - domItemCoordinates.height
           : coordinates.top + coordinates.height,
-        left: coordinates.left + coordinates.width - domItemCoordinates.width,
+        left: left,
         visibility: 'visible'
       }
     })
@@ -50,7 +63,7 @@ export default class Popover extends Component {
         }}
         className={this.props.className}
       >
-        {this.props.children}
+        {this.props.children(!this.state.hasNotEnoughSpace)}
       </div>
     )
   }
@@ -58,10 +71,12 @@ export default class Popover extends Component {
 
 Popover.defaultProps = {
   style: {},
-  className: {}
+  className: {},
+  align: ''
 }
 
 Popover.propTypes = {
   style: PropTypes.object,
-  className: PropTypes.string
+  className: PropTypes.string,
+  align: PropTypes.oneOf(['center', 'right'])
 }

--- a/react/Tooltip/index.jsx
+++ b/react/Tooltip/index.jsx
@@ -1,0 +1,38 @@
+import React, { Component } from 'react'
+import Popover from '../Popover'
+import styles from './styles.styl'
+import cx from 'classnames'
+class Tooltip extends Component {
+  state = { open: false }
+  onMouseEnter = () => {
+    this.setState({ open: true })
+  }
+  onMouseLeave = () => {
+    this.setState({ open: false })
+  }
+  render() {
+    return (
+      <div onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+        {this.state.open && (
+          <Popover align={'center'}>
+            {displayedBellow => (
+              <div
+                className={cx(styles['tooltip-buble'], {
+                  [styles['tooltip-top']]: displayedBellow,
+                  [styles['tooltip-bottom']]: !displayedBellow
+                })}
+              >
+                <div className={styles['tooltip-message']}>
+                  {this.props.title}
+                </div>
+              </div>
+            )}
+          </Popover>
+        )}
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+export default Tooltip

--- a/react/Tooltip/styles.styl
+++ b/react/Tooltip/styles.styl
@@ -1,0 +1,41 @@
+.tooltip-buble {
+  z-index: 10;
+  cursor: pointer
+
+  &::after {
+      content: ''
+      position: absolute
+  }
+}
+.tooltip-top {
+  padding-top: 8px;
+  
+  &::after {
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-bottom: 8px solid rgba(0,0,0,.7);
+    top: 0;
+    left: calc(50% - 8px);
+  }
+}
+
+.tooltip-bottom {
+  padding-bottom: 8px;
+  
+  &::after {
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 8px solid rgba(0,0,0,.7);
+    top: 0;
+    left: calc(50% - 8px);
+  }
+}
+
+.tooltip-message 
+  background: rgba(0,0,0,.7)
+  border-radius: 3px;
+  color: #fff
+  font-size: .75rem;
+  line-height: 1.4;
+  padding: .75em;
+  text-align: center;

--- a/react/index.js
+++ b/react/index.js
@@ -60,3 +60,4 @@ export {
 } from './Text'
 export { default as Empty } from './Empty'
 export { default as ContextHeader } from './ContextHeader'
+export { default as Tooltip } from './Tooltip'


### PR DESCRIPTION
Added `<Tooltip>` component based on `Popover` component.

I'm using it this way in Drive : 
```jsx 
export const Avatar = props => {
  return (
    <Tooltip title={props.textId}>
      <CozyUIAvatar {...props} className={styles['recipient-avatar']} />
    </Tooltip>
  )
}
```
