### PR TITLE
fix(Overlay): Use lib to lock scroll

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -9,7 +9,6 @@ import migrateProps from '../helpers/migrateProps'
 import palette from '../../stylus/settings/palette.json'
 import Portal from '../Portal'
 import uniqueId from 'lodash/uniqueId'
-import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 class AnimatedContentHeader extends Component {
   render() {
@@ -63,13 +62,11 @@ class ModalContent extends Component {
     this.scrollingContent.addEventListener('scroll', this.handleScroll, {
       passive: true
     })
-    disableBodyScroll(this.scrollingContent)
     document.body.classList.add('has-modal')
   }
 
   componentWillUnmount() {
     this.scrollingContent.removeEventListener('scroll', this.handleScroll)
-    clearAllBodyScrollLocks()
     document.body.classList.remove('has-modal')
   }
 

--- a/react/Overlay/index.jsx
+++ b/react/Overlay/index.jsx
@@ -3,14 +3,7 @@ import styles from './styles.styl'
 import cx from 'classnames'
 import omit from 'lodash/omit'
 import PropTypes from 'prop-types'
-
-const disableScroll = node => {
-  const previousOverflow = node.style.overflow
-  node.style.overflow = 'hidden'
-  return () => {
-    node.style.overflow = previousOverflow
-  }
-}
+import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 const ESC_KEYCODE = 27
 
@@ -29,8 +22,8 @@ const bodyTallerThanWindow = () => {
 class Overlay extends Component {
   componentDidMount() {
     if (bodyTallerThanWindow()) {
-      this.restoreScrollBody = disableScroll(document.body)
-      this.restoreScrollHtml = disableScroll(document.body.parentNode)
+      disableBodyScroll(document.body)
+      disableBodyScroll(document.body.parentNode)
     }
     if (this.props.onEscape) {
       document.addEventListener('keydown', this.handleKeydown)
@@ -46,8 +39,7 @@ class Overlay extends Component {
   componentWillUnmount() {
     // restauration function can be undefined if there was
     // an error during mounting/rendering
-    this.restoreScrollBody && this.restoreScrollBody()
-    this.restoreScrollBody && this.restoreScrollHtml()
+    clearAllBodyScrollLocks()
     if (this.props.onEscape) {
       document.removeEventListener('keydown', this.handleKeydown)
     }


### PR DESCRIPTION
Using the Overlay component to open a modal would result in the page being scroll-locked, because `body-scroll-lock` would restore the `overflow` property to `hidden` when the Modal closes, as set in the Overlay.
Using the lib in both cases fixes the issue.