### PR TITLE
feat: Counter component

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -32,7 +32,8 @@ module.exports = {
       components: () => [
         '../react/Layout/Layout.jsx',
         '../react/Hero/index.jsx',
-        '../react/Sidebar/index.jsx'
+        '../react/Sidebar/index.jsx',
+        '../react/Circle/index.jsx'
       ]
     },
     {

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -11,7 +11,8 @@ module.exports = {
         '../react/ButtonAction/index.jsx',
         '../react/Chip/index.jsx',
         '../react/Icon/index.jsx',
-        '../react/Spinner/index.jsx'
+        '../react/Spinner/index.jsx',
+        '../react/Counter/index.jsx'
       ]
     },
     {

--- a/react/Circle/Readme.md
+++ b/react/Circle/Readme.md
@@ -1,0 +1,11 @@
+Displays a simple circle with some text inside of it.
+
+### Default
+
+```
+<div >
+  <Circle>
+    yo
+  </Circle>
+</div>
+```

--- a/react/Circle/index.jsx
+++ b/react/Circle/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import styles from './styles.styl'
+
+const Circle = ({ children, backgroundColor, size, className }) => {
+  return (
+    <div
+      className={cx(
+        styles['c-circle'],
+        {
+          [styles[`c-circle--${size}`]]: size
+        },
+        className
+      )}
+      style={{ backgroundColor }}
+    >
+      <span className={styles['c-circle-text']}>{children}</span>
+    </div>
+  )
+}
+
+Circle.propTypes = {
+  backgroundColor: PropTypes.string,
+  size: PropTypes.oneOf(['medium']),
+  className: PropTypes.string
+}
+
+Circle.defaultProps = {
+  size: 'medium',
+  className: ''
+}
+
+export default Circle

--- a/react/Circle/styles.styl
+++ b/react/Circle/styles.styl
@@ -1,0 +1,10 @@
+@require '../../stylus/components/circle'
+
+.c-circle
+    @extend $circle
+
+.c-circle--medium
+    @extend $circle--medium
+
+.c-circle-text
+    @extend $circle-text

--- a/react/Counter/Readme.md
+++ b/react/Counter/Readme.md
@@ -1,0 +1,19 @@
+A simple way to show how many *things* there are.
+
+### Default
+
+```
+<div >
+  <Counter count={42} />
+</div>
+```
+
+### Maxed out
+
+Above a certain number, an approximation is displayed. The default treshold is 99.
+
+```
+<div >
+  <Counter count={14} max={5} />
+</div>
+```

--- a/react/Counter/index.jsx
+++ b/react/Counter/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Counter = ({ count, max }) => (
+  <span>{count > max ? `${max}+` : count}</span>
+)
+
+Counter.propTypes = {
+  count: PropTypes.number,
+  max: PropTypes.number
+}
+
+Counter.defaultProps = {
+  count: 0,
+  max: 99
+}
+
+export default Counter

--- a/react/index.js
+++ b/react/index.js
@@ -60,3 +60,4 @@ export {
 } from './Text'
 export { default as Empty } from './Empty'
 export { default as ContextHeader } from './ContextHeader'
+export { default as Circle } from './Circle'

--- a/react/index.js
+++ b/react/index.js
@@ -61,3 +61,4 @@ export {
 export { default as Empty } from './Empty'
 export { default as ContextHeader } from './ContextHeader'
 export { default as Circle } from './Circle'
+export { default as Counter } from './Counter'

--- a/stylus/components/circle.styl
+++ b/stylus/components/circle.styl
@@ -1,0 +1,20 @@
+@require '../settings/palette'
+@require '../tools/mixins'
+
+$circle
+    display inline-flex
+    align-items center
+    justify-content center
+    border-radius 50%
+    overflow hidden
+    background-color dodgerBlue
+    color white
+
+$circle--medium
+    width rem(40)
+    height rem(40)
+    font-size rem(20)
+
+$circle-text
+    font-weight bold
+    line-height 1


### PR DESCRIPTION
A new component to show a simple counter. [Here's a link to the demo and the docs!](https://yannick-lohse.fr/cozy-ui/react/#counter)

There are potentially more things that could be done, like coupling the `max` and the `size` properties, an easier way to change the font color, etc. I don't really know what the needs are at the moment, so I think we can expand it later, but le me know if you think something essential is missing.

There's only one size for now — I think we'll be using the same ones as in #650 once it's settled.

