### PR TITLE
feat(ContextHeader): Allow any illustration

### DIFF
--- a/react/ContextHeader/Readme.md
+++ b/react/ContextHeader/Readme.md
@@ -12,7 +12,7 @@ A little inset with text and optional icon that can be used to provide some cont
 
 ```
 <div >
-  <ContextHeader title="Pick a book" text="What will you read today?" icon="album" />
+  <ContextHeader title="Pick a book" text="What will you read today?" illustration={<Icon icon="album" size={32} />} />
 </div>
 ```
 
@@ -20,6 +20,6 @@ A little inset with text and optional icon that can be used to provide some cont
 
 ```
 <div >
-  <ContextHeader title="Pick a book" text="What will you read today?" icon="album" onClose={() => alert('Nothing then.')} />
+  <ContextHeader title="Pick a book" text="What will you read today?" illustration={<Icon icon="album" size={32} />} onClose={() => alert('Nothing then.')} />
 </div>
 ```

--- a/react/ContextHeader/index.jsx
+++ b/react/ContextHeader/index.jsx
@@ -7,10 +7,14 @@ import styles from './styles.styl'
 import palette from '../../stylus/settings/palette.json'
 import cx from 'classnames'
 
-const ContextHeader = ({ icon, title, text, onClose, className }) => {
+const ContextHeader = ({ illustration, title, text, onClose, className }) => {
   return (
     <div className={cx(styles['context-header'], className)}>
-      {icon && <Icon className={styles['context-header-icon']} icon={icon} />}
+      {illustration && (
+        <div className={styles['context-header-illustration']}>
+          {illustration}
+        </div>
+      )}
       <div className={styles['context-header-content']}>
         <Title ellipsis>{title}</Title>
         {text && <Text ellipsis>{text}</Text>}
@@ -36,7 +40,7 @@ const ContextHeader = ({ icon, title, text, onClose, className }) => {
 }
 
 ContextHeader.propTypes = {
-  icon: PropTypes.node,
+  illustration: PropTypes.node,
   title: PropTypes.string.isRequired,
   text: PropTypes.string,
   onClose: PropTypes.func,

--- a/react/ContextHeader/styles.styl
+++ b/react/ContextHeader/styles.styl
@@ -23,7 +23,7 @@
   flex-shrink 1
   overflow hidden
 
-.context-header-icon
+.context-header-illustration
   width rem(32)
   height rem(32)
   margin-right rem(16)


### PR DESCRIPTION
An evolution for the [`ContextHeader`](https://docs.cozy.io/cozy-ui/react/#contextheader) — instead of only supporting an icon for the visual clue, we can now pass it any component.

Technically this is a breaking change, since if you want an icon you now have to pass an `<Icon />` component to the new prop. However this component is very recent and AFAIK only used in one place, so using a new major version just for this seems like it would cause trouble than not. But let me know if you'd rather bump a major version anyway!