### PR TITLE
fix: 🐛 Scrolling table when icon button inside

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -54,6 +54,7 @@ themedBtn(theme)
 \*------------------------------------*/
 
 $button
+    position         relative
     box-sizing       border-box
     display          inline-flex
     margin           0 rem(4)


### PR DESCRIPTION
The `position: absolute` of `.u-visuallyhidden` class in a button was messing with the height of the scrollable container because the absolute had no origin inside the button.

