### PR TITLE
Use portal from preact-compat

### DIFF
--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -34,9 +34,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new MiniCssExtractPlugin('[name].css'),
-    new webpack.DefinePlugin({
-      'process.env.USE_REACT': true
-    })
+    new MiniCssExtractPlugin('[name].css')
   ]
 }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "mini-css-extract-plugin": "^0.4.3",
     "normalize.css": "^7.0.0",
     "preact": "^8.3.1",
-    "preact-portal": "^1.1.3",
     "pretty": "^2.0.0",
     "react-hot-loader": "^4.3.11",
     "react-select": "^2.0.0-beta.6",

--- a/react/Portal/index.jsx
+++ b/react/Portal/index.jsx
@@ -1,12 +1,7 @@
-let Portal
-if (process.env.USE_REACT) {
-  const ReactDOM = require('react-dom')
-  Portal = ({ into, children }) => {
-    const targetElement = document.querySelector(into)
-    return ReactDOM.createPortal(children, targetElement)
-  }
-} else {
-  Portal = require('preact-portal')
+const ReactDOM = require('react-dom')
+const Portal = ({ into, children }) => {
+  const targetElement = document.querySelector(into)
+  return ReactDOM.createPortal(children, targetElement)
 }
 
 export default Portal

--- a/yarn.lock
+++ b/yarn.lock
@@ -11020,11 +11020,6 @@ postinstall-build@^5.0.1:
   resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.3.tgz#238692f712a481d8f5bc8960e94786036241efc7"
   integrity sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg==
 
-preact-portal@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/preact-portal/-/preact-portal-1.1.3.tgz#22cdd3ecf6ad9aaa3f830607a9c6591de90aedb7"
-  integrity sha512-rE0KG2b7ggIly4VVsSm7+WmQmG/EoUZzBOed2IbycyaFIArOvz+yab/8RBoDogA0JWZuTsbMTStR41Ghc+5m7Q==
-
 preact@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.3.1.tgz#ed34f79d09edc5efd32a378a3416ef5dc531e3ac"


### PR DESCRIPTION
Since we use `preact-compat` as alias for `react-dom` there already a `createPortal` compatibility so we don't need to use `preact-portal` anymore. And same thing for the `USE_REACT` variable.
See 
https://github.com/developit/preact-compat/pull/486