### PR TITLE
AppIcon: Prefer img element over fetchIcon method

### DIFF
--- a/react/AppIcon/Preloader.js
+++ b/react/AppIcon/Preloader.js
@@ -1,0 +1,40 @@
+export const preload = async (app, domain, secure) => {
+  const source = _getAppIconURL(app, domain, secure)
+
+  if (!source) {
+    throw new Error(`Cannot get icon source for app ${app.name}`)
+  }
+
+  return new Promise((resolve, reject) => {
+    const loader = document.createElement('img')
+    loader.onload = () => {
+      resolve(source)
+    }
+    loader.onerror = () => {
+      const loadError = new Error(`Error while preloading ${source}`)
+      console.error(loadError.message)
+      reject(loadError)
+    }
+    loader.src = source
+  })
+}
+
+const _getProtocol = (secure = true) => {
+  return `http${secure ? 's' : ''}:`
+}
+
+const _getAppIconURL = (app, domain, secure) => {
+  if (!domain) throw new Error('Cannot fetch icon: missing domain')
+
+  return (
+    app.links &&
+    app.links.icon &&
+    `${_getProtocol(secure)}//${domain}${app.links.icon}`
+  )
+}
+
+export const Preloader = {
+  preload
+}
+
+export default Preloader

--- a/react/AppIcon/Preloader.js
+++ b/react/AppIcon/Preloader.js
@@ -1,3 +1,5 @@
+const _loaded = {}
+
 export const preload = async (app, domain, secure) => {
   const source = _getAppIconURL(app, domain, secure)
 
@@ -8,6 +10,7 @@ export const preload = async (app, domain, secure) => {
   return new Promise((resolve, reject) => {
     const loader = document.createElement('img')
     loader.onload = () => {
+      _loaded[source] = true
       resolve(source)
     }
     loader.onerror = () => {
@@ -17,6 +20,11 @@ export const preload = async (app, domain, secure) => {
     }
     loader.src = source
   })
+}
+
+export const getPreloaded = (app, domain, secure) => {
+  const source = _getAppIconURL(app, domain, secure)
+  return source && _loaded[source] ? source : null
 }
 
 const _getProtocol = (secure = true) => {

--- a/react/AppIcon/Preloader.js
+++ b/react/AppIcon/Preloader.js
@@ -34,10 +34,20 @@ const _getProtocol = (secure = true) => {
 const _getAppIconURL = (app, domain, secure) => {
   if (!domain) throw new Error('Cannot fetch icon: missing domain')
 
+  let path = _getInstalledIconPath(app)
+  path = path || _getRegistryIconPath(app)
+  return path ? `${_getProtocol(secure)}//${domain}${path}` : null
+}
+
+const _getInstalledIconPath = app => {
+  return app.links && app.links.icon
+}
+
+const _getRegistryIconPath = app => {
   return (
-    app.links &&
-    app.links.icon &&
-    `${_getProtocol(secure)}//${domain}${app.links.icon}`
+    app.latest_version &&
+    app.latest_version.version &&
+    `/registry/${app.slug}/${app.latest_version.version}/icon`
   )
 }
 

--- a/react/AppIcon/Readme.md
+++ b/react/AppIcon/Readme.md
@@ -1,6 +1,22 @@
-`<AppIcon />` uses a `fetchIcon` prop to load asynchronously an app icon.
+`<AppIcon />` renders an app icon.
 
-## Example with a fake instance of cozyClient
+It contains business logic related to apps documents.
+
+Apps documents provided by the stack are containing a `links.icon` property which is public and can be directly used as `src` value for an `<img />` tag.
+
+### Example
+```
+  <div>
+    <p>
+      <AppIcon app={app} />
+    </p>
+  </div>
+```
+
+## Using fetchIcon
+Is it also possible to provide a custom asynchronous `fetchIcon` which takes an app document as argument and resolves with an icon URL (see [`URL.createObjectURL`](https://developer.mozilla.org/en/docs/Web/API/URL/createObjectURL)). `fetchIcon` may also throw errors.
+
+### Example with fetchIcon
 ```
   <div>
     <p>
@@ -9,5 +25,5 @@
   </div>
 ```
 
-The `fetchIcon` method is given `app.links.icon` as argument and must return an URL. This URL may be created with [`URL.createObjectURL`](https://developer.mozilla.org/en/docs/Web/API/URL/createObjectURL).
-`fetchIcon` may also throw errors.
+## `domain` and `secure` props
+If the `fetchIcon` is missing, the `<AppIcon />` component needs the `domain` prop (litteraly the cozy domain) and the secure prop, to know which protocol use between `http` or `https`.

--- a/react/AppIcon/Readme.md
+++ b/react/AppIcon/Readme.md
@@ -4,6 +4,8 @@ It contains business logic related to apps documents.
 
 Apps documents provided by the stack are containing a `links.icon` property which is public and can be directly used as `src` value for an `<img />` tag.
 
+`<AppIcon />` is also able to retrive an icon for a registry app. If no attribute `links.icon` is present on the app document, `<AppIcon />` tries to fetch the icon with a registry link, computed thanks to the app attributes `slug` and `latest_version.version`.
+
 ### Example
 ```
   <div>

--- a/react/AppIcon/__mocks__/Preloader.js
+++ b/react/AppIcon/__mocks__/Preloader.js
@@ -1,0 +1,7 @@
+export const preload = jest.fn().mockImplementation(async () => {
+  return 'http://cozy.tools/apps/test/icon'
+})
+
+export default {
+  preload
+}

--- a/react/AppIcon/__mocks__/Preloader.js
+++ b/react/AppIcon/__mocks__/Preloader.js
@@ -2,6 +2,11 @@ export const preload = jest.fn().mockImplementation(async () => {
   return 'http://cozy.tools/apps/test/icon'
 })
 
+export const getPreloaded = jest
+  .fn()
+  .mockReturnValue('http://cozy.tools/apps/test/icon')
+
 export default {
+  getPreloaded,
   preload
 }

--- a/react/AppIcon/index.jsx
+++ b/react/AppIcon/index.jsx
@@ -6,7 +6,7 @@ import styles from './styles.styl'
 import Icon from '../Icon'
 
 import appDefaultIcon from '../../assets/icons/ui/cube.svg'
-import { preload } from './Preloader'
+import { getPreloaded, preload } from './Preloader'
 
 const DONE = 'done'
 const ERRORED = 'errored'
@@ -15,7 +15,13 @@ const FETCHING = 'fetching'
 export class AppIcon extends Component {
   constructor(props, context) {
     super(props, context)
-    this.state = { error: null, icon: null, status: FETCHING }
+    const { app, domain, secure } = props
+    const preloaded = getPreloaded(app, domain, secure)
+    this.state = {
+      error: null,
+      icon: preloaded,
+      status: preloaded ? DONE : FETCHING
+    }
   }
 
   componentDidMount() {

--- a/react/AppIcon/index.jsx
+++ b/react/AppIcon/index.jsx
@@ -7,11 +7,16 @@ import Icon from '../Icon'
 
 import appDefaultIcon from '../../assets/icons/ui/cube.svg'
 
+const DONE = 'done'
+const ERRORED = 'errored'
+const FETCHING = 'fetching'
+const IDLE = 'idle'
+
 export class AppIcon extends Component {
   constructor(props, context) {
     super(props, context)
     this.state = {
-      status: 'idle'
+      status: IDLE
     }
   }
 
@@ -26,14 +31,14 @@ export class AppIcon extends Component {
       throw new Error('fetchIcon prop is required')
     }
 
-    this.setState({ status: 'fetching' })
+    this.setState({ status: FETCHING })
 
     try {
       const icon = await fetchIcon(app.links.icon)
-      this.setState({ icon, status: 'done' })
+      this.setState({ icon, status: DONE })
     } catch (error) {
       console.error(error.message)
-      this.setState({ error, status: 'failed' })
+      this.setState({ error, status: ERRORED })
     }
   }
 
@@ -41,8 +46,8 @@ export class AppIcon extends Component {
     const { alt, className } = this.props
     const { icon, status } = this.state
     switch (status) {
-      case 'idle':
-      case 'fetching':
+      case IDLE:
+      case FETCHING:
         return (
           <div
             className={classNames(
@@ -52,7 +57,7 @@ export class AppIcon extends Component {
             )}
           />
         )
-      case 'done':
+      case DONE:
         return (
           <img
             alt={alt}
@@ -60,7 +65,7 @@ export class AppIcon extends Component {
             src={icon}
           />
         )
-      case 'failed':
+      case ERRORED:
       default:
         return (
           <Icon

--- a/react/AppIcon/test/AppIcon.spec.js
+++ b/react/AppIcon/test/AppIcon.spec.js
@@ -7,39 +7,99 @@ import { shallow } from 'enzyme'
 import AppIcon from '../'
 
 describe('AppIcon component', () => {
-  const app = {
-    links: {
-      icon: 'apps/test/icon'
-    }
-  }
+  const app = {}
+  const domain = 'cozy.tools'
+  const secure = true
 
-  const successFetchIcon = jest.fn().mockResolvedValue('data://test-url')
+  let successFetchIcon
+  let failureFetchIcon
 
-  it(`renders default when fetch error occurs`, () => {
-    const failureFetchIcon = jest.fn().mockImplementation(() => {
-      throw new Error('Mocked error')
-    })
-    const component = shallow(
-      <AppIcon app={app} fetchIcon={failureFetchIcon} />
-    ).getElement()
-    expect(component).toMatchSnapshot()
+  beforeEach(() => {
+    jest.resetModules()
+
+    successFetchIcon = jest
+      .fn()
+      .mockResolvedValue('http://cozy.tools/apps/test/icon')
+
+    failureFetchIcon = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error('Mocked error')))
+
+    console.error = jest.fn()
   })
 
   it(`renders as loading`, () => {
-    const component = shallow(
-      <AppIcon app={app} fetchIcon={successFetchIcon} />
-    ).getElement()
-    expect(component).toMatchSnapshot()
-  })
-
-  it('renders app icon after fetching', async () => {
-    const successFetchPromise = successFetchIcon()
     const wrapper = shallow(
-      <AppIcon app={app} fetchIcon={() => successFetchPromise} />
+      <AppIcon
+        app={app}
+        domain={domain}
+        fetchIcon={successFetchIcon}
+        secure={secure}
+      />
     )
-    await successFetchPromise
-    wrapper.update()
+
     const component = wrapper.getElement()
     expect(component).toMatchSnapshot()
+    expect(successFetchIcon).toHaveBeenCalledWith(app, domain, secure)
+    expect(console.error).toHaveBeenCalledTimes(0)
+  })
+
+  it(`renders correctly`, async done => {
+    const wrapper = shallow(
+      <AppIcon
+        app={app}
+        domain={domain}
+        fetchIcon={successFetchIcon}
+        onReady={() => {
+          wrapper.update()
+          const component = wrapper.getElement()
+          expect(component).toMatchSnapshot()
+          expect(successFetchIcon).toHaveBeenCalledWith(app, domain, secure)
+          expect(console.error).toHaveBeenCalledTimes(0)
+          done()
+        }}
+        secure={secure}
+      />
+    )
+  })
+
+  it(`renders default when fetch error occurs`, async done => {
+    const wrapper = shallow(
+      <AppIcon
+        app={app}
+        domain={domain}
+        fetchIcon={failureFetchIcon}
+        onReady={() => {
+          wrapper.update()
+          const component = wrapper.getElement()
+          expect(component).toMatchSnapshot()
+          expect(failureFetchIcon).toHaveBeenCalledWith(app, domain, secure)
+          expect(console.error).toHaveBeenCalledTimes(0)
+          done()
+        }}
+        secure={secure}
+      />
+    )
+  })
+
+  it(`uses Preloader.preload when no fetchIcon method is provided`, async done => {
+    jest.mock('../Preloader')
+    const AppIcon = require('../').default
+    const Preloader = require('../Preloader')
+    const wrapper = shallow(
+      <AppIcon
+        app={app}
+        domain={domain}
+        onReady={() => {
+          wrapper.update()
+          const component = wrapper.getElement()
+          expect(component).toMatchSnapshot()
+          expect(Preloader.preload).toHaveBeenCalledWith(app, domain, secure)
+          expect(console.error).toHaveBeenCalledTimes(0)
+          done()
+        }}
+        secure={secure}
+      />
+    )
   })
 })

--- a/react/AppIcon/test/AppIcon.spec.js
+++ b/react/AppIcon/test/AppIcon.spec.js
@@ -15,6 +15,7 @@ describe('AppIcon component', () => {
   let failureFetchIcon
 
   beforeEach(() => {
+    jest.unmock('../Preloader')
     jest.resetModules()
 
     successFetchIcon = jest
@@ -95,6 +96,34 @@ describe('AppIcon component', () => {
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
           expect(Preloader.preload).toHaveBeenCalledWith(app, domain, secure)
+          expect(console.error).toHaveBeenCalledTimes(0)
+          done()
+        }}
+        secure={secure}
+      />
+    )
+  })
+
+  it(`renders immediately when icon is alredy preloaded`, async done => {
+    jest.mock('../Preloader')
+    const AppIcon = require('../').default
+    const Preloader = require('../Preloader')
+
+    shallow(
+      <AppIcon
+        app={app}
+        domain={domain}
+        onReady={() => {
+          const wrapper = shallow(
+            <AppIcon app={app} domain={domain} secure={secure} />
+          )
+          const component = wrapper.getElement()
+          expect(component).toMatchSnapshot()
+          expect(Preloader.getPreloaded).toHaveBeenCalledWith(
+            app,
+            domain,
+            secure
+          )
           expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}

--- a/react/AppIcon/test/Preloader.spec.js
+++ b/react/AppIcon/test/Preloader.spec.js
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+import { preload } from '../Preloader'
+
+describe('Preloader', () => {
+  const app = {
+    name: 'TestApp',
+    links: {
+      icon: '/apps/test/icon'
+    }
+  }
+
+  const domain = 'cozy.tools'
+
+  let successImgMock
+  let erroredImgMock
+
+  beforeEach(() => {
+    successImgMock = {}
+    Object.defineProperty(successImgMock, 'onload', {
+      set: function(fn) {
+        fn()
+      }
+    })
+
+    erroredImgMock = {}
+    Object.defineProperty(erroredImgMock, 'onerror', {
+      set: function(fn) {
+        fn()
+      }
+    })
+
+    document.createElement = jest.fn().mockReturnValue(successImgMock)
+    console.error = jest.fn()
+  })
+
+  describe('preload', () => {
+    it('returns the expected url', async () => {
+      await expect(preload(app, domain)).resolves.toEqual(
+        'https://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('returns the expected unesecure url', async () => {
+      await expect(preload(app, domain, false)).resolves.toEqual(
+        'http://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('throw error on loading fail', async () => {
+      document.createElement = jest.fn().mockReturnValue(erroredImgMock)
+      await expect(preload(app, domain)).rejects.toEqual(
+        new Error('Error while preloading https://cozy.tools/apps/test/icon')
+      )
+      expect(console.error).toHaveBeenCalledTimes(1)
+      expect(console.error).toHaveBeenCalledWith(
+        'Error while preloading https://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('throw error on missing domain', async () => {
+      await expect(preload(app, null)).rejects.toEqual(
+        new Error('Cannot fetch icon: missing domain')
+      )
+    })
+  })
+})

--- a/react/AppIcon/test/Preloader.spec.js
+++ b/react/AppIcon/test/Preloader.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { preload } from '../Preloader'
+import { preload, getPreloaded } from '../Preloader'
 
 describe('Preloader', () => {
   const app = {
@@ -15,6 +15,8 @@ describe('Preloader', () => {
   let erroredImgMock
 
   beforeEach(() => {
+    jest.resetModules()
+
     successImgMock = {}
     Object.defineProperty(successImgMock, 'onload', {
       set: function(fn) {
@@ -61,6 +63,18 @@ describe('Preloader', () => {
       await expect(preload(app, null)).rejects.toEqual(
         new Error('Cannot fetch icon: missing domain')
       )
+    })
+
+    it('returns already loaded icon URL', async () => {
+      await preload(app, domain)
+      expect(getPreloaded(app, domain)).toBe(
+        'https://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('returns null for not already loaded icon URL', () => {
+      const getPreloaded = require('../Preloader').getPreloaded
+      expect(getPreloaded(app, domain)).toBeNull()
     })
   })
 })

--- a/react/AppIcon/test/Preloader.spec.js
+++ b/react/AppIcon/test/Preloader.spec.js
@@ -11,6 +11,13 @@ describe('Preloader', () => {
 
   const domain = 'cozy.tools'
 
+  const registryApp = {
+    slug: 'test',
+    latest_version: {
+      version: '1.2.3'
+    }
+  }
+
   let successImgMock
   let erroredImgMock
 
@@ -45,6 +52,18 @@ describe('Preloader', () => {
     it('returns the expected unesecure url', async () => {
       await expect(preload(app, domain, false)).resolves.toEqual(
         'http://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('fetch installed app icon', async () => {
+      await expect(preload(app, domain)).resolves.toEqual(
+        'https://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('fetch registry app icon', async () => {
+      await expect(preload(registryApp, domain)).resolves.toEqual(
+        'https://cozy.tools/registry/test/1.2.3/icon'
       )
     })
 

--- a/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
+++ b/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AppIcon component renders app icon after fetching 1`] = `
-<img
-  alt={undefined}
-  className="styles__c-app-icon___2_O40"
-  src="data://test-url"
-/>
-`;
-
 exports[`AppIcon component renders as loading 1`] = `
 <div
   className="styles__c-loading-placeholder___3L6Gz styles__c-app-icon___2_O40"
+/>
+`;
+
+exports[`AppIcon component renders correctly 1`] = `
+<img
+  alt={undefined}
+  className="styles__c-app-icon___2_O40"
+  src="http://cozy.tools/apps/test/icon"
 />
 `;
 
@@ -21,5 +21,13 @@ exports[`AppIcon component renders default when fetch error occurs 1`] = `
   icon="test-file-stub"
   spin={false}
   width="100%"
+/>
+`;
+
+exports[`AppIcon component uses Preloader.preload when no fetchIcon method is provided 1`] = `
+<img
+  alt={undefined}
+  className="styles__c-app-icon___2_O40"
+  src="http://cozy.tools/apps/test/icon"
 />
 `;

--- a/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
+++ b/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
@@ -24,6 +24,14 @@ exports[`AppIcon component renders default when fetch error occurs 1`] = `
 />
 `;
 
+exports[`AppIcon component renders immediately when icon is alredy preloaded 1`] = `
+<img
+  alt={undefined}
+  className="styles__c-app-icon___2_O40"
+  src="http://cozy.tools/apps/test/icon"
+/>
+`;
+
 exports[`AppIcon component uses Preloader.preload when no fetchIcon method is provided 1`] = `
 <img
   alt={undefined}


### PR DESCRIPTION
This PR ~~deprecates the fetchIcon prop for AppIcon~~ use directly icon sources
an `<img />` tag if no `fetchIcon` prop is passed, now that all icon served by the stack are accessible
without permissions on doctype `io.cozy.apps`.