### PR TITLE
feat: Upgrade to react-select 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "preact": "^8.3.1",
     "pretty": "^2.0.0",
     "react-hot-loader": "^4.3.11",
-    "react-select": "^2.0.0-beta.6",
+    "react-select": "2.1.1",
     "stylus": "^0.54.5",
     "svgstore-cli": "^1.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11506,7 +11506,7 @@ react-redux@^5.0.3:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
-react-select@^2.0.0-beta.6:
+react-select@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.1.1.tgz#762d0babd8c7c46a944db51cbb72e4ee117253f9"
   integrity sha512-ukie2LJStNfJEJ7wtqA+crAfzYpkpPr86urvmJGisECwsWJob9boCM4zjmKCi5QR7G8uY9+v7ZoliJpeCz/4xw==


### PR DESCRIPTION
ATM we're on a beta... So I upgraded to the latest stable. 

I didn't have any issue but regarding the changelog we can have one issue but I don't know if we are concerned
 
`[BREAKING] innerRef assignments in custom components must now be made from the root of the prop object, as opposed to reaching into innerProps. This is part of the work to normalize the behaviour circa custom components. #2824`
