### PR TITLE
feat(Modal): Add containerClassName prop

### DIFF
--- a/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
+++ b/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
@@ -6,6 +6,7 @@ exports[`IntentModal component renders as expected 1`] = `
   closable={true}
   closeBtnClassName="styles__intentModal__cross___1Hfuz"
   closeBtnColor={undefined}
+  containerClassName={undefined}
   description={undefined}
   dismissAction={[Function]}
   height={undefined}

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -294,6 +294,7 @@ class Modal extends Component {
       secondaryText,
       secondaryAction,
       secondaryType,
+      containerClassName,
       ...restProps
     } = this.props
     const { titleID } = this
@@ -301,7 +302,7 @@ class Modal extends Component {
     const maybeWrapInPortal = children =>
       into ? <Portal into={into}>{children}</Portal> : children
     return maybeWrapInPortal(
-      <div className={styles['c-modal-container']}>
+      <div className={cx(styles['c-modal-container'], containerClassName)}>
         <Overlay
           onEscape={closable && dismissAction}
           className={overlayClassName}
@@ -408,7 +409,9 @@ Modal.propTypes = {
   /** className to apply to Overlay component */
   overlayClassName: PropTypes.string,
   /** className to apply to wrapper element */
-  wrapperClassName: PropTypes.string
+  wrapperClassName: PropTypes.string,
+  /** className to apply to the container element */
+  containerClassName: PropTypes.string
 }
 
 Modal.defaultProps = {


### PR DESCRIPTION
I propose to add this prop so we can customize the style of the root element when we need it.

It is useful for example in banks in which we want to show a `Modal` when we click on the logout button. But it that case, since the `z-index` of the `Modal` is lower that the cozy-bar one, the modal is always behind it.