### PR TITLE
fix: 🐛 Changed Modal CSS order to avoid conflicts

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import styles from './styles.styl'
 import Overlay from '../Overlay'
 import { Button } from '../Button'
 import Icon from '../Icon'
@@ -9,6 +8,7 @@ import migrateProps from '../helpers/migrateProps'
 import palette from '../palette'
 import Portal from '../Portal'
 import uniqueId from 'lodash/uniqueId'
+import styles from './styles.styl'
 
 class AnimatedContentHeader extends Component {
   render() {


### PR DESCRIPTION
Button styles were loaded after the Modal styles, making some unreasonable conflicts.