### PR TITLE
Fix intents display

### DIFF
--- a/react/IntentIframe/styles.styl
+++ b/react/IntentIframe/styles.styl
@@ -13,7 +13,7 @@ iframe
     align-items center
 
 /* Don't mess with the spinner centering until the iframe is fully loaded. */
-.intentContainer[aria-busy] iframe
+.intentContainer[aria-busy=true] iframe
     height 0
     width 0
 


### PR DESCRIPTION
Intents display was broken due to aria-busy attribute always present
with a 'false' value.

This iframe was working since 7 months without changes and we
were not able to determine why it suddenly started to fail.

We suppose that an 'aria-busy' attribute to undefined was previously not
rendered at all, and a recent change made it rendered with a 'false' value.