### PR TITLE
AppIcon: Allow undefined domain

### DIFF
--- a/react/AppIcon/Preloader.js
+++ b/react/AppIcon/Preloader.js
@@ -1,6 +1,8 @@
 const _loaded = {}
 
 export const preload = async (app, domain, secure) => {
+  if (!domain) throw new Error('Cannot fetch icon: missing domain')
+
   const source = _getAppIconURL(app, domain, secure)
 
   if (!source) {
@@ -32,7 +34,7 @@ const _getProtocol = (secure = true) => {
 }
 
 const _getAppIconURL = (app, domain, secure) => {
-  if (!domain) throw new Error('Cannot fetch icon: missing domain')
+  if (!domain) return null
 
   let path = _getInstalledIconPath(app)
   path = path || _getRegistryIconPath(app)

--- a/react/AppIcon/test/AppIcon.spec.js
+++ b/react/AppIcon/test/AppIcon.spec.js
@@ -31,17 +31,12 @@ describe('AppIcon component', () => {
 
   it(`renders as loading`, () => {
     const wrapper = shallow(
-      <AppIcon
-        app={app}
-        domain={domain}
-        fetchIcon={successFetchIcon}
-        secure={secure}
-      />
+      <AppIcon app={app} fetchIcon={successFetchIcon} secure={secure} />
     )
 
     const component = wrapper.getElement()
     expect(component).toMatchSnapshot()
-    expect(successFetchIcon).toHaveBeenCalledWith(app, domain, secure)
+    expect(successFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
     expect(console.error).toHaveBeenCalledTimes(0)
   })
 
@@ -49,13 +44,12 @@ describe('AppIcon component', () => {
     const wrapper = shallow(
       <AppIcon
         app={app}
-        domain={domain}
         fetchIcon={successFetchIcon}
         onReady={() => {
           wrapper.update()
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
-          expect(successFetchIcon).toHaveBeenCalledWith(app, domain, secure)
+          expect(successFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
           expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}
@@ -68,13 +62,12 @@ describe('AppIcon component', () => {
     const wrapper = shallow(
       <AppIcon
         app={app}
-        domain={domain}
         fetchIcon={failureFetchIcon}
         onReady={() => {
           wrapper.update()
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
-          expect(failureFetchIcon).toHaveBeenCalledWith(app, domain, secure)
+          expect(failureFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
           expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}
@@ -90,12 +83,11 @@ describe('AppIcon component', () => {
     const wrapper = shallow(
       <AppIcon
         app={app}
-        domain={domain}
         onReady={() => {
           wrapper.update()
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
-          expect(Preloader.preload).toHaveBeenCalledWith(app, domain, secure)
+          expect(Preloader.preload).toHaveBeenCalledWith(app, undefined, secure)
           expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}
@@ -112,7 +104,6 @@ describe('AppIcon component', () => {
     shallow(
       <AppIcon
         app={app}
-        domain={domain}
         onReady={() => {
           const wrapper = shallow(
             <AppIcon app={app} domain={domain} secure={secure} />

--- a/react/AppIcon/test/Preloader.spec.js
+++ b/react/AppIcon/test/Preloader.spec.js
@@ -42,6 +42,24 @@ describe('Preloader', () => {
     console.error = jest.fn()
   })
 
+  describe('getPreloaded', () => {
+    it('returns null when no domain is specified', () => {
+      expect(getPreloaded(app)).toBeNull()
+    })
+
+    it('returns already loaded icon URL', async () => {
+      await preload(app, domain)
+      expect(getPreloaded(app, domain)).toBe(
+        'https://cozy.tools/apps/test/icon'
+      )
+    })
+
+    it('returns null for not already loaded icon URL', () => {
+      const getPreloaded = require('../Preloader').getPreloaded
+      expect(getPreloaded(app, domain)).toBeNull()
+    })
+  })
+
   describe('preload', () => {
     it('returns the expected url', async () => {
       await expect(preload(app, domain)).resolves.toEqual(
@@ -82,18 +100,6 @@ describe('Preloader', () => {
       await expect(preload(app, null)).rejects.toEqual(
         new Error('Cannot fetch icon: missing domain')
       )
-    })
-
-    it('returns already loaded icon URL', async () => {
-      await preload(app, domain)
-      expect(getPreloaded(app, domain)).toBe(
-        'https://cozy.tools/apps/test/icon'
-      )
-    })
-
-    it('returns null for not already loaded icon URL', () => {
-      const getPreloaded = require('../Preloader').getPreloaded
-      expect(getPreloaded(app, domain)).toBeNull()
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,21 +5,18 @@
 "@babel/code-frame@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
-  integrity sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==
   dependencies:
     "@babel/highlight" "7.0.0-beta.44"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.0.0":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.6.tgz#3733cbee4317429bc87c62b29cf8587dba7baeb3"
-  integrity sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/generator" "^7.1.6"


### PR DESCRIPTION
AppIcon was not usable without a domain prop,
making fetchIcon prop impossible to use.