### PR TITLE
docs: Set focus programmatically

### DIFF
--- a/react/Input/Readme.md
+++ b/react/Input/Readme.md
@@ -34,6 +34,33 @@
 <Input placeholder="I'm full width" fullwidth />
 ```
 
+### inputRef ( set focus / blur / ... programmatically)
+
+If you need to programmatically access the underlying `<input />` for example to give focus or move the caret, you can use the `innerRef` prop, that is passed to the `ref` property of the `<input />`.
+
+```
+
+class InputComponent extends React.Component {
+  constructor() {
+    super()
+    this.component = null;
+    this.setFocus = this.setFocus.bind(this)
+  }
+  setFocus() {
+    this.component.focus()
+  }
+  render() {
+    return (
+      <div>
+        <Button onClick={this.setFocus}>Set Focus</Button>
+        <Input inputRef={c => this.component = c} />
+      </div>
+    )
+  }
+}
+;<InputComponent />
+```
+
 ### Props forwarding
 
 `Input` forwards unknown props to the underlying `<input />` element.


### PR DESCRIPTION
Added an exemple to show how to focus programmatically an `<Input />`