### PR TITLE
chore: Commitlint cli is not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "@commitlint/cli": "^6.2.0",
     "@semantic-release/changelog": "^2.0.2",
     "@semantic-release/git": "^5.0.0",
     "@semantic-release/npm": "^3.3.1",


### PR DESCRIPTION
Since `commitlint/cli` is imported by `commitlint-config-cozy` https://github.com/cozy/cozy-libs/blob/master/packages/commitlint-config-cozy/package.json#L28  we don't need to depend on it 