### PR TITLE
Make react-dom a peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "pretty": "^2.0.0",
     "prop-types": "^15.6.0",
     "react": "^16.5.2",
-    "react-dom": "^16.6.3",
     "react-redux": "^5.0.3",
     "react-styleguidist": "7.3.11",
     "react-test-renderer": "16.6.3",
@@ -104,7 +103,8 @@
     "react-select": "2.1.1"
   },
   "peerDependencies": {
-    "piwik-react-router": "^0.8.2"
+    "piwik-react-router": "^0.8.2",
+    "react-dom": "^16.6.3"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
We only need it when a React application wants to use React components.