### PR TITLE
fix(AppIcon): Use cube icon instead of import

### DIFF
--- a/react/AppIcon/index.jsx
+++ b/react/AppIcon/index.jsx
@@ -4,8 +4,8 @@ import classNames from 'classnames'
 import styles from './styles.styl'
 
 import Icon from '../Icon'
+import palette from '../palette'
 
-import appDefaultIcon from '../../assets/icons/ui/cube.svg'
 import { getPreloaded, preload } from './Preloader'
 
 const DONE = 'done'
@@ -82,8 +82,9 @@ export class AppIcon extends Component {
               className
             )}
             height="100%"
-            icon={appDefaultIcon}
+            icon="cube"
             width="100%"
+            color={palette['coolGrey']}
           />
         )
     }

--- a/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
+++ b/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
@@ -17,8 +17,9 @@ exports[`AppIcon component renders correctly 1`] = `
 exports[`AppIcon component renders default when fetch error occurs 1`] = `
 <Icon
   className="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt"
+  color="#95999D"
   height="100%"
-  icon="test-file-stub"
+  icon="cube"
   spin={false}
   width="100%"
 />


### PR DESCRIPTION
Fix also an issue about icon cube not found in the last version of Cozy-UI