### PR TITLE
fix(Select): Transparent action buttons on desktop

### DIFF
--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -1,4 +1,5 @@
 @require '../../stylus/settings/palette'
+@require '../../stylus/settings/breakpoints'
 @require '../../stylus/tools/mixins'
 
 .select-control__input
@@ -20,6 +21,9 @@
     &:hover:not(.select-option--disabled)
         background-color paleGrey
         cursor pointer
+
+        .select-option__actions
+          opacity 1
 
 .select-option--focused:not(.select-option--disabled)
     background-color paleGrey
@@ -44,6 +48,11 @@
 
 .select-option__actions
     float right
+    opacity 0
+    transition all .2s ease-out
+
+    +medium-screen()
+      opacity 1
 
 .select__overlay
     // Covers all the app so that clicking outside ends up


### PR DESCRIPTION
As suggested in #700 , this PR makes the action buttons transparent on larger screens — this the demo [here](https://yannick-lohse.fr/cozy-ui/react/#selectbox).