### PR TITLE
chore: Put preact and react as peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "mini-css-extract-plugin": "^0.4.3",
     "npm-run-all": "^4.1.5",
     "postcss-loader": "^2.0.6",
+    "preact": "^8.3.1",
+    "preact-portal": "^1.1.3",
     "pretty": "^2.0.0",
     "prop-types": "^15.6.0",
     "react": "^16.5.2",
@@ -101,12 +103,14 @@
     "node-polyglot": "^2.2.2",
     "normalize.css": "^7.0.0",
     "react-hot-loader": "^4.3.11",
-    "preact": "^8.3.1",
-    "preact-portal": "^1.1.3",
     "react-select": "2.1.1"
   },
   "peerDependencies": {
-    "piwik-react-router": "^0.8.2"
+    "piwik-react-router": "^0.8.2",
+    "preact": "^8.3.1",
+    "preact-portal": "^1.1.3",
+    "react": "^16.6.3",
+    "react-dom": "^16.5.2"
   },
   "eslintConfig": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -10194,16 +10194,6 @@ postinstall-build@^5.0.1:
   resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.3.tgz#238692f712a481d8f5bc8960e94786036241efc7"
   integrity sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg==
 
-preact-portal@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/preact-portal/-/preact-portal-1.1.3.tgz#22cdd3ecf6ad9aaa3f830607a9c6591de90aedb7"
-  integrity sha512-rE0KG2b7ggIly4VVsSm7+WmQmG/EoUZzBOed2IbycyaFIArOvz+yab/8RBoDogA0JWZuTsbMTStR41Ghc+5m7Q==
-
-preact@^8.3.1:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.3.1.tgz#ed34f79d09edc5efd32a378a3416ef5dc531e3ac"
-  integrity sha512-s8H1Y8O9e+mOBo3UP1jvWqArPmjCba2lrrGLlq/0kN1XuIINUbYtf97iiXKxCuG3eYwmppPKnyW2DBrNj/TuTg==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
We do not want to have preact installed in the host application when
installing cozy-ui.

See how material UI does that : https://github.com/mui-org/material-ui/blob/master/package.json#L55