### PR TITLE
Fix/wizard styles

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -23,10 +23,7 @@
   "cssLiteral": "never",
   "customProperties": [],
   "depthLimit": 4,
-  "duplicates": {
-    "expect": true,
-    "error": true
-  },
+  "duplicates": false,
   "efficient": {
     "expect": "always",
     "error": true

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -289,21 +289,27 @@ $button-client-mobile
 /*------------------------------------*\
   Sizes
 \*------------------------------------*/
-$button--tiny
+button--tiny =
     min-height rem(24)
     min-width rem(80)
     padding rem(2 16)
+$button--tiny
+    {button--tiny}
 
-$button--small
+button--small =
     min-height rem(32)
     min-width rem(96)
     padding rem(3 8)
+$button--small
+    {button--small}
 
-$button--large
+button--large =
     min-height rem(48)
     min-width rem(160)
     padding rem(8 24)
     font-size rem(16)
+$button--large
+    {button--large}
 
 /*------------------------------------*\
   Extensions

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -267,16 +267,22 @@ $input-text
     &:invalid
         border rem(1) solid pomegranate
 
-$input-text--tiny
+input-text--tiny =
     border-radius rem(2)
     padding rem(4 8 6)
+$input-text--tiny
+    {input-text--tiny}
 
-$input-text--medium
+input-text--medium =
     border-radius rem(2)
     padding rem(8 16 10)
+$input-text--medium
+    {input-text--medium}
 
-$input-text--fullwidth
+input-text--fullwidth =
     max-width 100%
+$input-text--fullwidth
+    {input-text--fullwidth}
 
 $checkbox
     // To make sure that checkbox's wrapper have the height of the checkbox

--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -2,6 +2,7 @@
 @require '../settings/breakpoints'
 @require '../settings/palette'
 @require '../components/forms'
+@require '../components/button'
 
 // Wizard layout
 $wizard
@@ -108,17 +109,11 @@ $wizard-next
 
 $wizard-button
     +small-screen('min')
-        // Cannot @extend $button--large inside a Media Query :(
-        min-height rem(48)
-        min-width rem(160)
-        padding rem(8 24)
-        font-size rem(16)
+        {button--large}
 
 $wizard-password
     +small-screen()
-        // Cannot @extend $input-text--medium inside a Media Query :(
-        border-radius rem(2)
-        padding rem(8 16 10)
+        {input-text--medium}
 
 $wizard-title
     margin 0 0 rem(8)

--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -35,7 +35,6 @@ $wizard-wrapper--welcome
 
 $wizard-errors
     order 1
-    color pomegranate
 
 $wizard-header
     display flex
@@ -49,6 +48,7 @@ $wizard-main
 
 $wizard-footer
     display flex
+    order 2
     flex-wrap wrap
     flex 0 0 auto
     padding-bottom env(safe-area-inset-bottom)
@@ -56,13 +56,7 @@ $wizard-footer
     & > button // @stylint ignore
     & > a:link // @stylint ignore
         flex 1 1 100%
-
-
-$wizard-footer--welcome
-    & > button // @stylint ignore
-    & > a:link // @stylint ignore
-        flex 1 0 40%
-        margin 0 rem(4) rem(8)
+        margin 0 0 rem(8)
 
 // Wizard elements
 $wizard-logo
@@ -99,9 +93,10 @@ $wizard-header-help
 
 $wizard-previous
     position fixed
-    top rem(10)
-    left rem(16)
+    top rem(7)
+    left 0
     margin 0
+    padding rem(10) rem(16)
     color coolGrey
 
 $wizard-next
@@ -138,7 +133,6 @@ $wizard-subtitle
     text-align center
     font-size rem(16)
     line-height 1.5
-    color coolGrey
     margin 0 0 rem(8)
     +small-screen()
         font-size rem(14)

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -886,8 +886,6 @@ Display an chip that represents complex identity
 .wizard--welcome
     .wizard-wrapper
         @extend $wizard-wrapper--welcome
-    .wizard-footer
-        @extend $wizard-footer--welcome
     .wizard-title
         @extend $wizard-title--welcome
 


### PR DESCRIPTION
Some fixes after some feedbacks.

The removal of the linter rule is due to a bug from Stylint, that sees @block as duplicate.
Since this is a way of doing we're gonna use a lot in the near future and since Stylint development is kinda dropped, I guess disabling the rule was better than adding `// Stylint ignore` everytime.