### PR TITLE
fix: 🐛 table divider z-index & color

### DIFF
--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -1,5 +1,6 @@
 @require '../settings/breakpoints'
 @require '../settings/palette'
+@require '../settings/z-index'
 @require '../tools/mixins'
 
 $table
@@ -93,22 +94,14 @@ $table-cell--primary
 
 $table-divider
     position sticky
+    z-index $low-index
     top 0
-    background-color white
+    background-color zircon
     text-indent rem(32)
     font-weight bold
     font-size rem(12)
     line-height 1.33
     color coolGrey
-
-    &::before
-        content ''
-        position absolute
-        top 0
-        left 0
-        width 100%
-        height 100%
-        background-color zircon
 
     & + * // @stylint ignore
         border-top 0

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -19,6 +19,7 @@
 
     $below-index        - **index -1** Layer below the app, mostly for hiding purpose
     $app-index          - **index 0** App index, the ground zero.
+    $low-index          - **index 1** Low level index, to make sure a positionned element goes over elements with z-index 0.
     $alert-index-mobile - **index 10** Alert index like success, errors, infos *mobile only*
     $nav-index          - **index 20** Nav index
     $bar-index          - **index 21** Bar index equals Nav index + 1, not actually used, just as reference.
@@ -34,6 +35,7 @@
 
 $below-index        = -1
 $app-index          = 0
+$low-index          = 1
 $alert-index-mobile = 10
 $nav-index          = 20
 $bar-index          = $nav-index + 1 // Not actually used, just as reference


### PR DESCRIPTION
Removed the problematic pseudo-element `::before`