### PR TITLE
fix(Modal): Removed useless tab-index

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -167,7 +167,6 @@ const ModalHeader = ({
       className={cx(styles['c-modal-header'], className)}
       style={style}
       id={id}
-      tabIndex="-1"
     >
       {title && <h2>{title}</h2>}
       {isTitle ? <h2>{children}</h2> : children}


### PR DESCRIPTION
It was supposed to help giving the focus when opening the modal but it's
not needed anymore since we plugged FocusTrap

Also, it will remove the outline style when header is clicked.