### PR TITLE
fix: 🐛 Add !important to .u-hide utility

### DIFF
--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -69,8 +69,8 @@ _convert-to-rem($px, $base)
     Styleguide Tools.mixins.hide
 */
 hide()
-    display     none
-    visibility  hidden
+    display     none !important  // @stylint ignore
+    visibility  hidden !important  // @stylint ignore
 
 /*
     reset()


### PR DESCRIPTION
So it's always applied, since it's meant to override.
