### PR TITLE
Handle AppIcon update

### DIFF
--- a/react/AppIcon/test/AppIcon.spec.js
+++ b/react/AppIcon/test/AppIcon.spec.js
@@ -7,50 +7,44 @@ import { shallow } from 'enzyme'
 import AppIcon from '../'
 
 describe('AppIcon component', () => {
-  const app = {}
+  const app = { slug: 'test-app' }
   const domain = 'cozy.tools'
   const secure = true
+  const iconURL = 'http://cozy.tools/apps/test/icon'
 
-  let successFetchIcon
-  let failureFetchIcon
+  let PreloaderMock
 
   beforeEach(() => {
     jest.unmock('../Preloader')
     jest.resetModules()
 
-    successFetchIcon = jest
-      .fn()
-      .mockResolvedValue('http://cozy.tools/apps/test/icon')
-
-    failureFetchIcon = jest
-      .fn()
-      .mockImplementation(() => Promise.reject(new Error('Mocked error')))
-
-    console.error = jest.fn()
+    jest.mock('../Preloader')
+    PreloaderMock = require('../Preloader')
+    PreloaderMock.preload.mockReset()
+    PreloaderMock.getPreloaded.mockReset()
   })
 
   it(`renders as loading`, () => {
     const wrapper = shallow(
-      <AppIcon app={app} fetchIcon={successFetchIcon} secure={secure} />
+      <AppIcon app={app} domain={domain} secure={secure} />
     )
 
     const component = wrapper.getElement()
     expect(component).toMatchSnapshot()
-    expect(successFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
-    expect(console.error).toHaveBeenCalledTimes(0)
   })
 
   it(`renders correctly`, async done => {
+    PreloaderMock.preload = jest.fn().mockReturnValueOnce(iconURL)
+    const AppIcon = require('../').default
+
     const wrapper = shallow(
       <AppIcon
         app={app}
-        fetchIcon={successFetchIcon}
+        domain={domain}
         onReady={() => {
           wrapper.update()
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
-          expect(successFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
-          expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}
         secure={secure}
@@ -59,6 +53,10 @@ describe('AppIcon component', () => {
   })
 
   it(`renders default when fetch error occurs`, async done => {
+    const failureFetchIcon = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error('Mocked error')))
+
     const wrapper = shallow(
       <AppIcon
         app={app}
@@ -68,7 +66,6 @@ describe('AppIcon component', () => {
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
           expect(failureFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
-          expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}
         secure={secure}
@@ -76,46 +73,67 @@ describe('AppIcon component', () => {
     )
   })
 
-  it(`uses Preloader.preload when no fetchIcon method is provided`, async done => {
-    jest.mock('../Preloader')
+  it(`uses fetchIcon method when provided`, async done => {
     const AppIcon = require('../').default
-    const Preloader = require('../Preloader')
-    const wrapper = shallow(
-      <AppIcon
-        app={app}
-        onReady={() => {
-          wrapper.update()
-          const component = wrapper.getElement()
-          expect(component).toMatchSnapshot()
-          expect(Preloader.preload).toHaveBeenCalledWith(app, undefined, secure)
-          expect(console.error).toHaveBeenCalledTimes(0)
-          done()
-        }}
-        secure={secure}
-      />
-    )
-  })
-
-  it(`renders immediately when icon is alredy preloaded`, async done => {
-    jest.mock('../Preloader')
-    const AppIcon = require('../').default
-    const Preloader = require('../Preloader')
+    const successFetchIcon = jest.fn().mockResolvedValue(iconURL)
 
     shallow(
       <AppIcon
         app={app}
+        fetchIcon={successFetchIcon}
         onReady={() => {
-          const wrapper = shallow(
-            <AppIcon app={app} domain={domain} secure={secure} />
+          expect(successFetchIcon).toHaveBeenCalledWith(app, undefined, secure)
+          done()
+        }}
+        secure={secure}
+      />
+    )
+  })
+
+  it(`renders immediately when icon is alredy preloaded`, () => {
+    PreloaderMock.getPreloaded = jest.fn().mockReturnValue(iconURL)
+
+    const AppIcon = require('../').default
+
+    const wrapper = shallow(
+      <AppIcon app={app} domain={domain} secure={secure} />
+    )
+    const component = wrapper.getElement()
+    expect(component).toMatchSnapshot()
+    expect(PreloaderMock.getPreloaded).toHaveBeenCalledWith(app, domain, secure)
+  })
+
+  it(`does not keep previous icon in state`, async done => {
+    // Assert that the AppIcon behaves correctly inside lists and update
+    // its icon (previous implementation was storing icon in state)
+    PreloaderMock.preload = jest.fn().mockResolvedValueOnce(iconURL)
+
+    const AppIcon = require('../').default
+
+    const anotherApp = { slug: 'another' }
+    const wrapper = shallow(
+      <AppIcon
+        app={app}
+        onReady={() => {
+          PreloaderMock.preload.mockResolvedValueOnce(
+            'http://cozy.tools/apps/test/other'
           )
+          wrapper.setProps({
+            app: anotherApp,
+            domain: domain,
+            secure: secure
+          })
+        }}
+        onUpdate={() => {
+          wrapper.update()
+
           const component = wrapper.getElement()
           expect(component).toMatchSnapshot()
-          expect(Preloader.getPreloaded).toHaveBeenCalledWith(
-            app,
+          expect(PreloaderMock.getPreloaded).toHaveBeenCalledWith(
+            anotherApp,
             domain,
             secure
           )
-          expect(console.error).toHaveBeenCalledTimes(0)
           done()
         }}
         secure={secure}

--- a/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
+++ b/react/AppIcon/test/__snapshots__/AppIcon.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AppIcon component does not keep previous icon in state 1`] = `
+<img
+  alt={undefined}
+  className="styles__c-app-icon___2_O40"
+  src="http://cozy.tools/apps/test/other"
+/>
+`;
+
 exports[`AppIcon component renders as loading 1`] = `
 <div
   className="styles__c-loading-placeholder___3L6Gz styles__c-app-icon___2_O40"
@@ -26,14 +34,6 @@ exports[`AppIcon component renders default when fetch error occurs 1`] = `
 `;
 
 exports[`AppIcon component renders immediately when icon is alredy preloaded 1`] = `
-<img
-  alt={undefined}
-  className="styles__c-app-icon___2_O40"
-  src="http://cozy.tools/apps/test/icon"
-/>
-`;
-
-exports[`AppIcon component uses Preloader.preload when no fetchIcon method is provided 1`] = `
 <img
   alt={undefined}
   className="styles__c-app-icon___2_O40"


### PR DESCRIPTION
We faced a case when AppIcons were nested in lists and keeping
their state, i.e. displaying the wrong icon.

See capture.

![capture_du_2018-11-30_12-10-45](https://user-images.githubusercontent.com/776764/49443113-cdebbb00-f7cb-11e8-8a0c-54ea07ffc18f.png)

This PR fixes this behavior and add a related test.