### PR TITLE
Proposal: Don't use a single stylesheet for all transpiled components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,10 +9,16 @@
     "transpilation": {
       "plugins": [
         ["css-modules-transform", {
-          extensions: [".styl"],
-          preprocessCss: "./preprocess",
-          extractCss: "./transpiled/stylesheet.css",
-          generateScopedName: "[name]__[local]___[hash:base64:5]",
+          "extensions": [".styl"],
+          "preprocessCss": "./preprocess",
+          "importPathFormatter": "./scripts/importPathFormatter",
+          "extractCss": {
+              "dir": "./transpiled/react/",
+              "relativeRoot": "./react/",
+              "filename": "[path]/[name].css"
+          },
+          "generateScopedName": "[name]__[local]___[hash:base64:5]",
+          "keepImport": true
         }]
       ]
     }

--- a/.babelrc
+++ b/.babelrc
@@ -21,6 +21,15 @@
           "keepImport": true
         }]
       ]
+    },
+    "test": {
+      "plugins": [
+        ["css-modules-transform", {
+          "extensions": [".styl"],
+          "preprocessCss": "./preprocess",
+          "generateScopedName": "[name]__[local]___[hash:base64:5]"
+        }]
+      ]
     }
   },
   "ignore": ["examples/**/*"]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sprite": "scripts/make-icon-sprite.sh",
     "test": "yarn test:jest",
     "test:jest": "env BABEL_ENV=transpilation jest --verbose --coverage",
-    "transpile": "env BABEL_ENV=transpilation babel react/ --out-dir transpiled/react --copy-files --ignore '**/test/**,**/__mocks__/**,**/*.spec.*'",
+    "transpile": "env BABEL_ENV=transpilation babel react/ --out-dir transpiled/react --ignore '**/test/**,**/__mocks__/**,**/*.spec.*'",
     "travis-deploy-once": "travis-deploy-once",
     "watch:css": "yarn build:css --watch",
     "watch:doc:react": "env BABEL_ENV=transpilation styleguidist server --config docs/styleguide.config.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "build:doc:react": "styleguidist build --config docs/styleguide.config.js",
     "clean:doc:kss": "rm -rf build/styleguide",
     "commitmsg": "commitlint -e $GIT_PARAMS",
-    "copy-files": "scripts/copy-files.sh",
     "deploy:doc": "git-directory-deploy --directory build/ --branch gh-pages",
     "lint": "npm-run-all 'lint:*'",
     "lint:commit": "git merge-base HEAD master && commitlint --from=$(git merge-base HEAD master) --to=HEAD || true",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semantic-release": "semantic-release",
     "sprite": "scripts/make-icon-sprite.sh",
     "test": "yarn test:jest",
-    "test:jest": "env BABEL_ENV=transpilation jest --verbose --coverage",
+    "test:jest": "env BABEL_ENV=test jest --verbose --coverage",
     "transpile": "env BABEL_ENV=transpilation babel react/ --out-dir transpiled/react --ignore '**/test/**,**/__mocks__/**,**/*.spec.*'",
     "travis-deploy-once": "travis-deploy-once",
     "watch:css": "yarn build:css --watch",

--- a/scripts/importPathFormatter.js
+++ b/scripts/importPathFormatter.js
@@ -1,0 +1,1 @@
+module.exports = path => path.replace(/\.styl$/, '.css')


### PR DESCRIPTION
Using a single stylesheet doesn't give any choice about which component styles are imported and need a custom require in the application or the webpack configuration which to much to use cozy-ui IMHO.

Since we juste want to transpile our components, I think that we should keep the application handle the styles files required by the components on its side.

With this transpiling configuration, all components will have a single css files required in its JS code.
When the app will import the components to use it, it will automatically import the good css-transformed stylesheet related file:
<img width="260" alt="screenshot 2018-12-07 at 13 36 40" src="https://user-images.githubusercontent.com/10224453/49648191-2f5a9680-fa25-11e8-9a9b-197b67ceeb23.png">

It may be considered as a breaking change if some applications are still looking for a single `transpiled/stylesheet.css`