### PR TITLE
fix: Wizard select padding

### DIFF
--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -212,7 +212,7 @@ $wizard-select
     margin rem(2)
     width rem(148)
     border 0
-    padding rem(11 16 11 8)
+    padding rem(11 38 11 8)
 
     &:hover
     &:focus
@@ -224,7 +224,7 @@ $wizard-select
 
 $wizard-select--medium
     @extend $select--medium
-    padding rem(6 16 8 8)
+    padding rem(6 38 8 8)
 
 $wizard-select--narrow
     width rem(40)


### PR DESCRIPTION
Oops. I unfixed a fix. Here is the fix fixed.
The text from a select shouldn't go over the arrow now.