### PR TITLE
feat: Remove noise from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,5 @@ yarn.lock
 examples
 docs
 coverage
+codemods
+loaders

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@ yarn.lock
 /scripts
 .changelog
 examples
+docs
+coverage


### PR DESCRIPTION
- coverage
- docs
- codemods
- loaders

should not be available from NPM. They were added to the
.npmignore file.