### PR TITLE
fix: Palette variables

### DIFF
--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -5,18 +5,12 @@ $theme = json('theme.json', { hash: true })
 // build the final palette with rgba() values
 $palette = { }
 
-colorFromArray(c)
-    s('rgba(%s, %s, %s, %s)', c['0'], c['1'], c['2'], c['3'] || 1)
-
-
 variableFromName(name)
     s('var(--%s)', s(name))
 
 buildPalette(theme)
     for name, color in theme
-        $palette[name] = colorFromArray(color)
-        define(name, variableFromName(name), true)
-
+        $palette[name] = color
 
 buildPalette($theme)
 
@@ -36,7 +30,7 @@ buildPalette($theme)
 
 :root {
   for name,value in $palette {
-    {s('--%s',s(name))}: $value
+    {s('--%s',s(name))}: value
   }
 }
 


### PR DESCRIPTION
Before
```
:root {
  --black: $value;
  --white: $value;
  --paleGrey: $value;
  --silver: $value;
  --coolGrey: $value;
  --slateGrey: $value;
  --charcoalGrey: $value;
  --overlay: $value;
  --zircon: $value;
  --frenchPass: $value;
  --dodgerBlue: $value;
  --scienceBlue: $value;
  --puertoRico: $value;
  --emerald: $value;
  --malachite: $value;
  --texasRose: $value;
  --chablis: $value;
  --yourPink: $value;
  --pomegranate: $value;
  --monza: $value;
  --portage: $value;
  --azure: $value;
  --melon: $value;
  --blazeOrange: $value;
  --mango: $value;
  --pumpkinOrange: $value;
  --darkPeriwinkle: $value;
  --purpley: $value;
  --lightishPurple: $value;
  --barney: $value;
  --weirdGreen: $value;
}
```

After
```
:root {
  --black: #000;
  --white: #fff;
  --paleGrey: #f5f6f7;
  --silver: #d6d8da;
  --coolGrey: #95999d;
  --slateGrey: #5d6165;
  --charcoalGrey: #32363f;
  --overlay: rgba(50,54,63,0.5);
  --zircon: #f1f7ff;
  --frenchPass: #c2dcff;
  --dodgerBlue: #297ef2;
  --scienceBlue: #0b61d6;
  --puertoRico: #4dcec5;
  --emerald: #35ce68;
  --malachite: #08b442;
  --texasRose: #ffae5f;
  --chablis: #fff2f2;
  --yourPink: #fdcbcb;
  --pomegranate: #f52d2d;
  --monza: #dd0505;
  --portage: #9169f2;
  --azure: #1fa8f1;
  --melon: #fd7461;
  --blazeOrange: #fc6d00;
  --mango: #ff962f;
  --pumpkinOrange: #ff7f1b;
  --darkPeriwinkle: #6984ce;
  --purpley: #7f6bee;
  --lightishPurple: #b449e7;
  --barney: #922bc2;
  --weirdGreen: #40de8e;
}
```