### PR TITLE
Select option with prefix

### DIFF
--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -129,3 +129,13 @@ const ValueContainer = props => {
 
 />
 ```
+
+Add a prefix className:
+
+```
+const options = [
+  { value: 'chocolate', label: 'Chocolate' }
+];
+
+<SelectBox options={options} menuIsOpen classNamePrefix='needsclick cz' />
+```

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -5,7 +5,7 @@ import styles from './styles.styl'
 import Icon from '../Icon'
 import { dodgerBlue, silver, coolGrey } from '../palette'
 import withBreakpoints from '../helpers/withBreakpoints'
-import cx from 'classnames'
+import classNames from 'classnames'
 
 const customStyles = {
   container: base => ({
@@ -73,7 +73,7 @@ const Option = ({
   <div
     {...innerProps}
     ref={innerRef}
-    className={cx(styles['select-option'], {
+    className={classNames(styles['select-option'], {
       [styles['select-option--selected']]: isSelected && !withCheckbox,
       [styles['select-option--focused']]: isFocused,
       [styles['select-option--disabled']]: isDisabled
@@ -179,7 +179,7 @@ class SelectBox extends Component {
         onMenuOpen={this.handleOpen}
         onMenuClose={this.handleClose}
         {...props}
-        className={cx(
+        className={classNames(
           {
             [styles['select__overlay']]: showOverlay
           },

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -60,8 +60,17 @@ const reactSelectControl = CustomControl => ({
   </div>
 )
 
-export const withPrefix = (cx, className) => {
-  const classNameWithPrefix = cx(null, { [` ${className}`]: true })
+export const withPrefix = (reactSelectCx, className) => {
+  // react-select implement a classnames function https://git.io/fhT8S
+  // it's not the same as classnames library (https://www.npmjs.com/package/classnames)
+  // 1st parameter is bound by react-select with prefix https://git.io/fhkIj
+  // 2nd parameter is cssKey. We don't need it so it's set to null
+  // 3rd parameter is used to add prefix but we don't want to stick with
+  //   webpack className so we add space (' ') in front of it
+  const classNameWithPrefix = reactSelectCx(null, { [` ${className}`]: true })
+
+  // When we don't use classNamePrefix cx return '' so we verify to send
+  // className
   return classNameWithPrefix === '' ? className : classNameWithPrefix
 }
 
@@ -73,7 +82,7 @@ const Option = ({
   innerProps,
   innerRef,
   labelComponent,
-  cx, // it's classnames of react-select https://git.io/fhT8S
+  cx,
   withCheckbox
 }) => (
   <div

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import ReactSelect from 'react-select'
 import styles from './styles.styl'
 import Icon from '../Icon'
-import palette from '../palette'
+import { dodgerBlue, silver, coolGrey } from '../palette'
 import withBreakpoints from '../helpers/withBreakpoints'
 import cx from 'classnames'
 
@@ -16,10 +16,10 @@ const customStyles = {
     ...base,
     backgroundColor: 'white',
     border: state.isFocused
-      ? `.0625rem solid ${palette['dodgerBlue']}`
-      : `.0625rem solid ${palette['silver']}`,
+      ? `.0625rem solid ${dodgerBlue}`
+      : `.0625rem solid ${silver}`,
     ':hover': {
-      borderColor: palette['coolGrey']
+      borderColor: coolGrey
     },
     borderRadius: '.1875rem',
     boxShadow: 'unset',
@@ -98,7 +98,7 @@ const Option = ({
         {isSelected && (
           <Icon
             icon="check-circleless"
-            color={palette['dodgerBlue']}
+            color={dodgerBlue}
             className="u-ph-half"
           />
         )}
@@ -127,7 +127,7 @@ const ActionsOption = ({ actions, ...props }) => (
         <Icon
           key={index}
           icon={action.icon}
-          color={props.isFocused ? palette['coolGrey'] : palette['silver']}
+          color={props.isFocused ? coolGrey : silver}
           className="u-ph-half"
           onClick={e => {
             e.stopPropagation()

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -60,6 +60,11 @@ const reactSelectControl = CustomControl => ({
   </div>
 )
 
+export const withPrefix = (cx, className) => {
+  const classNameWithPrefix = cx(null, { [` ${className}`]: true })
+  return classNameWithPrefix === '' ? className : classNameWithPrefix
+}
+
 const Option = ({
   children,
   isSelected,
@@ -68,38 +73,42 @@ const Option = ({
   innerProps,
   innerRef,
   labelComponent,
+  cx, // it's classnames of react-select https://git.io/fhT8S
   withCheckbox
 }) => (
   <div
     {...innerProps}
     ref={innerRef}
-    className={classNames(styles['select-option'], {
-      [styles['select-option--selected']]: isSelected && !withCheckbox,
-      [styles['select-option--focused']]: isFocused,
-      [styles['select-option--disabled']]: isDisabled
-    })}
+    className={withPrefix(
+      cx,
+      classNames(styles['select-option'], {
+        [styles['select-option--selected']]: isSelected && !withCheckbox,
+        [styles['select-option--focused']]: isFocused,
+        [styles['select-option--disabled']]: isDisabled
+      })
+    )}
   >
     {withCheckbox && (
       <input
         type="checkbox"
         readOnly
         checked={isSelected}
-        className={styles['select-option__checkbox']}
+        className={withPrefix(cx, styles['select-option__checkbox'])}
       />
     )}
-    <span className={styles['select-option__label']}>
-      <span className="u-ellipsis">
+    <span className={withPrefix(cx, styles['select-option__label'])}>
+      <span className={withPrefix(cx, 'u-ellipsis')}>
         {labelComponent ? labelComponent : children}
       </span>
       {labelComponent ? children : false}
     </span>
     {!withCheckbox && (
-      <span className={styles['select-option__checkmark']}>
+      <span className={withPrefix(cx, styles['select-option__checkmark'])}>
         {isSelected && (
           <Icon
             icon="check-circleless"
             color={dodgerBlue}
-            className="u-ph-half"
+            className={withPrefix(cx, 'u-ph-half')}
           />
         )}
       </span>
@@ -122,13 +131,13 @@ CheckboxOption.propTypes = {}
 
 const ActionsOption = ({ actions, ...props }) => (
   <Option {...props} labelComponent={props.children}>
-    <span className={styles['select-option__actions']}>
+    <span className={withPrefix(props.cx, styles['select-option__actions'])}>
       {actions.map((action, index) => (
         <Icon
           key={index}
           icon={action.icon}
           color={props.isFocused ? coolGrey : silver}
-          className="u-ph-half"
+          className={withPrefix(props.cx, 'u-ph-half')}
           onClick={e => {
             e.stopPropagation()
             action.onClick(props)

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1067,6 +1067,33 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 </div>"
 `;
 
+exports[`SelectBox should render examples: SelectBox 8`] = `
+"<div>
+  <div class=\\"css-1h8pu2y\\">
+    <div class=\\"css-1mag0rk needsclick cz__control\\">
+      <div class=\\"css-1phseng needsclick cz__value-container\\">
+        <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
+        <div class=\\"css-1g6gooi\\">
+          <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+          </div>
+        </div>
+      </div>
+      <div class=\\"css-1wy0on6 needsclick cz__indicators\\"><span class=\\"css-1hyfx7x needsclick cz__indicator-separator\\"></span>
+        <div aria-hidden=\\"true\\" class=\\"css-kww5l needsclick cz__indicator needsclick cz__dropdown-indicator\\"><svg height=\\"20\\" width=\\"20\\" viewBox=\\"0 0 20 20\\" aria-hidden=\\"true\\" focusable=\\"false\\" class=\\"css-19bqh2r\\">
+            <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\"></path>
+          </svg></div>
+      </div>
+    </div>
+    <div class=\\"css-1dhof61 needsclick cz__menu\\">
+      <div class=\\"css-11unzgr needsclick cz__menu-list\\">
+        <div id=\\"react-select-9-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Chocolate</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
 exports[`Sidebar should render examples: Sidebar 1`] = `
 "<div>
   <aside class=\\"styles__o-sidebar___1295j\\">

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1087,7 +1087,7 @@ exports[`SelectBox should render examples: SelectBox 8`] = `
     </div>
     <div class=\\"css-1dhof61 needsclick cz__menu\\">
       <div class=\\"css-11unzgr needsclick cz__menu-list\\">
-        <div id=\\"react-select-9-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Chocolate</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+        <div id=\\"react-select-9-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Add classNamePrefix on Option class.

On Banks app we add `classNamePrefix='needsclick cz'` but the Option component don't use it, it's a bug we can display only on iOS ;)

https://kosssi.github.io/cozy-ui/react/#!/SelectBox