### PR TITLE
Add size prop for Field

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -2,12 +2,13 @@
 
 ```
 <form>
-  <Field 
-    id="idField" 
-    label="I'm a label" 
+  <Field
+    id="idField"
+    label="I'm a label"
     type="textarea"
     placeholder="I'm a textarea"
     onChange={() => {}}
+    size="medium"
   />
 </form>
 ```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -16,7 +16,8 @@ const Field = props => {
     placeholder,
     error,
     onChange,
-    readOnly
+    readOnly,
+    size
   } = props
 
   const inputType = type => {
@@ -45,6 +46,7 @@ const Field = props => {
             error={error}
             onChange={onChange}
             readOnly={readOnly}
+            size={size}
           />
         )
       default:
@@ -68,7 +70,8 @@ Field.propTypes = {
   type: PropTypes.oneOf(['text', 'password', 'email', 'url', 'textarea']),
   value: PropTypes.string,
   placeholder: PropTypes.string,
-  error: PropTypes.bool
+  error: PropTypes.bool,
+  size: PropTypes.oneOf(['tiny', 'medium', 'large'])
 }
 
 Field.defaultProps = {
@@ -77,7 +80,8 @@ Field.defaultProps = {
   type: 'text',
   value: '',
   placeholder: '',
-  error: false
+  error: false,
+  size: 'large'
 }
 
 export default Field

--- a/react/Input/Readme.md
+++ b/react/Input/Readme.md
@@ -17,6 +17,8 @@
 
 ### Alternative input sizes
 
+By default, the size is `large`.
+
 ```
 <div>
   <p>

--- a/react/Input/index.jsx
+++ b/react/Input/index.jsx
@@ -44,7 +44,7 @@ Input.propTypes = {
   value: PropTypes.string,
   placeholder: PropTypes.string,
   error: PropTypes.bool,
-  size: PropTypes.oneOf(['tiny', 'medium']),
+  size: PropTypes.oneOf(['tiny', 'medium', 'large']),
   fullwidth: PropTypes.bool,
   /**
    * Use that property to pass a ref callback to the native input component.
@@ -55,7 +55,8 @@ Input.propTypes = {
 Input.defaultProps = {
   type: 'text',
   error: false,
-  fullwidth: false
+  fullwidth: false,
+  size: 'large'
 }
 
 export default Input

--- a/react/Input/styles.styl
+++ b/react/Input/styles.styl
@@ -9,5 +9,8 @@
 .c-input-text--medium
     @extend $input-text--medium
 
+.c-input-text--large
+    @extend $input-text--large
+
 .c-input-text--fullwidth
     @extend $input-text--fullwidth

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -211,7 +211,7 @@ exports[`Field should render examples: Field 1`] = `
 exports[`Field should render examples: Field 2`] = `
 "<div>
   <form>
-    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldError\\" class=\\"styles__c-label___o4ozG\\">I'm an error label</label><input type=\\"text\\" id=\\"idFieldError\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ\\" placeholder=\\"I'm an error input[type=text]\\" value=\\"\\"></div>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldError\\" class=\\"styles__c-label___o4ozG\\">I'm an error label</label><input type=\\"text\\" id=\\"idFieldError\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ styles__c-input-text--large___28EaR\\" placeholder=\\"I'm an error input[type=text]\\" value=\\"\\"></div>
   </form>
 </div>"
 `;
@@ -821,7 +821,7 @@ exports[`Infos should render examples: Infos 1`] = `
 exports[`Label should render examples: Label 1`] = `
 "<div>
   <form>
-    <div><label for=\\"idInput\\" class=\\"styles__c-label___o4ozG\\">This is a label</label><input type=\\"text\\" id=\\"idInput\\" class=\\"styles__c-input-text___3TAv1\\" placeholder=\\"Recherche\\" value=\\"\\"></div>
+    <div><label for=\\"idInput\\" class=\\"styles__c-label___o4ozG\\">This is a label</label><input type=\\"text\\" id=\\"idInput\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"Recherche\\" value=\\"\\"></div>
   </form>
 </div>"
 `;
@@ -829,7 +829,7 @@ exports[`Label should render examples: Label 1`] = `
 exports[`Label should render examples: Label 2`] = `
 "<div>
   <form>
-    <div><label for=\\"idInput2\\" class=\\"styles__c-label___o4ozG styles__is-error___2Dwem\\">This is an error label</label><input type=\\"text\\" id=\\"idInput2\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ\\" placeholder=\\"Recherche\\" value=\\"\\"></div>
+    <div><label for=\\"idInput2\\" class=\\"styles__c-label___o4ozG styles__is-error___2Dwem\\">This is an error label</label><input type=\\"text\\" id=\\"idInput2\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ styles__c-input-text--large___28EaR\\" placeholder=\\"Recherche\\" value=\\"\\"></div>
   </form>
 </div>"
 `;

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -281,6 +281,12 @@ input-text--medium =
 $input-text--medium
     {input-text--medium}
 
+input-text--large =
+    border-radius rem(3)
+    padding rem(13 16)
+$input-text--large
+    {input-text--large}
+
 input-text--fullwidth =
     max-width 100%
 $input-text--fullwidth

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -297,6 +297,7 @@
  .is-error - Error variant
  .c-input-text--tiny - Tiny size variant
  .c-input-text--medium - Medium size variant
+ .c-input-text--large - Large size variant (default)
  .c-input-text--fullwidth - Full width variant
 
  Weight: 2


### PR DESCRIPTION
This PR adds `size` prop to Field component, which is passed to Input component.

We chose to explicitly set the default Input size to `large` and use a new dedicated placeholder `input-text-size--large`.

Next step should be to change the default size to `medium` to avoid CSS property duplications between `input-text` and `input-text-size--large`. It will cause breaking changes.