### PR TITLE
feat(AppIcon): Add possibility to get the icon from an app slug

### DIFF
--- a/react/AppIcon/Preloader.js
+++ b/react/AppIcon/Preloader.js
@@ -46,6 +46,10 @@ const _getInstalledIconPath = app => {
 }
 
 const _getRegistryIconPath = app => {
+  if (typeof app === 'string') {
+    return `/registry/${app}/icon`
+  }
+
   return (
     app.latest_version &&
     app.latest_version.version &&

--- a/react/AppIcon/Readme.md
+++ b/react/AppIcon/Readme.md
@@ -6,6 +6,11 @@ Apps documents provided by the stack are containing a `links.icon` property whic
 
 `<AppIcon />` is also able to retrive an icon for a registry app. If no attribute `links.icon` is present on the app document, `<AppIcon />` tries to fetch the icon with a registry link, computed thanks to the app attributes `slug` and `latest_version.version`.
 
+The given app can be:
+
+* An object representing an app fetched from the registry
+* An app's slug string
+
 ### Example
 ```
   <div>

--- a/react/AppIcon/index.jsx
+++ b/react/AppIcon/index.jsx
@@ -93,7 +93,7 @@ export class AppIcon extends Component {
 
 AppIcon.propTypes = {
   alt: PropTypes.string,
-  app: PropTypes.object,
+  app: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.string,
   domain: PropTypes.string,
   fetchIcon: PropTypes.func,

--- a/react/AppIcon/test/Preloader.spec.js
+++ b/react/AppIcon/test/Preloader.spec.js
@@ -18,6 +18,8 @@ describe('Preloader', () => {
     }
   }
 
+  const stringApp = 'test'
+
   let successImgMock
   let erroredImgMock
 
@@ -82,6 +84,12 @@ describe('Preloader', () => {
     it('fetch registry app icon', async () => {
       await expect(preload(registryApp, domain)).resolves.toEqual(
         'https://cozy.tools/registry/test/1.2.3/icon'
+      )
+    })
+
+    it('fetch registry app icon via string', async () => {
+      await expect(preload(stringApp, domain)).resolves.toEqual(
+        'https://cozy.tools/registry/test/icon'
       )
     })
 


### PR DESCRIPTION
Currently we can only get an app icon by giving an object with slug and latest_version properties to `AppIcon`. In Banks, we will need to get konnectors icons from their slug.

The idea here is to make `AppIcon` accept a string as its `app` prop. If we pass a string, it will always fetch the icon url from the registry via the [`/registry/:app/icon` route](https://github.com/cozy/cozy-stack/blob/master/docs/registry.md#get-registryappicon).