### PR TITLE
fix: 🐛 height of onboarding bleeding wrapper

### DIFF
--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -52,6 +52,9 @@ $wizard-wrapper--bleed
     height 100%
     max-width rem(1032)
 
+    +tiny-screen('min')
+        height 100%
+
 $wizard-wrapper--dual
     @extend $wizard-wrapper--bleed
     max-width none


### PR DESCRIPTION
Fix the height of the onboarding wrapper to 100% when using a bleeding wrapper on desktop.