### PR TITLE
feat: Ui theme for MUIMenu

### DIFF
--- a/react/MuiCozyTheme/Menus/Readme.md
+++ b/react/MuiCozyTheme/Menus/Readme.md
@@ -1,55 +1,25 @@
 ```
 const MuiCozyTheme = require('..').default
-const Menu = require('@material-ui/core/Menu').default
+const Menu = require('.').default
 const MenuItem = require('@material-ui/core/MenuItem').default
-const MenuList = require('@material-ui/core/MenuList').default
-const Button = require('@material-ui/core/Button').default;
-
-class SimpleMenu extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = { anchorEl: null }
-    this.handleClick = this.handleClick.bind(this)
-    this.handleClose = this.handleClose.bind(this)
-  }
-
-  handleClick (event) {
-    console.log(event)
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose () {
-    this.setState({ anchorEl: null });
-  }
-
-  render() {
-    const { anchorEl } = this.state;
-
-    return (
-      <div>
-        <Button
-          aria-owns={anchorEl ? 'simple-menu' : undefined}
-          aria-haspopup="true"
-          onClick={this.handleClick}
-        >
-          Open Menu
-        </Button>
-        <Menu
-          id="simple-menu"
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={this.handleClose}
-        >
-          <MenuItem onClick={this.handleClose}>Profile</MenuItem>
-          <MenuItem onClick={this.handleClose}>My account</MenuItem>
-          <MenuItem onClick={this.handleClose}>Logout</MenuItem>
-        </Menu>
-      </div>
-    );
-  }
-}
+const Button = require('../../Button').default;
 
 <MuiCozyTheme>
-  <SimpleMenu />
+  <Menu
+    component={
+      <Button
+        label='Click for more !'
+        theme="secondary"
+        icon="dots"
+        extension="narrow"
+        iconOnly
+      />
+    }
+  >
+    <MenuItem>Profile</MenuItem>
+    <MenuItem>My account</MenuItem>
+    <hr />
+    <MenuItem>Logout</MenuItem>
+  </Menu>
 </MuiCozyTheme>
 ```

--- a/react/MuiCozyTheme/Menus/index.js
+++ b/react/MuiCozyTheme/Menus/index.js
@@ -1,3 +1,7 @@
+// This component is inspired by https://material-ui.com/demos/menus/#menulist-composition
+// Since the MuiMenu component doesn't allow another Popover positioning,
+// we have to recompose the Menu component ourselves with basic Mui component
+
 import React, { Component } from 'react'
 
 import MenuButton from '../../Button'

--- a/react/MuiCozyTheme/Menus/index.js
+++ b/react/MuiCozyTheme/Menus/index.js
@@ -1,3 +1,122 @@
-import Menu from '@material-ui/core/Menu'
+import React, { Component } from 'react'
 
-export default Menu
+import MenuButton from '../../Button'
+import PropTypes from 'prop-types'
+
+import ClickAwayListener from '@material-ui/core/ClickAwayListener'
+import Grow from '@material-ui/core/Grow'
+import Popper from '@material-ui/core/Popper'
+import Paper from '@material-ui/core/Paper'
+import MenuList from '@material-ui/core/MenuList'
+import { withStyles } from '@material-ui/core/styles'
+
+const styles = {
+  root: {
+    position: 'relative'
+  },
+  paper: {
+    '& hr': {
+      margin: '8px 0',
+      border: 0,
+      borderTop: '1px solid var(--silver)'
+    }
+  }
+}
+
+class Menu extends Component {
+  state = { open: false, anchorEl: null }
+
+  toggle = event => {
+    const { currentTarget } = event
+    this.setState(state => ({
+      anchorEl: currentTarget,
+      open: !state.open
+    }))
+  }
+
+  close = () => {
+    this.setState({
+      open: false
+    })
+  }
+
+  render() {
+    const {
+      label,
+      disabled,
+      buttonClassName,
+      component,
+      children,
+      placement,
+      classes
+    } = this.props
+    const { open, anchorEl } = this.state
+    const offset = {
+      offset: {
+        offset: '0, 4'
+      }
+    }
+
+    return (
+      <ClickAwayListener onClickAway={this.close}>
+        <div className={classes.root}>
+          {!component ? (
+            <MenuButton
+              disabled={disabled}
+              onClick={this.toggle}
+              label={label}
+              buttonClassName={buttonClassName}
+            />
+          ) : (
+            React.cloneElement(component, {
+              disabled,
+              onClick: this.toggle
+            })
+          )}
+          <Popper
+            open={open}
+            anchorEl={anchorEl}
+            transition
+            disablePortal
+            placement={placement}
+            modifiers={offset}
+          >
+            {({ TransitionProps, placement }) => (
+              <Grow
+                {...TransitionProps}
+                style={{
+                  transformOrigin:
+                    placement === 'bottom-end' ? 'center top' : 'center bottom'
+                }}
+              >
+                <Paper className={classes.paper}>
+                  <MenuList>{children}</MenuList>
+                </Paper>
+              </Grow>
+            )}
+          </Popper>
+        </div>
+      </ClickAwayListener>
+    )
+  }
+}
+
+Menu.defaultProps = {
+  disabled: false,
+  component: null,
+  placement: 'bottom-end'
+}
+
+Menu.propTypes = {
+  /** Disables the menu */
+  disabled: PropTypes.bool,
+  /** Specifies a custom component for the opener */
+  component: PropTypes.element,
+  /** placement for the popover */
+  placement: PropTypes.oneOf(['bottom-start', 'bottom-end'])
+}
+
+Menu.MenuButton = MenuButton
+export default withStyles(styles, { name: 'MuiMenu' })(Menu)
+
+export { MenuButton }

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -20,12 +20,39 @@ export const theme = createMuiTheme({
       main: getCssVariableValue('portage'),
       dark: getCssVariableValue('azure'),
       contrastText: getCssVariableValue('white')
+    },
+    grey: {
+      0: getCssVariableValue('white'),
+      100: getCssVariableValue('paleGrey'),
+      200: getCssVariableValue('silver'),
+      300: getCssVariableValue('coolGrey'),
+      400: getCssVariableValue('slateGrey'),
+      800: getCssVariableValue('charcoalGrey'),
+      900: getCssVariableValue('black')
     }
   },
   overrides: {
     MuiButton: {
       root: {
         borderRadius: 0
+      }
+    },
+    MuiListItem: {
+      button: {
+        '&:hover': {
+          backgroundColor: getCssVariableValue('paleGrey')
+        }
+      }
+    },
+    MuiMenuItem: {
+      root: {
+        paddingTop: 4,
+        paddingBottom: 4,
+        color: getCssVariableValue('charcoalGrey')
+      },
+      gutters: {
+        paddingLeft: 24,
+        paddingRight: 24
       }
     }
   }


### PR DESCRIPTION
[Styleguidist preview](https://gooz.github.io/cozy-ui/react/#menus)

Still glitching and/or missing:
- ~~The `Grow` transition only works when opening but not when closing.~~
- Z-index issue on the `Popper`, I'm still trying to figure out if there's a way to get a higher z-index without using styles like the legacy `MuiMenu` that "uses" Modal styles… ¯\_(ツ)_/¯
- Getting the drawer on mobile
- Put styles in `theme.json` only