### PR TITLE
fix: 🐛 Buttons should have bold text

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -67,6 +67,7 @@ $button
     vertical-align   top
     text-align       center
     font-size        rem(14)
+    font-weight      bold
     line-height      1
     text-transform   uppercase
     text-decoration  none


### PR DESCRIPTION
All buttons should have a bold text, since… forever actually.
Preview: [KSS](https://gooz.github.io/cozy-ui/styleguide/section-components.html) & [styleguidist](https://gooz.github.io/cozy-ui/react/#button)