### PR TITLE
fix(Checkbox): Allow children for Checkbox component

### DIFF
--- a/react/Checkbox/Readme.md
+++ b/react/Checkbox/Readme.md
@@ -17,3 +17,9 @@
 ```
 <div><Checkbox label="This is a mixed checkbox" mixed /></div>
 ```
+
+### Checkbox with complex children
+
+```
+<div><Checkbox>This is a <strong>complex</strong> text</Checkbox></div>
+```

--- a/react/Checkbox/index.jsx
+++ b/react/Checkbox/index.jsx
@@ -4,7 +4,16 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
 const Checkbox = props => {
-  const { className, value, name, label, error, mixed, ...restProps } = props
+  const {
+    className,
+    value,
+    name,
+    label,
+    error,
+    mixed,
+    children,
+    ...restProps
+  } = props
   return (
     <label
       className={cx(
@@ -17,7 +26,7 @@ const Checkbox = props => {
       aria-checked={mixed ? 'mixed' : ''}
     >
       <input type="checkbox" value={value} name={name} {...restProps} />
-      <span>{label}</span>
+      <span>{label || children}</span>
     </label>
   )
 }

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -222,6 +222,12 @@ exports[`Checkbox should render examples: Checkbox 3`] = `
 </div>"
 `;
 
+exports[`Checkbox should render examples: Checkbox 4`] = `
+"<div>
+  <div><label class=\\"styles__c-input-checkbox___2CzvY\\" aria-checked=\\"\\"><input type=\\"checkbox\\" name=\\"\\" value=\\"\\"><span>This is a <strong>complex</strong> text</span></label></div>
+</div>"
+`;
+
 exports[`Field should render examples: Field 1`] = `
 "<div>
   <form>


### PR DESCRIPTION
Useful to pass much complicated text with bold parts or links