### PR TITLE
SelectBox: Add boundaries prop to avoid overflow

### DIFF
--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -27,6 +27,46 @@ const options = [
 
 ### Props
 
+#### `container`
+
+Defines an element used as container for the SelectBox, especially when the
+option list is shown.
+
+This example should not cause an overflow on the SelectBoxWrapper component.
+
+```
+const options = [
+  { value: 'banana', label: 'Banana' },
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'lemon', label: 'Lemon' },
+  { value: 'strawberry', label: 'Strawberry' },
+  { value: 'vanilla', label: 'Vanilla' }
+];
+
+
+class SelectBoxWrapper extends React.Component {
+  constructor(props, context){
+    super(props, context)
+    this.container = React.createRef()
+  }
+
+  render(){
+    return (<div ref={this.container} style={{
+      height: '12rem',
+      padding: '.5rem',
+      overflow: 'auto'}}>
+      <SelectBox
+        container={this.container}
+        options={options}
+      />
+    </div>)
+  }
+}
+
+<SelectBoxWrapper />
+```
+
+
 #### `fullwidth`
 
 Set the select to spread to 100% of the available width (default: `false`).

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ReactSelect, { components } from 'react-select'
+
 import styles from './styles.styl'
 import Icon from '../Icon'
 import { dodgerBlue, silver, coolGrey } from '../palette'
@@ -47,6 +48,39 @@ const customStyles = props => ({
     zIndex: 10
   })
 })
+
+/**
+ * Determines maxHeight property for menuList component. This value is computed
+ * with a container element and the current SelectBox element.
+ * The container element defines an element which the SelectBox should not
+ * overflow.
+ * @param  {object} container React reference to an element containing
+ * the SelectBox
+ * @param  {object} element    React reference to the ReactSelect element
+ * @return {object}            A style object, with `menuList` property set.
+ */
+const computedMenuListHeightStyles = (container, selectElement) => {
+  if (!(container && selectElement)) return {}
+
+  const containerPaddingTop = container.style.paddingTop || '0px'
+  const containerPaddingBottom = container.style.paddingBottom || '0px'
+
+  return {
+    menuList: base => {
+      const basePaddings = (base.paddingTop || 0) + (base.paddingBottom || 0)
+      const spaceLeft =
+        container.getBoundingClientRect().bottom -
+        selectElement.getBoundingClientRect().bottom -
+        basePaddings
+      return {
+        ...base,
+        // containerPaddingTop and containerPaddingBottom can be in `rem`, so
+        // let's use calc()
+        maxHeight: `calc(${spaceLeft}px - ${containerPaddingTop} - ${containerPaddingBottom})`
+      }
+    }
+  }
+}
 
 const DropdownIndicator = props => {
   return (
@@ -197,6 +231,7 @@ class SelectBox extends Component {
   render() {
     const {
       className,
+      container,
       components,
       fullwidth,
       styles: reactSelectStyles,
@@ -216,6 +251,12 @@ class SelectBox extends Component {
           styles={{
             ...customStyles(this.props),
             ...reactSelectStyles,
+            ...computedMenuListHeightStyles(
+              // With React, the referenced element is in the current property.
+              // With Preact, the referenced element is the object
+              (container && container.current) || container,
+              this.element
+            )
           }}
           onMenuOpen={this.handleOpen}
           onMenuClose={this.handleClose}
@@ -239,6 +280,7 @@ class SelectBox extends Component {
 }
 
 SelectBox.propTypes = {
+  container: PropTypes.object,
   components: PropTypes.object,
   fullwidth: PropTypes.bool,
   size: PropTypes.oneOf(['tiny', 'medium', 'large']),
@@ -253,4 +295,11 @@ SelectBox.defaultProps = {
 }
 
 export default withBreakpoints()(SelectBox)
-export { Option, CheckboxOption, ActionsOption, reactSelectControl, components }
+export {
+  Option,
+  CheckboxOption,
+  ActionsOption,
+  computedMenuListHeightStyles,
+  reactSelectControl,
+  components
+}

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -184,6 +184,8 @@ ActionsOption.defaultProps = {
 
 class SelectBox extends Component {
   state = { isOpen: false }
+  element = null
+
   handleOpen = () => {
     this.setState({ isOpen: true })
   }
@@ -204,25 +206,34 @@ class SelectBox extends Component {
     } = this.props
     const showOverlay = this.state.isOpen && isMobile
     return (
-      <ReactSelect
-        components={{ DropdownIndicator, Option, ...components }}
-        styles={{ ...customStyles(this.props), ...reactSelectStyles }}
-        onMenuOpen={this.handleOpen}
-        onMenuClose={this.handleClose}
-        {...props}
-        className={classNames(
-          {
-            [styles['select__overlay']]: showOverlay,
-            [styles['select--autowidth']]: !fullwidth,
-            [styles['select--fullwidth']]: fullwidth
-          },
-          className
-        )}
-        // react-select temporarily adds className to its innerComponents
-        // but this behavior will soon be removed. For the moment, we
-        // cancel it by setting it to empty string
-        classNamePrefix={classNamePrefix || ''}
-      />
+      <div
+        ref={element => {
+          this.element = element
+        }}
+      >
+        <ReactSelect
+          components={{ DropdownIndicator, Option, ...components }}
+          styles={{
+            ...customStyles(this.props),
+            ...reactSelectStyles,
+          }}
+          onMenuOpen={this.handleOpen}
+          onMenuClose={this.handleClose}
+          {...props}
+          className={classNames(
+            {
+              [styles['select__overlay']]: showOverlay,
+              [styles['select--autowidth']]: !fullwidth,
+              [styles['select--fullwidth']]: fullwidth
+            },
+            className
+          )}
+          // react-select temporarily adds className to its innerComponents
+          // but this behavior will soon be removed. For the moment, we
+          // cancel it by setting it to empty string
+          classNamePrefix={classNamePrefix || ''}
+        />
+      </div>
     )
   }
 }

--- a/react/SelectBox/test/SelectBox.spec.js
+++ b/react/SelectBox/test/SelectBox.spec.js
@@ -1,0 +1,68 @@
+'use strict'
+/* eslint-env jest */
+import { computedMenuListHeightStyles } from '../SelectBox'
+
+describe('SelectBox', () => {
+  describe('computedMenuListHeightStyles', () => {
+    const fixtures = {
+      containerMock: {
+        getBoundingClientRect: jest.fn().mockReturnValue({
+          bottom: 235
+        }),
+        style: {
+          paddingTop: '1rem',
+          paddingBottom: '2rem'
+        }
+      },
+      selectMock: {
+        getBoundingClientRect: jest.fn().mockReturnValue({
+          bottom: 100
+        })
+      },
+      stylesBaseMock: {
+        paddingTop: 2,
+        paddingBottom: 2
+      }
+    }
+
+    it('returns expected style object', () => {
+      const styleClosures = computedMenuListHeightStyles(
+        fixtures.containerMock,
+        fixtures.selectMock
+      )
+      expect(typeof styleClosures.menuList).toBe('function')
+
+      expect(styleClosures.menuList(fixtures.stylesBaseMock)).toEqual({
+        paddingTop: 2,
+        paddingBottom: 2,
+        maxHeight: 'calc(131px - 1rem - 2rem)'
+      })
+    })
+
+    it('returns expected style object when container has no padding', () => {
+      const styleClosures = computedMenuListHeightStyles(
+        { ...fixtures.containerMock, style: {} },
+        fixtures.selectMock
+      )
+      expect(typeof styleClosures.menuList).toBe('function')
+
+      expect(styleClosures.menuList(fixtures.stylesBaseMock)).toEqual({
+        paddingTop: 2,
+        paddingBottom: 2,
+        maxHeight: 'calc(131px - 0px - 0px)'
+      })
+    })
+
+    it('returns expected style object when base styles have no padding', () => {
+      const styleClosures = computedMenuListHeightStyles(
+        fixtures.containerMock,
+        fixtures.selectMock
+      )
+      expect(typeof styleClosures.menuList).toBe('function')
+
+      expect(styleClosures.menuList({})).toEqual({
+        maxHeight: 'calc(135px - 1rem - 2rem)'
+      })
+    })
+  })
+})

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1073,13 +1073,39 @@ exports[`SelectBox should render examples: SelectBox 2`] = `
 
 exports[`SelectBox should render examples: SelectBox 3`] = `
 "<div>
+  <div style=\\"height: 12rem; padding: .5rem; overflow: auto;\\">
+    <div>
+      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+        <div class=\\"css-2zgoaw\\">
+          <div class=\\"css-1phseng\\">
+            <div class=\\"css-1492t68\\">Select...</div>
+            <div class=\\"css-1g6gooi\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-6-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+              </div>
+            </div>
+          </div>
+          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                <use xlink:href=\\"#bottom\\"></use>
+              </svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 4`] = `
+"<div>
   <div>
     <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
       <div class=\\"css-2zgoaw\\">
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
-            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-6-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
@@ -1095,7 +1121,7 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 4`] = `
+exports[`SelectBox should render examples: SelectBox 5`] = `
 "<div>
   <div>
     <div class=\\"u-mb-1\\">
@@ -1105,7 +1131,7 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
             <div class=\\"css-1phseng\\">
               <div class=\\"css-xp4uvy\\">I am a tiny SelectBox</div>
               <div class=\\"css-1g6gooi\\">
-                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                   <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
                 </div>
               </div>
@@ -1126,7 +1152,7 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
             <div class=\\"css-1phseng\\">
               <div class=\\"css-xp4uvy\\">I am a medium SelectBox</div>
               <div class=\\"css-1g6gooi\\">
-                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                   <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
                 </div>
               </div>
@@ -1147,7 +1173,7 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
             <div class=\\"css-1phseng\\">
               <div class=\\"css-xp4uvy\\">I am a large SelectBox</div>
               <div class=\\"css-1g6gooi\\">
-                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                   <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
                 </div>
               </div>
@@ -1165,7 +1191,7 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 5`] = `
+exports[`SelectBox should render examples: SelectBox 6`] = `
 "<div>
   <div>
     <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
@@ -1174,7 +1200,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
           <div class=\\"css-1phseng\\">
             <div class=\\"css-1492t68\\">Select...</div>
             <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
@@ -1184,30 +1210,6 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
                 <use xlink:href=\\"#bottom\\"></use>
               </svg></div>
           </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 6`] = `
-"<div>
-  <div>
-    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-      <div class=\\"css-2zgoaw\\">
-        <div class=\\"css-1phseng\\">
-          <div class=\\"css-1492t68\\">Select...</div>
-          <div class=\\"css-1g6gooi\\">
-            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-            </div>
-          </div>
-        </div>
-        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-              <use xlink:href=\\"#bottom\\"></use>
-            </svg></div>
         </div>
       </div>
     </div>
@@ -1254,46 +1256,8 @@ exports[`SelectBox should render examples: SelectBox 8`] = `
         </div>
         <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
           <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-              <use xlink:href=\\"#top\\"></use>
+              <use xlink:href=\\"#bottom\\"></use>
             </svg></div>
-        </div>
-      </div>
-      <div class=\\"css-1dhof61\\">
-        <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
-          <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
-            <div>
-              <div id=\\"react-select-13-option-0-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">D</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">E</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">F</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">G</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">H</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">I</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">J</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">K</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">L</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">M</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">N</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">O</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">P</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Q</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">R</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">S</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">T</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">U</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">V</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">W</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">X</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-0-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            </div>
-          </div>
-          <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
-            <div>
-              <div id=\\"react-select-13-option-1-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-              <div id=\\"react-select-13-option-1-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -1306,10 +1270,72 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
   <div>
     <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
       <div class=\\"css-2zgoaw\\">
-        <div class=\\"css-1phseng needsclick\\">
+        <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
             <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-14-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
+          </div>
+        </div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#top\\"></use>
+            </svg></div>
+        </div>
+      </div>
+      <div class=\\"css-1dhof61\\">
+        <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
+          <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
+            <div>
+              <div id=\\"react-select-14-option-0-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">D</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">E</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">F</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">G</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">H</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">I</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">J</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">K</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">L</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">M</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">N</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">O</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">P</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Q</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">R</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">S</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">T</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">U</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">V</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">W</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">X</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-0-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            </div>
+          </div>
+          <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
+            <div>
+              <div id=\\"react-select-14-option-1-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-14-option-1-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 10`] = `
+"<div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng needsclick\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-15-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
@@ -1325,7 +1351,7 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 10`] = `
+exports[`SelectBox should render examples: SelectBox 11`] = `
 "<div>
   <div>
     <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
@@ -1333,7 +1359,7 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
         <div class=\\"css-1phseng needsclick cz__value-container\\">
           <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
-            <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-15-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-16-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
@@ -1346,7 +1372,7 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
       </div>
       <div class=\\"css-1dhof61 needsclick cz__menu\\">
         <div class=\\"css-11unzgr needsclick cz__menu-list\\">
-          <div id=\\"react-select-15-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
+          <div id=\\"react-select-16-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
         </div>
       </div>
     </div>

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -242,39 +242,43 @@ exports[`Field should render examples: Field 3`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'am a SelectBox</label>
-      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-2zgoaw\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-1492t68\\">Select ...</div>
-            <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+      <div>
+        <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
+          <div class=\\"css-2zgoaw\\">
+            <div class=\\"css-1phseng\\">
+              <div class=\\"css-1492t68\\">Select ...</div>
+              <div class=\\"css-1g6gooi\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                  <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+                </div>
               </div>
             </div>
-          </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-                <use xlink:href=\\"#bottom\\"></use>
-              </svg></div>
+            <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+              <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                  <use xlink:href=\\"#bottom\\"></use>
+                </svg></div>
+            </div>
           </div>
         </div>
       </div>
     </div>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'am a SelectBox with a value</label>
-      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-2zgoaw\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-xp4uvy\\">Choice 2</div>
-            <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+      <div>
+        <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
+          <div class=\\"css-2zgoaw\\">
+            <div class=\\"css-1phseng\\">
+              <div class=\\"css-xp4uvy\\">Choice 2</div>
+              <div class=\\"css-1g6gooi\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                  <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+                </div>
               </div>
             </div>
-          </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-                <use xlink:href=\\"#bottom\\"></use>
-              </svg></div>
+            <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+              <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                  <use xlink:href=\\"#bottom\\"></use>
+                </svg></div>
+            </div>
           </div>
         </div>
       </div>
@@ -1016,148 +1020,13 @@ exports[`Radio should render examples: Radio 2`] = `
 
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-          </div>
-        </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#bottom\\"></use>
-          </svg></div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 2`] = `
-"<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-          </div>
-        </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#top\\"></use>
-          </svg></div>
-      </div>
-    </div>
-    <div class=\\"css-1dhof61\\">
-      <div class=\\"css-11unzgr\\">
-        <div id=\\"react-select-5-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Chocolate</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 3`] = `
-"<div>
-  <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-6-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-          </div>
-        </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#bottom\\"></use>
-          </svg></div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 4`] = `
-"<div>
   <div>
-    <div class=\\"u-mb-1\\">
-      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-        <div class=\\"css-1rg8gyn\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-xp4uvy\\">I am a tiny SelectBox</div>
-            <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-              </div>
-            </div>
-          </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-                <use xlink:href=\\"#bottom\\"></use>
-              </svg></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class=\\"u-mb-1\\">
-      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-        <div class=\\"css-15w89vh\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-xp4uvy\\">I am a medium SelectBox</div>
-            <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-              </div>
-            </div>
-          </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-                <use xlink:href=\\"#bottom\\"></use>
-              </svg></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class=\\"u-mb-1\\">
-      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-        <div class=\\"css-2zgoaw\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-xp4uvy\\">I am a large SelectBox</div>
-            <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-              </div>
-            </div>
-          </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-                <use xlink:href=\\"#bottom\\"></use>
-              </svg></div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 5`] = `
-"<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div><button>toggle options</button>
-      <div class=\\"styles__select-control__input___1xDlj\\">
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
-            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
@@ -1173,22 +1042,173 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 6`] = `
+exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
+          </div>
+        </div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#top\\"></use>
+            </svg></div>
+        </div>
+      </div>
+      <div class=\\"css-1dhof61\\">
+        <div class=\\"css-11unzgr\\">
+          <div id=\\"react-select-5-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Chocolate</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 3`] = `
+"<div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-6-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
+          </div>
+        </div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#bottom\\"></use>
+            </svg></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 4`] = `
+"<div>
+  <div>
+    <div class=\\"u-mb-1\\">
+      <div>
+        <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+          <div class=\\"css-1rg8gyn\\">
+            <div class=\\"css-1phseng\\">
+              <div class=\\"css-xp4uvy\\">I am a tiny SelectBox</div>
+              <div class=\\"css-1g6gooi\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                  <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+                </div>
+              </div>
+            </div>
+            <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+              <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                  <use xlink:href=\\"#bottom\\"></use>
+                </svg></div>
+            </div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#bottom\\"></use>
-          </svg></div>
+    </div>
+    <div class=\\"u-mb-1\\">
+      <div>
+        <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+          <div class=\\"css-15w89vh\\">
+            <div class=\\"css-1phseng\\">
+              <div class=\\"css-xp4uvy\\">I am a medium SelectBox</div>
+              <div class=\\"css-1g6gooi\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                  <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+                </div>
+              </div>
+            </div>
+            <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+              <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                  <use xlink:href=\\"#bottom\\"></use>
+                </svg></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class=\\"u-mb-1\\">
+      <div>
+        <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+          <div class=\\"css-2zgoaw\\">
+            <div class=\\"css-1phseng\\">
+              <div class=\\"css-xp4uvy\\">I am a large SelectBox</div>
+              <div class=\\"css-1g6gooi\\">
+                <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                  <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+                </div>
+              </div>
+            </div>
+            <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+              <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                  <use xlink:href=\\"#bottom\\"></use>
+                </svg></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 5`] = `
+"<div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div><button>toggle options</button>
+        <div class=\\"styles__select-control__input___1xDlj\\">
+          <div class=\\"css-1phseng\\">
+            <div class=\\"css-1492t68\\">Select...</div>
+            <div class=\\"css-1g6gooi\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+                <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+              </div>
+            </div>
+          </div>
+          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+            <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+                <use xlink:href=\\"#bottom\\"></use>
+              </svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 6`] = `
+"<div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
+          </div>
+        </div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#bottom\\"></use>
+            </svg></div>
+        </div>
       </div>
     </div>
   </div>
@@ -1197,20 +1217,22 @@ exports[`SelectBox should render examples: SelectBox 6`] = `
 
 exports[`SelectBox should render examples: SelectBox 7`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-12-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-12-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#bottom\\"></use>
-          </svg></div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#bottom\\"></use>
+            </svg></div>
+        </div>
       </div>
     </div>
   </div>
@@ -1219,56 +1241,58 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 
 exports[`SelectBox should render examples: SelectBox 8`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-13-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-13-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#top\\"></use>
-          </svg></div>
-      </div>
-    </div>
-    <div class=\\"css-1dhof61\\">
-      <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
-        <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
-          <div>
-            <div id=\\"react-select-13-option-0-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">D</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">E</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">F</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">G</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">H</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">I</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">J</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">K</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">L</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">M</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">N</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">O</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">P</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Q</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">R</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">S</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">T</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">U</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">V</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">W</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">X</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-0-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-          </div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#top\\"></use>
+            </svg></div>
         </div>
-        <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
-          <div>
-            <div id=\\"react-select-13-option-1-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-13-option-1-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+      </div>
+      <div class=\\"css-1dhof61\\">
+        <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
+          <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
+            <div>
+              <div id=\\"react-select-13-option-0-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">D</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">E</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">F</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">G</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">H</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">I</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">J</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">K</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">L</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">M</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">N</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">O</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">P</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Q</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">R</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">S</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">T</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">U</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">V</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">W</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">X</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-0-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            </div>
+          </div>
+          <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
+            <div>
+              <div id=\\"react-select-13-option-1-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+              <div id=\\"react-select-13-option-1-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            </div>
           </div>
         </div>
       </div>
@@ -1279,20 +1303,22 @@ exports[`SelectBox should render examples: SelectBox 8`] = `
 
 exports[`SelectBox should render examples: SelectBox 9`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
-      <div class=\\"css-1phseng needsclick\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-14-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-1phseng needsclick\\">
+          <div class=\\"css-1492t68\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-14-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#bottom\\"></use>
-          </svg></div>
+        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#bottom\\"></use>
+            </svg></div>
+        </div>
       </div>
     </div>
   </div>
@@ -1301,25 +1327,27 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
 
 exports[`SelectBox should render examples: SelectBox 10`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw needsclick cz__control\\">
-      <div class=\\"css-1phseng needsclick cz__value-container\\">
-        <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-15-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+  <div>
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw needsclick cz__control\\">
+        <div class=\\"css-1phseng needsclick cz__value-container\\">
+          <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
+          <div class=\\"css-1g6gooi\\">
+            <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-15-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+            </div>
           </div>
         </div>
+        <div class=\\"css-1wy0on6 needsclick cz__indicators\\"><span class=\\"css-1hyfx7x needsclick cz__indicator-separator\\"></span>
+          <div aria-hidden=\\"true\\" class=\\"css-n6ypum needsclick cz__indicator needsclick cz__dropdown-indicator\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <use xlink:href=\\"#top\\"></use>
+            </svg></div>
+        </div>
       </div>
-      <div class=\\"css-1wy0on6 needsclick cz__indicators\\"><span class=\\"css-1hyfx7x needsclick cz__indicator-separator\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum needsclick cz__indicator needsclick cz__dropdown-indicator\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#top\\"></use>
-          </svg></div>
-      </div>
-    </div>
-    <div class=\\"css-1dhof61 needsclick cz__menu\\">
-      <div class=\\"css-11unzgr needsclick cz__menu-list\\">
-        <div id=\\"react-select-15-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
+      <div class=\\"css-1dhof61 needsclick cz__menu\\">
+        <div class=\\"css-11unzgr needsclick cz__menu-list\\">
+          <div id=\\"react-select-15-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
In Cozy-Harvest-Lib we faced an overflow issue with the SelectBox component:

![capture d ecran 2019-01-16 a 16 47 54](https://user-images.githubusercontent.com/776764/51266826-87899e80-19bc-11e9-942f-d2a52f23bd07.png)


This issue could be resolved in several way:
* Limit the height
* Use a React Portal to show the menu list below all the other element in the DOM

There is already an height limitation in PR #795.

Portaling does not work with preact, and Cozy-Home is still in Preact.

In this PR we propose another solution: give an element as boundaries, and
not expand the menu list outside those boundaries.

With this PR, our first issue is resolved and our SelectBox in Cozy-Harvest-Lib
now looks like this:

![capture d ecran 2019-01-16 a 18 11 55](https://user-images.githubusercontent.com/776764/51266835-8f494300-19bc-11e9-897c-0c2ac67559b1.png)

You can have a preview [here](https://gregorylegarec.github.io/cozy-ui/react/#!/SelectBox/5).