### PR TITLE
fix: 🐛 Invalid input show style only on blur

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -266,7 +266,7 @@ $input-text
         outline 0
 
     &.is-error
-    &:invalid
+    &:not(:focus):invalid
         border rem(1) solid pomegranate
 
 input-text--tiny =


### PR DESCRIPTION
It now shows the red borders for `:invalid` inputs only when your're not focus in it. 

That way it doesn't get red prematurely, like when you're typing the first letters of your email in a mail input and it gets red right away even if you're not finished. That sent the wrong UX message.