### PR TITLE
feat: Add MuiSwitch style to global MUI theme

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -104,6 +104,48 @@ export const theme = createMuiTheme({
         paddingLeft: 24,
         paddingRight: 24
       }
+    },
+    MuiSwitch: {
+      root: {
+        width: 40,
+        height: 23
+      },
+      switchBase: {
+        width: 25,
+        height: 23
+      },
+      checked: {
+        '& + $bar': {
+          opacity: 1
+        }
+      },
+      icon: {
+        width: 16,
+        height: 16
+      },
+      bar: {
+        width: 25,
+        height: 12,
+        marginTop: -6,
+        marginLeft: -12,
+        backgroundColor: '#d6d8da',
+        opacity: 1
+      },
+      colorPrimary: {
+        '&$checked': {
+          color: 'white'
+        }
+      },
+      colorSecondary: {
+        '&$checked': {
+          color: 'white'
+        }
+      },
+      disabled: {
+        '&$switchBase': {
+          color: 'white'
+        }
+      }
     }
   }
 })

--- a/react/Toggle/Readme.md
+++ b/react/Toggle/Readme.md
@@ -20,7 +20,7 @@
 
 #### Disabled
 ```js
-<Toggle id="toggle" disabled={false} />
+<Toggle id="toggle" disabled />
 ```
 
 ### More complex example

--- a/react/Toggle/index.jsx
+++ b/react/Toggle/index.jsx
@@ -1,37 +1,39 @@
-import styles from './styles.styl'
-
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import MuiCozyTheme from '../MuiCozyTheme'
+import Switch from '@material-ui/core/Switch'
+import omit from 'lodash/omit'
 
 class Toggle extends Component {
-  onChange(e) {
+  onChange = (e, checked) => {
+    // The legacy `onToggle` prop takes only the checked state
     if (this.props.onToggle) {
-      this.props.onToggle(e.target.checked)
+      this.props.onToggle(checked)
+    }
+
+    // MUI's `onChange` props takes the event and the checked state
+    if (this.props.onChange) {
+      this.props.onChange(e, checked)
     }
   }
+
   render() {
-    const { id, checked = false, disabled = false } = this.props
+    // `onToggle` is not a valid prop for MUI's `Switch`, so we omit it
+    // `onToggle` will be used in `onChange`
+    const switchProps = omit(this.props, ['onToggle'])
+
     return (
-      <span className={styles['toggle']}>
-        <input
-          type="checkbox"
-          id={id}
-          className={styles['checkbox']}
-          checked={checked}
-          disabled={disabled}
-          onChange={this.onChange.bind(this)}
-        />
-        <label htmlFor={id} className={styles['label']} />
-      </span>
+      <MuiCozyTheme>
+        <Switch {...switchProps} color="primary" onChange={this.onChange} />
+      </MuiCozyTheme>
     )
   }
 }
 
-Toggle.propTypes = {
-  id: PropTypes.string.isRequired, // A unique id for the toggle, used internally.
-  checked: PropTypes.bool, // The state of the toggle
-  disabled: PropTypes.bool, // Guess what...
-  onToggle: PropTypes.func // A callback when the state of the toggle changes. Called with the new state as argument.
+Toggle.propsTypes = {
+  ...Switch.propTypes,
+  /** A callback when the state of the toggle changes. Called with the new state as argument. This is for backward compatibility purposes only. You should use `onChange` prop */
+  onToggle: PropTypes.func
 }
 
 export default Toggle

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1010,6 +1010,8 @@ exports[`MuiCozyTheme/ExpansionPanel should render examples: MuiCozyTheme/Expans
 
 exports[`MuiCozyTheme/Menus should render examples: MuiCozyTheme/Menus 1`] = `"<div></div>"`;
 
+exports[`MuiCozyTheme/Switch should render examples: MuiCozyTheme/Switch 1`] = `"<div></div>"`;
+
 exports[`Radio should render examples: Radio 1`] = `
 "<div>
   <form>


### PR DESCRIPTION
This adds the Switch component to our MUI theme. You can see the result on https://drazik.github.io/cozy-ui/react/#switch.