### PR TITLE
feat(Toggle): Add subtle variant

### DIFF
--- a/react/Toggle/Readme.md
+++ b/react/Toggle/Readme.md
@@ -23,6 +23,40 @@
 <Toggle id="toggle" disabled={false} />
 ```
 
+### Variants
+
+#### Normal
+
+```jsx
+<div>
+  <div>
+    <Toggle id="toggle" /> Normal not checked
+  </div>
+  <div>
+    <Toggle id="toggle" checked /> Normal checked
+  </div>
+  <div>
+    <Toggle id="toggle" disabled /> Normal disabled
+  </div>
+</div>
+```
+
+#### Subtle
+
+```jsx
+<div>
+  <div>
+    <Toggle id="toggle" variant="subtle" /> Sublte not checked
+  </div>
+  <div>
+    <Toggle id="toggle" variant="subtle" checked /> Subtle checked
+  </div>
+  <div>
+    <Toggle id="toggle" variant="subtle" disabled /> Subtle disabled
+  </div>
+</div>
+```
+
 ### More complex example
 
 ```jsx

--- a/react/Toggle/index.jsx
+++ b/react/Toggle/index.jsx
@@ -2,6 +2,7 @@ import styles from './styles.styl'
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 class Toggle extends Component {
   onChange(e) {
@@ -10,9 +11,15 @@ class Toggle extends Component {
     }
   }
   render() {
-    const { id, checked = false, disabled = false } = this.props
+    const {
+      id,
+      checked = false,
+      disabled = false,
+      variant = 'normal'
+    } = this.props
+
     return (
-      <span className={styles['toggle']}>
+      <span className={cx(styles['toggle'], styles[`toggle--${variant}`])}>
         <input
           type="checkbox"
           id={id}
@@ -31,7 +38,8 @@ Toggle.propTypes = {
   id: PropTypes.string.isRequired, // A unique id for the toggle, used internally.
   checked: PropTypes.bool, // The state of the toggle
   disabled: PropTypes.bool, // Guess what...
-  onToggle: PropTypes.func // A callback when the state of the toggle changes. Called with the new state as argument.
+  onToggle: PropTypes.func, // A callback when the state of the toggle changes. Called with the new state as argument.
+  variant: PropTypes.oneOf(['normal', 'subtle'])
 }
 
 export default Toggle

--- a/react/Toggle/styles.styl
+++ b/react/Toggle/styles.styl
@@ -6,6 +6,12 @@
     width   rem(40)
     height  rem(24)
 
+.toggle--subtle
+    width rem(25)
+    height rem(16)
+    display inline-flex
+    align-items center
+
 .checkbox
     display none
 
@@ -33,8 +39,23 @@
     background    white
     transition    all .2s ease-out
 
+.toggle--subtle .label
+    height rem(12)
+
+.toggle--subtle .label:before
+    width rem(16)
+    height rem(16)
+    box-shadow 0 2px 2px 0 rgba(0, 0, 0, 0.12), 0 0 2px 0 rgba(0, 0, 0, 0.24)
+    left rem(-2)
+
 .checkbox:checked + .label
     background emerald
 
     &:before
         left rem(18)
+
+.toggle--subtle .checkbox:checked + .label
+    background var(--dodgerBlue)
+
+    &:before
+        left rem(9)

--- a/react/Toggle/styles.styl
+++ b/react/Toggle/styles.styl
@@ -59,3 +59,6 @@
 
     &:before
         left rem(9)
+
+.checkbox:disabled + .label
+    cursor default


### PR DESCRIPTION
This adds a `subtle` variant to the `Toggle` component. This variant is needed in Banks for the new panels UI on the "current balance" page.

![image](https://user-images.githubusercontent.com/1606068/51393157-52558b80-1b37-11e9-83f1-9677d25bcc2b.png)

See https://drazik.github.io/cozy-ui/react/#toggle