### PR TITLE
feat: ✨ Button font-size matches its size

### DIFF
--- a/react/Text/styles.styl
+++ b/react/Text/styles.styl
@@ -18,15 +18,3 @@
 .u-caption
     @extend $caption
 
-.u-t-left
-    @extend $left
-
-.u-t-right
-    @extend $right
-
-.u-t-center
-    @extend $center
-
-.u-t-justify
-    @extend $justify
-

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -293,6 +293,8 @@ button--tiny =
     min-height rem(24)
     min-width rem(80)
     padding rem(2 16)
+    font-size rem(12)
+    line-height 1.3
 $button--tiny
     {button--tiny}
 
@@ -300,6 +302,8 @@ button--small =
     min-height rem(32)
     min-width rem(96)
     padding rem(3 8)
+    font-size rem(13)
+    line-height 1.4
 $button--small
     {button--small}
 
@@ -308,6 +312,7 @@ button--large =
     min-width rem(160)
     padding rem(8 24)
     font-size rem(16)
+    line-height 1.5
 $button--large
     {button--large}
 

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -819,6 +819,43 @@ Display an chip that represents complex identity
 */
 
 /*
+ Font-size
+
+ Sets various font-size to a text
+
+ Markup:
+ <p class="{{modifier_class}}">Aliquam etiam natoque phasellus habitant interdum a hendrerit ac aliquet</p>
+
+ .u-fz-tiny - Sets a tiny font-size (12px)
+ .u-fz-xsmall - Sets a xsmall font-size (13px)
+ .u-fz-small - Sets a small font-size (14px)
+ .u-fz-medium - Sets a medium font-size (16px)
+ .u-fz-large - Sets a large font-size (18px)
+
+ Weight: 6
+
+ Styleguide utilities.text.fontsize
+*/
+
+/*
+ Text alignement
+
+ Sets a text alignement to a text
+
+ Markup:
+ <p class="{{modifier_class}}">Facilisis eget nam turpis id adipiscing facilisi odio ut fames, aliquet laoreet felis habitasse tincidunt litora leo senectus.</p>
+
+ .u-ta-left - Sets a left alignment
+ .u-ta-right - Sets a right alignment
+ .u-ta-center - Sets a center alignment
+ .u-ta-justify - Sets a justify alignment
+
+ Weight: 7
+
+ Styleguide utilities.text.alignment
+*/
+
+/*
  Ellipsis
 
  Adds ellipsis to a long text
@@ -829,7 +866,7 @@ Display an chip that represents complex identity
 
  .u-ellipsis - Ellipsis at the end
 
- Weight: 6
+ Weight: 8
 
  Styleguide utilities.text.ellipsis
 */
@@ -846,7 +883,7 @@ Display an chip that represents complex identity
 
  .u-midellipsis - Ellipsis in the middle
 
- Weight: 7
+ Weight: 9
 
  Styleguide utilities.text.midellipsis
 */
@@ -864,10 +901,6 @@ Display an chip that represents complex identity
  <h4 class="u-title-h4">Heading 4</h4>
  <p class="u-text">Basic text</p>
  <p class="u-caption">Caption text</p>
- <p class="u-t-left">Left aligned text</p>
- <p class="u-t-right">Right aligned text</p>
- <p class="u-t-center">Center aligned text</p>
- <p class="u-t-justify">Justify aligned text</p>
 
  Weight: -1
 

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -61,6 +61,58 @@ $midellipsis
         > :first-child
             text-overflow '[...]'
 
+// @stylint off
+fz-tiny =
+    font-size rem(12)!important
+    line-height 1.3!important
+$fz-tiny
+    {fz-tiny}
+
+fz-xsmall =
+    font-size rem(13)!important
+    line-height 1.4!important
+$fz-xsmall
+    {fz-xsmall}
+
+fz-small =
+    font-size rem(14)!important
+    line-height 1.4!important
+$fz-small
+    {fz-small}
+
+fz-medium =
+    font-size rem(16)!important
+    line-height 1.5!important
+$fz-medium
+    {fz-medium}
+
+fz-large =
+    font-size rem(18)!important
+    line-height 1.5!important
+$fz-large
+    {fz-large}
+
+ta-left =
+    text-align left!important
+$ta-left
+    {ta-left}
+
+ta-right =
+    text-align right!important
+$ta-right
+    {ta-right}
+
+ta-center =
+    text-align center!important
+$ta-center
+    {ta-center}
+
+ta-justify =
+    text-align justify!important
+$ta-justify
+    {ta-justify}
+// @stylint on
+
 // Global classes
 global('.u-error', $error)
 global('.u-error--warning', $error-warning)
@@ -68,3 +120,12 @@ global('.u-valid', $valid)
 global('.u-warn', $warn)
 global('.u-ellipsis', $ellipsis)
 global('.u-midellipsis', $midellipsis)
+global('.u-fz-tiny', $fz-tiny)
+global('.u-fz-xsmall', $fz-xsmall)
+global('.u-fz-small', $fz-small)
+global('.u-fz-medium', $fz-medium)
+global('.u-fz-large', $fz-large)
+global('.u-ta-left', $ta-left)
+global('.u-ta-right', $ta-right)
+global('.u-ta-center', $ta-center)
+global('.u-ta-justify', $ta-justify)


### PR DESCRIPTION
Button variants with different sizes have now a matching font-size.

<img width="193" alt="screenshot 2019-01-18 18 55 12" src="https://user-images.githubusercontent.com/1280069/51404291-44adff00-1b53-11e9-9fd3-94fbf06e5324.png">

Normal button size -> font-size = 14px
Small button size -> font-size = 13px
Tiny button size -> font-size = 12px
Large button size -> font-size = 16px

Also added utility classes to handle font-size to a given text:
```
 .u-fz-tiny - Sets a tiny font-size (12px)
 .u-fz-xsmall - Sets a xsmall font-size (13px)
 .u-fz-small - Sets a small font-size (14px)
 .u-fz-medium - Sets a medium font-size (16px)
 .u-fz-large - Sets a large font-size (18px)
```

And finally, I fixed text-alignment utility classes by moving them to the right place and renaming them more clearly.