### PR TITLE
fix(field): Right position different with & whithout fullwidth

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -61,7 +61,7 @@ const options = [
 </form>
 ```
 
-##### Password field without show/hide button
+#### Password field without show/hide button
 
 ```
 <form>
@@ -74,7 +74,7 @@ const options = [
 </form>
 ```
 
-##### Password field without show/hide button
+#### Side element
 
 ```
 <form>
@@ -84,3 +84,16 @@ const options = [
   />
 </form>
 ```
+
+#### Side element with fullwidth element
+
+```
+<form>
+  <Field
+    label="I'm a label"
+    side="(optional)"
+    fullwidth={true}
+  />
+</form>
+```
+

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -19,7 +19,7 @@ class InputPassword extends React.Component {
   }
 
   render() {
-    const { hideLabel, showLabel, showVisibilityButton } = this.props
+    const { hideLabel, showLabel, showVisibilityButton, fullwidth } = this.props
     const { visible } = this.state
     return (
       <div className={styles['o-field-input']}>
@@ -27,7 +27,8 @@ class InputPassword extends React.Component {
           <div
             className={cx(
               labelStyles['c-label'],
-              styles['o-field-input-action']
+              styles['o-field-input-action'],
+              { [styles['o-side-fullwidth']]: fullwidth }
             )}
             onClick={() => this.toggleVisibility()}
           >
@@ -135,7 +136,11 @@ const Field = props => {
     <div className={cx(styles['o-field'], className)}>
       <Label htmlFor={id}>{label}</Label>
       {side && (
-        <div className={cx(styles['o-side'], labelStyles['c-label'])}>
+        <div
+          className={cx(styles['o-side'], labelStyles['c-label'], {
+            [styles['o-side-fullwidth']]: fullwidth
+          })}
+        >
           {side}
         </div>
       )}

--- a/react/Field/styles.styl
+++ b/react/Field/styles.styl
@@ -10,9 +10,15 @@
 .o-side
     position absolute
     top 0
-    right 0
+    left 0
+    width 100%
+    max-width rem(512)
+    text-align right
     cursor pointer
     text-transform unset
+
+.o-side-fullwidth
+    max-width 100%
 
 .o-field-input-action
     @extend .o-side

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -316,6 +316,16 @@ exports[`Field should render examples: Field 5`] = `
 </div>"
 `;
 
+exports[`Field should render examples: Field 6`] = `
+"<div>
+  <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'm a label</label>
+      <div class=\\"styles__o-side___tXbXL styles__c-label___o4ozG styles__o-side-fullwidth___7WcCI\\">(optional)</div><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR styles__c-input-text--fullwidth___33o_f\\" placeholder=\\"\\" value=\\"\\">
+    </div>
+  </form>
+</div>"
+`;
+
 exports[`Hero should render examples: Hero 1`] = `
 "<div>
   <div class=\\"styles__Hero___14z7_\\">


### PR DESCRIPTION
The position of the side element should be align on the right of the input.
With or without fullwidth option.