### PR TITLE
fix: Stylus build without webpack's css loader

### DIFF
--- a/stylus/generic/normalize.styl
+++ b/stylus/generic/normalize.styl
@@ -20,4 +20,4 @@
 
     Styleguide Generic.normalize
 */
-@require '~normalize.css/normalize.css'
+@require 'normalize.css/normalize.css'

--- a/stylus/index.js
+++ b/stylus/index.js
@@ -12,13 +12,16 @@
 var path = require('path')
 var stylus = require('stylus')
 
+const NODE_MODULES_PATH = path.resolve(__dirname, '../..')
+
 var plugin = function () {
   return function (style) {
     style.set('include css', true)
     style.include(__dirname)
     style.define('embed', stylus.url({
-      paths: [path.join(__dirname, '../assets')]
-    }))
+        paths: [path.join(__dirname, '../assets')]
+      }))
+    style.set('paths', [...style.options.paths, NODE_MODULES_PATH])
     return style
   }
 }


### PR DESCRIPTION
To locate `node_modules/normalize.css` from stylus
we used to use a `~` character that webpack's
css loader is able to interpret.
But if you use the stylus CLI to generate css files
you cannot use `~` character.
But you can add a path to resolve the path.

See https://github.com/webpack-contrib/css-loader#url
And https://github.com/cozy/cozy-ui/pull/233/files
And http://stylus-lang.com/docs/import.html

__[EDIT]__
See styleguidist here: https://enguerran.github.io/cozy-ui/react/