### PR TITLE
feat: Make the CSS in dist 7kb lighter ✨

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cozy-ui",
   "version": "0.0.0-development",
-  "description": "Cozy apps Ui SDK",
+  "description": "Cozy apps UI SDK",
   "main": "./index.js",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/cozy/cozy-ui",
   "scripts": {
-    "build:css": "stylus -c --include stylus -o dist/cozy-ui.min.css stylus/cozy-ui/build.styl --use ./node_modules/autoprefixer-stylus --with \"{ browsers: ['last 2 versions'] }\" --include-css",
+    "build:css": "stylus -c --include stylus -o dist/cozy-ui.min.css stylus/cozy-ui/build.styl --use ./node_modules/autoprefixer-stylus --with \"{ browsers: ['last 2 versions'] }\"",
     "build:css:app": "stylus --include stylus -o build/styleguide/app.css stylus/cozy-ui/build.styl --use ./node_modules/autoprefixer-stylus --with \"{ browsers: ['last 2 versions'] }\" --include-css",
     "build:doc": "npm-run-all 'build:doc:*'",
     "build:doc:config": "copyfiles -u 1 docs/*.md docs/_config.yml build",
@@ -29,7 +29,7 @@
     "lint:js": "eslint 'react/**/*.jsx' 'react/**/*.js'",
     "lint:stylus": "stylint stylus --config .stylintrc",
     "palette": "scripts/make-palette.sh",
-    "prebuild:css": "mkdir -p dist/",
+    "prebuild:css": "mkdir -p dist/ && stylus -C node_modules/normalize.css/normalize.css node_modules/normalize.css/normalize.styl",
     "prebuild:css:app": "mkdir -p build/styleguide",
     "prebuild:doc:kss": "run-s clean:doc:kss build:css:app",
     "prepare": "yarn release",

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -1,7 +1,7 @@
 @require '../settings/z-index'
 @require '../components/button'
 @require '../tools/mixins'
-/*!
+/*
  * NOTIFICATIONS
  * =============
  *

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -10,7 +10,7 @@
 @require '../settings/*'
 @require '../tools/*'
 @require '../generic/animations'
-@require '../../node_modules/normalize.css/normalize.css'
+@require '../../node_modules/normalize.css/normalize'
 @require '../elements/*'
 @require '../objects/*'
 @require '../components/*'


### PR DESCRIPTION
By transforming normalize.css to a stylus file and loading this file, stylus can remove the comments from this file. It makes the CSS file in dist/ 7kb lighter (from 84kb to 77kb).
