### PR TITLE
refactor: Refactored style for Empty view

### DIFF
--- a/stylus/components/empty.styl
+++ b/stylus/components/empty.styl
@@ -1,6 +1,9 @@
 @require '../settings/palette'
 @require '../settings/breakpoints'
 @require '../tools/mixins'
+@require '../objects/layouts'
+
+contentHeight = barHeight + navHeight
 
 $empty
     display          flex
@@ -12,19 +15,16 @@ $empty
     text-align       center
 
     +medium-screen()
-        height 100%
-        width 100%
-        position fixed
-        top 0
-        left 0
-        pointer-events none
+        margin-top 'calc(50vh - %s)' % contentHeight
+        transform translateY(-50%)
 
 $empty-img
     display              block
-    margin               0 auto rem(32)
+    margin               0 auto rem(16)
     height               rem(140)
 
     +medium-screen()
+        margin-bottom rem(8)
         height  rem(105)
 
 $empty-title

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -5,6 +5,12 @@
 @require '../elements/defaults'
 
 /*------------------------------------*\
+  Layout vars
+\*------------------------------------*/
+barHeight = rem(48)
+navHeight = rem(48)
+
+/*------------------------------------*\
   Layouts
 \*------------------------------------*/
 
@@ -94,7 +100,12 @@ $app
         &:after
             content ''
             display block
-            height rem(48)
+
+        &:before
+            height barHeight
+
+        &:after
+            height navHeight
 
 // STICKY layout
 // When you want a sidebar and you want it to act like a sticky footer on mobile


### PR DESCRIPTION
So I removed the fixed positionning and added a `margin-top` to the Empty element according to the viewport height (minus the height of the cozy-bar and the navigation to be a little more precise), which basically should render exactly the same as before but without overlapping any other element so no more "pointer-events" issue.

The fix in Drive about that would be removable but won't break things if it stays (which it shouldn't obviously) so you have time to clean this up.

Also reduced the `margin-bottom` of the icon as requested by the designers.