### PR TITLE
feat(Modal): ✨ Add ModalContent fixed props

### DIFF
--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -170,6 +170,33 @@ const headerStyle = {
 </div>
 ```
 
+### Complex modals with fixed content
+
+If you need a part of your modal content fixed (not scrollable) and the other part scrollable, you need to compose you own complex modal.
+
+```
+const { ModalContent, ModalHeader, ModalFooter } = Modal;
+
+<div>
+  <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  {state.modalOpened &&
+    <Modal
+        overflowHidden={true}
+        dismissAction={()=>setState({ modalOpened: false})} >
+      <ModalHeader title="Augusta Ada King-Noel, Countess of Lovelace" />
+      <ModalContent fixed className='u-pv-1'>
+        { content.ada.short }
+      </ModalContent>
+      <ModalContent>
+        { content.ada.long }
+      </ModalContent>
+      <ModalFooter><strong>This a custom footer</strong></ModalFooter>
+    </Modal>}
+</div>
+```
+
 ### Branded modals
 
 If you need a modal with a branded header when you have a brand related content.

--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -88,13 +88,16 @@ class ModalContent extends Component {
   }
 
   render() {
-    const { className } = this.props
+    const { className, fixed } = this.props
 
     const { displayGhostHeader } = this.state
     const { animatedHeader, childrenToRender } = this
     return (
       <div
-        className={cx(styles['c-modal-content'], className)}
+        className={cx(
+          styles[`c-modal-content${fixed ? '-fixed' : ''}`],
+          className
+        )}
         ref={div => {
           this.scrollingContent = div
         }}
@@ -433,7 +436,8 @@ ModalHeader.propTypes = {
 
 ModalContent.propTypes = {
   iconSrc: PropTypes.node,
-  iconDest: PropTypes.node
+  iconDest: PropTypes.node,
+  fixed: PropTypes.bool
 }
 
 const EnhancedModal = migrateProps([

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -74,6 +74,9 @@
 .c-modal-content
     @extend $modal-content
 
+.c-modal-content-fixed
+    @extend $modal-content-fixed
+
 .c-modal--small-spacing
     .c-modal-close
         @extend $modal-close--small
@@ -81,6 +84,8 @@
         @extend $modal-header--small
     .c-modal-content
         @extend $modal-content--small
+    .c-modal-content-fixed
+        @extend $modal-content-fixed--small
 
 .c-modal--large-spacing
     .c-modal-close
@@ -89,6 +94,8 @@
         @extend $modal-header--large
     .c-modal-content
         @extend $modal-content--large
+    .c-modal-content-fixed
+        @extend $modal-content-fixed--large
 
 .c-modal-close
     @extend $modal-close

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -166,6 +166,23 @@ $modal-header-app-icon
     height rem(18)
     margin-right rem(8)
 
+$modal-content-fixed
+    border-bottom rem(1) solid silver
+    flex 0 0 auto
+    padding 0 medium-padding
+
+$modal-content-fixed--small
+    padding 0 small-padding
+
+    +tiny-screen()
+        padding 0 tiny-padding
+
+$modal-content-fixed--large
+    padding 0 large-padding
+
+    +tiny-screen()
+        padding 0 medium-padding
+
 $modal-content
     @extend $elastic-content
     padding 0 medium-padding


### PR DESCRIPTION
Fixes: #653

`ModalContent` has a new props `fixed` that turn this scrollable (by default) element into a non-scrollable one making it look like a fixed element of the modal.

[Preview](https://gooz.github.io/cozy-ui/react/#modal) 