### PR TITLE
fix(wizard): Fluid fixed header

### DIFF
--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -244,14 +244,16 @@ $wizard-header-fixed
     position fixed
     top rem(14)
     left 0
-    padding-left rem(32)
+    display inline-flex
+    align-items center
 
 $wizard-previous
-    margin 0 0 0 -2rem
+    margin 0
     padding rem(10) rem(16)
     color coolGrey
 
 $wizard-brand
+    margin-left rem(32)
     +small-device()
         display none
 


### PR DESCRIPTION
Wizard's fixed header is a little bit smarter.
Margins are handled by the children elements instead of the parent.