### PR TITLE
Field: Expose autocomplete

### DIFF
--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -55,6 +55,7 @@ InputPassword.defaultProps = {
 
 const Field = props => {
   const {
+    autoComplete,
     className,
     disabled,
     fieldProps,
@@ -95,6 +96,7 @@ const Field = props => {
       case 'password':
         return (
           <InputPassword
+            autoComplete={autoComplete}
             disabled={disabled}
             fullwidth={fullwidth}
             id={id}
@@ -116,6 +118,7 @@ const Field = props => {
       case 'text':
         return (
           <Input
+            autoComplete={autoComplete}
             disabled={disabled}
             fullwidth={fullwidth}
             id={id}
@@ -154,6 +157,7 @@ const Field = props => {
 }
 
 Field.propTypes = {
+  autoComplete: PropTypes.string,
   fieldProps: PropTypes.object,
   fullwidth: PropTypes.bool,
   label: PropTypes.string.isRequired,

--- a/react/Input/index.jsx
+++ b/react/Input/index.jsx
@@ -5,6 +5,7 @@ import styles from './styles.styl'
 
 const Input = props => {
   const {
+    autoComplete,
     disabled,
     type,
     id,
@@ -20,6 +21,7 @@ const Input = props => {
   return (
     <input
       aria-disabled={disabled}
+      autoComplete={autoComplete}
       type={type}
       id={id}
       ref={inputRef}
@@ -41,6 +43,7 @@ const Input = props => {
 }
 
 Input.propTypes = {
+  autoComplete: PropTypes.string,
   disabled: PropTypes.bool,
   type: PropTypes.oneOf(['date', 'email', 'password', 'text', 'url']),
   id: PropTypes.string,


### PR DESCRIPTION
To manage autocompletion behavior in cozy-harvest-lib, we
need to be able to specify the `autocomplete` attribute of
`<input />` elements.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete