### PR TITLE
fix: Layout issue on iPhone X

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -88,6 +88,7 @@ $app
         main
             padding-left env(safe-area-inset-left)
             padding-right env(safe-area-inset-right)
+            padding-bottom env(safe-area-inset-bottom)
 
         main,
         main > [role=contentinfo], // Deprecated


### PR DESCRIPTION
Add padding-bottom to `main` in order display correctly on iPhone X.

This is a relive of https://github.com/cozy/cozy-ui/pull/822 

This time this commit is well tested on native & web (drive) 