### PR TITLE
fix(Button): Expose size===normal

### DIFF
--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -36,6 +36,7 @@ const { Button } = require('./index');
 <div>
   <p><Button size='tiny' label='Tiny' /></p>
   <p><Button size='small' label='Small' /></p>
+  <p><Button size='normal' label='Normal' /></p>
   <p><Button label='Normal' /></p>
   <p><Button size='large' label='Large' /></p>
 </div>

--- a/react/Button/index.jsx
+++ b/react/Button/index.jsx
@@ -10,7 +10,7 @@ const btnClass = function(options) {
     styles['c-btn'],
     {
       [styles[`c-btn--${theme}`]]: theme,
-      [styles[`c-btn--${size}`]]: size,
+      [styles[`c-btn--${size}`]]: size !== 'normal',
       [styles[`c-btn--${variant}`]]: variant,
       [styles[`c-btn--${extension}`]]: extension,
       [styles[`c-btn--round`]]: round
@@ -116,7 +116,7 @@ Button.propTypes = {
   /** Displays only the icon, not the label */
   iconOnly: PropTypes.bool,
   theme: PropTypes.string,
-  size: PropTypes.oneOf(['tiny', 'small', 'large']),
+  size: PropTypes.oneOf(['tiny', 'small', 'large', 'normal']),
   /** Spacing of the button */
   extension: PropTypes.oneOf(['narrow', 'full']),
   /** Will make the button round */
@@ -139,7 +139,8 @@ Button.propTypes = {
 
 Button.defaultProps = {
   type: 'submit',
-  tag: 'button'
+  tag: 'button',
+  size: 'normal'
 }
 
 ButtonLink.defaultProps = {

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -104,6 +104,7 @@ exports[`Button should render examples: Button 2`] = `
     <p><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--tiny___1pFv6\\"><span><span>Tiny</span></span></button></p>
     <p><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--small___3ArkI\\"><span><span>Small</span></span></button></p>
     <p><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj\\"><span><span>Normal</span></span></button></p>
+    <p><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj\\"><span><span>Normal</span></span></button></p>
     <p><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--large___2gatN\\"><span><span>Large</span></span></button></p>
   </div>
 </div>"


### PR DESCRIPTION
We had a lot of discussion during the rewrite of `Avatar` concerning the default & explicit props (https://github.com/cozy/cozy-ui/commit/fad19337e8ee9522d70c4200f520d5a35b372328) 

I applied the same behavior for `Button`