### PR TITLE
feat: Add flexbox utility classes

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1252,3 +1252,237 @@ Display an chip that represents complex identity
 
     Styleguide utilities.paddings
 */
+
+/*
+    Flexbox display
+
+    Classes to make Flexbox containers
+
+    .u-flex - Display a flex element
+    .u-inline-flex - Display an inline-flex element
+    .u-flex-none - Undisplay a flex element
+
+    Markup:
+    <div class="{{modifier_class}}" style="background-color:dimgrey; border: 1px solid black;">
+        <div style="padding:.5rem; background-color:gainsboro;">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div style="padding:.5rem; background-color:gainsboro;">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro;">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 1
+
+    Styleguide utilities.flexbox-display
+*/
+
+/*
+    Flexbox direction
+
+    Classes to set Flexbox container's direction
+
+    .u-flex-column - Set the direction to column
+    .u-flex-row - Set the direction to row
+    .u-flex-column-reverse - Set the direction to column-reverse
+    .u-flex-row-reverse - Set the direction to row-reverse
+
+    Markup:
+    <div class="u-flex {{modifier_class}}" style="background-color:dimgrey; border: 1px solid black;">
+        <div style="padding:.5rem; background-color:gainsboro;">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div style="padding:.5rem; background-color:gainsboro;">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro;">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 2
+
+    Styleguide utilities.flexbox-direction
+*/
+
+/*
+    Flexbox wrap
+
+    Classes to set Flexbox container's wrapping
+
+    .u-flex-wrap - Set the wrapping to true
+    .u-flex-nowrap - Set the wrapping to false
+    .u-flex-wrap-reverse - Set the reverse wrapping to true
+
+    Markup:
+    <div class="u-flex {{modifier_class}}" style="background-color:dimgrey; border: 1px solid black;">
+        <div style="padding:.5rem; background-color:gainsboro; flex-basis: calc(50% -1rem);">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex-basis: calc(50% -1rem);">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex-basis: calc(50% -1rem);">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 3
+
+    Styleguide utilities.flexbox-wrap
+*/
+
+/*
+    Flexbox align items
+
+    Classes to set Flexbox items alignment
+
+    .u-flex-items-start - Flex items aligned to flex-start
+    .u-flex-items-end - Flex items aligned to flex-end
+    .u-flex-items-center - Flex items aligned to center
+    .u-flex-items-baseline - Flex items aligned to baseline
+    .u-flex-items-stretch - Flex items aligned to stretch
+
+    Markup:
+    <div class="u-flex u-flex-nowrap {{modifier_class}}" style="background-color:dimgrey; border: 1px solid black; height: 100px";>
+        <div style="padding:.5rem; background-color:gainsboro;">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div style="padding:.5rem; background-color:gainsboro;">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro;">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 4
+
+    Styleguide utilities.flexbox-items
+*/
+
+/*
+    Flexbox justify cotnent
+
+    Classes to set Flexbox items main axis alignment
+
+    .u-flex-justify-start - Set main axis alignment of flex items to flex-start
+    .u-flex-justify-end - Set main axis alignment of flex items to flex-end
+    .u-flex-justify-center - Set main axis alignment of flex items to center
+    .u-flex-justify-between - Set main axis alignment of flex items to space-between
+    .u-flex-justify-around - Set main axis alignment of flex items to space-around
+    .u-flex-content-start - Set container lines alignment to flex-start
+
+    Markup:
+    <div class="u-flex u-flex-nowrap {{modifier_class}}" style="background-color:dimgrey; border: 1px solid black; height: 100px";>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 1 20%">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 1 20%">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 1 20%">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 5
+
+    Styleguide utilities.flexbox-justify
+*/
+
+/*
+    Flexbox content alignment (lines)
+
+    Classes to set Flexbox line items alignment
+
+    .u-flex-content-start - Set container lines alignment to flex-start
+    .u-flex-content-end - Set container lines alignment to flex-end
+    .u-flex-content-center - Set container lines alignment to center
+    .u-flex-content-between -  Set container lines alignment to space-between
+    .u-flex-content-around -  Set container lines alignment to space-around
+    .u-flex-content-stretch - Set container lines alignment to stretch
+
+    Markup:
+    <div class="u-flex u-flex-wrap u-flex-items-start {{modifier_class}}" style="background-color:dimgrey; border: 1px solid black; height: 300px";>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 0 100%">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 0 100%">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 0 100%">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 6
+
+    Styleguide utilities.flexbox-content
+*/
+
+/*
+    Flexbox align-self
+
+    Classes to set align-self on items
+
+    .u-flex-self-start - Specific flex item aligned to flex-start
+    .u-flex-self-end - Specific flex item aligned to flex-end
+    .u-flex-self-center - Specific flex item aligned to center
+    .u-flex-self-baseline - Specific flex item aligned to baseline
+    .u-flex-self-stretch - Specific flex item aligned to stretch
+
+    Markup:
+    <div class="u-flex u-flex-nowrap u-flex-items-start" style="background-color:dimgrey; border: 1px solid black; height: 300px";>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 0 30%">Suspendisse mauris montes elementum varius lectus ullamcorper per, ac praesent maximus curabitur parturient vitae.</div>
+        <div class="{{modifier_class}}" style="padding:.5rem; background-color:gainsboro; flex: 0 0 30%">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:gainsboro; flex: 0 0 30%">Nullam praesent iaculis phasellus vel turpis taciti facilisis, fermentum bibendum himenaeos class efficitur urna, per nam ut parturient enim dapibus.</div>
+    </div>
+
+    Weight: 7
+
+    Styleguide utilities.flexbox-self
+*/
+
+/*
+    Flexbox order
+
+    Classes to set order on items
+
+    .u-flex-order-0 - Set flex item order to 0
+    .u-flex-order-1 - Set flex item order to 1
+    .u-flex-order-2 - Set flex item order to 2
+    .u-flex-order-3 - Set flex item order to 3
+    .u-flex-order-4 - Set flex item order to 4
+    .u-flex-order-5 - Set flex item order to 5
+    .u-flex-order-6 - Set flex item order to 6
+    .u-flex-order-7 - Set flex item order to 7
+    .u-flex-order-8 - Set flex item order to 8
+    .u-flex-order-last - Set flex item order to the last position (99999)
+
+    Markup:
+    <div class="u-flex u-flex-nowrap u-flex-items-start" style="background-color:dimgrey; border: 1px solid black;";>
+        <div class="u-title-h1 {{modifier_class}}" style="padding:.5rem; background-color:red; flex: 0 0 5%">item</div>
+        <div class="u-title-h1" style="order:1 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">1</div>
+        <div class="u-title-h1" style="order:2 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">2</div>
+        <div class="u-title-h1" style="order:3 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">3</div>
+        <div class="u-title-h1" style="order:4 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">4</div>
+        <div class="u-title-h1" style="order:5 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">5</div>
+        <div class="u-title-h1" style="order:6 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">6</div>
+        <div class="u-title-h1" style="order:7 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">7</div>
+        <div class="u-title-h1" style="order:8 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">8</div>
+        <div class="u-title-h1" style="order:9 ;padding:.5rem; background-color:gainsboro; flex: 0 0 5%">9</div>
+    </div>
+
+    Weight: 8
+
+    Styleguide utilities.flexbox-order
+*/
+
+/*
+    Flexbox items grow
+
+    Classes to set items growth
+
+    .u-flex-auto - Make a flex item fill the space
+    .u-flex-grow-0 - Flex item doesn't grow
+    .u-flex-grow-1 - Flex item grows
+
+    Markup:
+    <div class="u-flex u-flex-nowrap u-flex-items-start" style="background-color:dimgrey; border: 1px solid black;";>
+        <div style="padding:.5rem; background-color:gainsboro;">Tincidunt at porttitor augue ac</div>
+        <div class="{{modifier_class}}" style="padding:.5rem; background-color:bisque;">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum.</div>
+        <div style="padding:.5rem; background-color:darkkhaki;">Cubilia pharetra faucibus</div>
+    </div>
+
+    Weight: 9
+
+    Styleguide utilities.flexbox-grow
+*/
+
+/*
+    Flexbox items shrink
+
+    Classes to set items shrink
+
+    .u-flex-shrink-0 - Flex item doesn't shrink
+    .u-flex-shrink-1 - Flex item shrinks
+
+    Markup:
+    <div class="u-flex u-flex-nowrap u-flex-items-start" style="background-color:dimgrey; border: 1px solid black;";>
+        <div style="padding:.5rem; background-color:gainsboro;">Tincidunt at porttitor augue ac</div>
+        <div class="{{modifier_class}}" style="padding:.5rem; background-color:bisque;">Nulla ex aptent eleifend tempus mauris habitant imperdiet porta, ac mattis lobortis felis per dictum commodo parturient condimentum.</div>
+        <div style="padding:.5rem; background-color:darkkhaki;">Cubilia pharetra faucibus commodo parturient condimentum inceptos montes nisl egestas facilisis.</div>
+    </div>
+
+    Weight: 10
+
+    Styleguide utilities.flexbox-shrink
+*/

--- a/stylus/settings/breakpoints.styl
+++ b/stylus/settings/breakpoints.styl
@@ -36,6 +36,20 @@ size-helper(direction, size)
     direction == 'min' ? size + 1 : size
 
 /*
+    teeny-screen()
+
+    teeny-screen() Refers to (max-width: 375px)
+    teeny-screen('min') Refers to (min-width: 376px)
+
+    Weight: -6
+
+    Styleguide Settings.breakpoints.teeny
+*/
+teeny-screen(direction='max')
+    @media ({direction}-width: rem(size-helper(direction, BP-teeny)))
+        {block}
+
+/*
     tiny-screen()
 
     tiny-screen() Refers to (max-width: 543px)

--- a/stylus/utilities/flexbox.styl
+++ b/stylus/utilities/flexbox.styl
@@ -1,0 +1,197 @@
+@require '../settings/breakpoints'
+
+flexbox()
+    display flex
+
+inline-flexbox()
+    display inline-flex
+
+/* 1 Fix for Chrome 44 bug.
+ * https//code.google.com/p/chromium/issues/detail?id=506893 */
+flexbox-auto()
+    flex 1 1 auto
+    min-width 0 /* 1 */
+    min-height 0 /* 1 */
+
+flexbox-none()
+    flex none
+
+flexbox-column()
+    flex-direction column
+flexbox-row()
+    flex-direction row
+flexbox-wrap()
+    flex-wrap wrap
+flexbox-nowrap()
+    flex-wrap nowrap
+flexbox-wrap-reverse()
+    flex-wrap wrap-reverse
+flexbox-column-reverse()
+    flex-direction column-reverse
+flexbox-row-reverse()
+    flex-direction row-reverse
+
+flexbox-items-start()
+    align-items flex-start
+flexbox-items-end()
+    align-items flex-end
+flexbox-items-center()
+    align-items center
+flexbox-items-baseline()
+    align-items baseline
+flexbox-items-stretch()
+    align-items stretch
+
+flexbox-self-start()
+    align-self flex-start
+flexbox-self-end()
+    align-self flex-end
+flexbox-self-center()
+    align-self center
+flexbox-self-baseline()
+    align-self baseline
+flexbox-self-stretch()
+    align-self stretch
+
+flexbox-justify-start()
+    justify-content flex-start
+flexbox-justify-end()
+    justify-content flex-end
+flexbox-justify-center()
+    justify-content center
+flexbox-justify-between()
+    justify-content space-between
+flexbox-justify-around()
+    justify-content space-around
+
+flexbox-content-start()
+    align-content flex-start
+flexbox-content-end()
+    align-content flex-end
+flexbox-content-center()
+    align-content center
+flexbox-content-between()
+    align-content space-between
+flexbox-content-around()
+    align-content space-around
+flexbox-content-stretch()
+    align-content stretch
+
+flexbox-order-0()
+    order 0
+flexbox-order-1()
+    order 1
+flexbox-order-2()
+    order 2
+flexbox-order-3()
+    order 3
+flexbox-order-4()
+    order 4
+flexbox-order-5()
+    order 5
+flexbox-order-6()
+    order 6
+flexbox-order-7()
+    order 7
+flexbox-order-8()
+    order 8
+flexbox-order-last()
+    order 99999
+
+flexbox-grow-0()
+    flex-grow 0
+flexbox-grow-1()
+    flex-grow 1
+
+flexbox-shrink-0()
+    flex-shrink 0
+flexbox-shrink-1()
+    flex-shrink 1
+
+// Global classes generation
+
+breakpoints = {
+    'none': '',
+    'teeny': 'tt',
+    'tiny': 't',
+    'small': 's',
+    'medium': 'm',
+    'large': 'l',
+    'extra-large': 'xl'
+}
+
+props = {
+    'flexbox': 'flex',
+    'inline-flexbox': 'inline-flex',
+    'flexbox-none': 'flex-none',
+    'flexbox-column': 'flex-column',
+    'flexbox-row': 'flex-row',
+    'flexbox-wrap': 'flex-wrap',
+    'flexbox-nowrap': 'flex-nowrap',
+    'flexbox-wrap-reverse': 'flex-wrap-reverse',
+    'flexbox-column-reverse': 'flex-column-reverse',
+    'flexbox-row-reverse': 'flex-row-reverse',
+    'flexbox-auto': 'flex-auto',
+    'flexbox-items-start': 'flex-items-start',
+    'flexbox-items-end': 'flex-items-end',
+    'flexbox-items-center': 'flex-items-center',
+    'flexbox-items-baseline': 'flex-items-baseline',
+    'flexbox-items-stretch': 'flex-items-stretch',
+    'flexbox-self-start': 'flex-self-start',
+    'flexbox-self-end': 'flex-self-end',
+    'flexbox-self-center': 'flex-self-center',
+    'flexbox-self-baseline': 'flex-self-baseline',
+    'flexbox-self-stretch': 'flex-self-stretch',
+    'flexbox-justify-start': 'flex-justify-start',
+    'flexbox-justify-end': 'flex-justify-end',
+    'flexbox-justify-center': 'flex-justify-center',
+    'flexbox-justify-between': 'flex-justify-between',
+    'flexbox-justify-around': 'flex-justify-around',
+    'flexbox-content-start': 'flex-content-start',
+    'flexbox-content-end': 'flex-content-end',
+    'flexbox-content-center': 'flex-content-center',
+    'flexbox-content-between': 'flex-content-between',
+    'flexbox-content-around': 'flex-content-around',
+    'flexbox-content-stretch': 'flex-content-stretch',
+    'flexbox-order-0': 'flex-order-0',
+    'flexbox-order-1': 'flex-order-1',
+    'flexbox-order-2': 'flex-order-2',
+    'flexbox-order-3': 'flex-order-3',
+    'flexbox-order-4': 'flex-order-4',
+    'flexbox-order-5': 'flex-order-5',
+    'flexbox-order-6': 'flex-order-6',
+    'flexbox-order-7': 'flex-order-7',
+    'flexbox-order-8': 'flex-order-8',
+    'flexbox-order-last': 'flex-order-last',
+    'flexbox-grow-0': 'flex-grow-0',
+    'flexbox-grow-1': 'flex-grow-1',
+    'flexbox-shrink-0': 'flex-shrink-0',
+    'flexbox-shrink-1': 'flex-shrink-1'
+}
+
+cssModules()
+    for kProp, vProp in props
+        for kBp, vBp in breakpoints
+            if vBp == ''
+                :global(.u-{vProp})
+                    {kProp}()
+            else
+                @media (max-width: rem(lookup('BP-'+kBp)))
+                    :global(.u-{vProp}-{vBp})
+                        {kProp}()
+
+native()
+    for kProp, vProp in props
+        for kBp, vBp in breakpoints
+            if vBp == ''
+                .u-{vProp}
+                    {kProp}()
+            else
+                @media (max-width: rem(lookup('BP-'+kBp)))
+                    .u-{vProp}-{vBp}
+                        {kProp}()
+
+if cssmodules == true
+    cssModules()
+else
+    native()


### PR DESCRIPTION
Added flexbox utility classes [inspired by Tachyons](https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css).

Basically there's a class for every flexbox related properties.

Each one of them is also available for every basic Media Query.

For example, the class `u-flex` that displays an element with flexbox property goes like this
```css
.u-flex {
  display: flex;
}
@media (max-width: 23.438rem) {
  .u-flex-tt {
    display: flex;
  }
}
@media (max-width: 33.938rem) {
  .u-flex-t {
    display: flex;
  }
}
/* Etc, for every breakpoint */
```

[Documentation preview](https://gooz.github.io/cozy-ui/styleguide/section-utilities.html#kssref-utilities-flexbox-display)

~~📌 NB: Couldn't find a way (yet) to generate those classes with a function due to Stylus limitations.
See the [Stack Overflow question](https://stackoverflow.com/questions/54924167/calling-a-stylus-block-with-a-variable-in-an-iteration)~~
Found a workaround using `mixins()` instead of `{blocks}`. Thanks @nono 🙏