### PR TITLE
feat(utils): Get CSS variable value from body

### DIFF
--- a/react/utils/color.js
+++ b/react/utils/color.js
@@ -1,5 +1,5 @@
 export const getCssVariableValue = variableName =>
   window
-    .getComputedStyle(document.documentElement)
+    .getComputedStyle(document.body)
     .getPropertyValue(`--${variableName}`)
     .trim()


### PR DESCRIPTION
Stack themes are overriding CSS variable on body. So getting it from
html can lead to incorrect values when using a theme from the stack.

For example, in an app that uses a stack theme, I can be in the
following situation:

```
:root {
  --primaryColor: black;
}

body {
  --primaryColor: white;
}
```

In that case, if we get the variable value from `html`, we will get
`black`, where we want to get `white`. With this fix, we will get
`white`.

I tried to write tests for this helper, but JSDOM doesn't handle `:root` and `setProperty`, so I couldn't (see https://github.com/jsdom/jsdom/issues/1895)