### PR TITLE
feat(Field): Expose Input's inputRef prop ✨

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -19,6 +19,38 @@ Like `Input` component, it can have the following properties:
 </form>
 ```
 
+- `inputRef`
+
+This property is mapped to `<Input />` component `inputRef` property.
+It gives access to the underlying `<input />` element, for example to give focus or move the caret.
+
+##### Example
+
+```
+class FieldWithFocus extends React.Component {
+  constructor() {
+    super()
+    this.component = null;
+    this.setFocus = this.setFocus.bind(this)
+  }
+  setFocus() {
+    this.component.focus()
+  }
+  render() {
+    return (
+      <div>
+          <Field
+            inputRef={c => this.component = c}
+            label="I can have focus"
+            placeholder="Focus please" />
+        <Button onClick={this.setFocus}>Set Focus</Button>
+      </div>
+    )
+  }
+}
+;<FieldWithFocus />
+```
+
 #### Field when there's an error
 
 ```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -62,6 +62,7 @@ const Field = props => {
     fullwidth,
     label,
     id,
+    inputRef,
     type,
     value,
     placeholder,
@@ -100,6 +101,7 @@ const Field = props => {
             disabled={disabled}
             fullwidth={fullwidth}
             id={id}
+            inputRef={inputRef}
             type={type}
             placeholder={placeholder}
             value={value}
@@ -122,6 +124,7 @@ const Field = props => {
             disabled={disabled}
             fullwidth={fullwidth}
             id={id}
+            inputRef={inputRef}
             type={type}
             placeholder={placeholder}
             value={value}
@@ -162,6 +165,7 @@ Field.propTypes = {
   fullwidth: PropTypes.bool,
   label: PropTypes.string.isRequired,
   id: PropTypes.string,
+  inputRef: PropTypes.func,
   type: PropTypes.oneOf(['text', 'password', 'email', 'url', 'textarea']),
   value: PropTypes.string,
   placeholder: PropTypes.string,

--- a/react/Input/Readme.md
+++ b/react/Input/Readme.md
@@ -46,7 +46,7 @@ By default, the size is `large`.
 
 ### inputRef ( set focus / blur / ... programmatically)
 
-If you need to programmatically access the underlying `<input />` for example to give focus or move the caret, you can use the `innerRef` prop, that is passed to the `ref` property of the `<input />`.
+If you need to programmatically access the underlying `<input />` for example to give focus or move the caret, you can use the `inputRef` prop, that is passed to the `ref` property of the `<input />`.
 
 ```
 

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -279,13 +279,21 @@ exports[`Field should render examples: Field 1`] = `
 
 exports[`Field should render examples: Field 2`] = `
 "<div>
+  <div>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I can have focus</label><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"Focus please\\" value=\\"\\"></div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj\\"><span>Set Focus</span></button>
+  </div>
+</div>"
+`;
+
+exports[`Field should render examples: Field 3`] = `
+"<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldError\\" class=\\"styles__c-label___o4ozG\\">I'm an error label</label><input type=\\"text\\" id=\\"idFieldError\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ styles__c-input-text--large___28EaR\\" placeholder=\\"I'm an error input[type=text]\\" value=\\"\\"></div>
   </form>
 </div>"
 `;
 
-exports[`Field should render examples: Field 3`] = `
+exports[`Field should render examples: Field 4`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'am a SelectBox</label>
@@ -330,7 +338,7 @@ exports[`Field should render examples: Field 3`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 4`] = `
+exports[`Field should render examples: Field 5`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldPassword\\" class=\\"styles__c-label___o4ozG\\">I'm a password label</label>
@@ -342,7 +350,7 @@ exports[`Field should render examples: Field 4`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 5`] = `
+exports[`Field should render examples: Field 6`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'm a label</label>
@@ -352,7 +360,7 @@ exports[`Field should render examples: Field 5`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 6`] = `
+exports[`Field should render examples: Field 7`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'm a label</label>


### PR DESCRIPTION
It's pretty convenient to have this prop available in Field. It allow us to give them focus, for example in https://github.com/cozy/cozy-libs/pull/316.