### PR TITLE
SelectBox: Handle disabled prop

### DIFF
--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -178,6 +178,7 @@ const Field = props => {
 
 Field.propTypes = {
   ...inputSpecificPropTypes,
+  disabled: PropTypes.bool,
   fieldProps: PropTypes.object,
   fullwidth: PropTypes.bool,
   label: PropTypes.string.isRequired,

--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -72,10 +72,9 @@ class SelectBoxWrapper extends React.Component {
 <SelectBoxWrapper />
 ```
 
+#### `disabled`
 
-#### `fullwidth`
-
-Set the select to spread to 100% of the available width (default: `false`).
+Disable the SelectBox
 
 ```
 const options = [
@@ -83,6 +82,22 @@ const options = [
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
   { value: 'vanilla', label: 'Vanilla' },
   { value: 'long', label: 'Salt and vinegar crisps with vegamite and brussel sprouts, double chai latte sauce' },
+];
+
+<SelectBox options={options} disabled />
+```
+
+#### `fullwidth`
+
+Set the select to spread to 100% of the available width (default: `false`).
+
+```
+
+const options = [
+{ value: 'chocolate', label: 'Chocolate' },
+{ value: 'strawberry', label: 'Strawberry', isDisabled: true },
+{ value: 'vanilla', label: 'Vanilla' },
+{ value: 'long', label: 'Salt and vinegar crisps with vegamite and brussel sprouts, double chai latte sauce' },
 ];
 
 <SelectBox options={options} fullwidth />

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -17,7 +17,7 @@ const heights = {
 const customStyles = props => ({
   control: (base, state) => ({
     ...base,
-    backgroundColor: 'white',
+    backgroundColor: 'transparent',
     border: state.isFocused
       ? `.0625rem solid ${dodgerBlue}`
       : `.0625rem solid ${silver}`,

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -268,6 +268,7 @@ class SelectBox extends Component {
     const {
       className,
       components,
+      disabled,
       fullwidth,
       styles: reactSelectStyles,
       breakpoints: { isMobile },
@@ -289,10 +290,12 @@ class SelectBox extends Component {
         onMenuOpen={this.handleOpen}
         onMenuClose={this.handleClose}
         {...props}
+        isDisabled={disabled}
         className={classNames(
           {
             [styles['select__overlay']]: showOverlay,
             [styles['select--autowidth']]: !fullwidth,
+            [styles['select--disabled']]: disabled,
             [styles['select--fullwidth']]: fullwidth
           },
           className
@@ -309,6 +312,7 @@ class SelectBox extends Component {
 SelectBox.propTypes = {
   container: PropTypes.object,
   components: PropTypes.object,
+  disabled: PropTypes.bool,
   fullwidth: PropTypes.bool,
   size: PropTypes.oneOf(['tiny', 'medium', 'large']),
   styles: PropTypes.object

--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -11,6 +11,9 @@
 .select--autowidth
     max-width 30rem
 
+.select--disabled
+    @extends $select--disabled
+
 .select--fullwidth
     @extends $select--fullwidth
     padding-right 0

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -299,7 +299,7 @@ exports[`Field should render examples: Field 4`] = `
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'am a SelectBox</label>
       <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-19fknmj\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-1492t68\\">Select ...</div>
             <div class=\\"css-1g6gooi\\">
@@ -318,7 +318,7 @@ exports[`Field should render examples: Field 4`] = `
     </div>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'am a SelectBox with a value</label>
       <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-19fknmj\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">Choice 2</div>
             <div class=\\"css-1g6gooi\\">
@@ -1125,7 +1125,7 @@ exports[`Radio should render examples: Radio 3`] = `
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1147,7 +1147,7 @@ exports[`SelectBox should render examples: SelectBox 1`] = `
 exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1175,7 +1175,7 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 "<div>
   <div style=\\"height: 12rem; padding: .5rem; overflow: auto;\\">Container height: 12rem. <button>Change container height</button>
     <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-      <div class=\\"css-2zgoaw\\">
+      <div class=\\"css-19fknmj\\">
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
@@ -1198,7 +1198,7 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 exports[`SelectBox should render examples: SelectBox 4`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1222,7 +1222,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
   <div>
     <div class=\\"u-mb-1\\">
       <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-        <div class=\\"css-1rg8gyn\\">
+        <div class=\\"css-1472sn5\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a tiny SelectBox</div>
             <div class=\\"css-1g6gooi\\">
@@ -1241,7 +1241,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
     </div>
     <div class=\\"u-mb-1\\">
       <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-        <div class=\\"css-15w89vh\\">
+        <div class=\\"css-4oellt\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a medium SelectBox</div>
             <div class=\\"css-1g6gooi\\">
@@ -1260,7 +1260,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
     </div>
     <div class=\\"u-mb-1\\">
       <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-        <div class=\\"css-2zgoaw\\">
+        <div class=\\"css-19fknmj\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a large SelectBox</div>
             <div class=\\"css-1g6gooi\\">
@@ -1308,7 +1308,7 @@ exports[`SelectBox should render examples: SelectBox 6`] = `
 exports[`SelectBox should render examples: SelectBox 7`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1330,7 +1330,7 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 exports[`SelectBox should render examples: SelectBox 8`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1352,7 +1352,7 @@ exports[`SelectBox should render examples: SelectBox 8`] = `
 exports[`SelectBox should render examples: SelectBox 9`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1412,7 +1412,7 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
 exports[`SelectBox should render examples: SelectBox 10`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw\\">
+    <div class=\\"css-19fknmj\\">
       <div class=\\"css-1phseng needsclick\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1434,7 +1434,7 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
 exports[`SelectBox should render examples: SelectBox 11`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-2zgoaw needsclick cz__control\\">
+    <div class=\\"css-19fknmj needsclick cz__control\\">
       <div class=\\"css-1phseng needsclick cz__value-container\\">
         <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
         <div class=\\"css-1g6gooi\\">

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1197,12 +1197,12 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 
 exports[`SelectBox should render examples: SelectBox 4`] = `
 "<div>
-  <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-1sontr1 styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
+    <div class=\\"css-adwy96\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+          <div class=\\"\\" style=\\"display: inline-block;\\"><input disabled=\\"\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
@@ -1219,6 +1219,28 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
 
 exports[`SelectBox should render examples: SelectBox 5`] = `
 "<div>
+  <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
+    <div class=\\"css-19fknmj\\">
+      <div class=\\"css-1phseng\\">
+        <div class=\\"css-1492t68\\">Select...</div>
+        <div class=\\"css-1g6gooi\\">
+          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+          </div>
+        </div>
+      </div>
+      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+            <use xlink:href=\\"#bottom\\"></use>
+          </svg></div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 6`] = `
+"<div>
   <div>
     <div class=\\"u-mb-1\\">
       <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
@@ -1226,7 +1248,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a tiny SelectBox</div>
             <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
@@ -1245,7 +1267,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a medium SelectBox</div>
             <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
@@ -1264,7 +1286,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a large SelectBox</div>
             <div class=\\"css-1g6gooi\\">
-              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+              <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
@@ -1281,7 +1303,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 6`] = `
+exports[`SelectBox should render examples: SelectBox 7`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
     <div><button>toggle options</button>
@@ -1289,7 +1311,7 @@ exports[`SelectBox should render examples: SelectBox 6`] = `
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
-            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-12-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
@@ -1299,28 +1321,6 @@ exports[`SelectBox should render examples: SelectBox 6`] = `
               <use xlink:href=\\"#bottom\\"></use>
             </svg></div>
         </div>
-      </div>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`SelectBox should render examples: SelectBox 7`] = `
-"<div>
-  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-1492t68\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
-          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-12-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
-            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
-          </div>
-        </div>
-      </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#bottom\\"></use>
-          </svg></div>
       </div>
     </div>
   </div>
@@ -1363,46 +1363,8 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
       </div>
       <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
         <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
-            <use xlink:href=\\"#top\\"></use>
+            <use xlink:href=\\"#bottom\\"></use>
           </svg></div>
-      </div>
-    </div>
-    <div class=\\"css-1dhof61\\">
-      <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
-        <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
-          <div>
-            <div id=\\"react-select-14-option-0-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">D</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">E</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">F</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">G</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">H</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">I</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">J</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">K</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">L</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">M</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">N</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">O</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">P</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Q</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">R</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">S</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">T</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">U</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">V</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">W</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">X</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-0-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-          </div>
-        </div>
-        <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
-          <div>
-            <div id=\\"react-select-14-option-1-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-            <div id=\\"react-select-14-option-1-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -1413,10 +1375,70 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
     <div class=\\"css-19fknmj\\">
-      <div class=\\"css-1phseng needsclick\\">
+      <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-15-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+            <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
+          </div>
+        </div>
+      </div>
+      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
+        <div aria-hidden=\\"true\\" class=\\"css-n6ypum\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+            <use xlink:href=\\"#top\\"></use>
+          </svg></div>
+      </div>
+    </div>
+    <div class=\\"css-1dhof61\\">
+      <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
+        <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
+          <div>
+            <div id=\\"react-select-15-option-0-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-2\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">D</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-3\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">E</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-4\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">F</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-5\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">G</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-6\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">H</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-7\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">I</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-8\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">J</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-9\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">K</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-10\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">L</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-11\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">M</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-12\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">N</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-13\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">O</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-14\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">P</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-15\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Q</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-16\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">R</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-17\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">S</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-18\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">T</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-19\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">U</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-20\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">V</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-21\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">W</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-22\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">X</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-0-23\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+          </div>
+        </div>
+        <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
+          <div>
+            <div id=\\"react-select-15-option-1-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+            <div id=\\"react-select-15-option-1-1\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`SelectBox should render examples: SelectBox 11`] = `
+"<div>
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-19fknmj\\">
+      <div class=\\"css-1phseng needsclick\\">
+        <div class=\\"css-1492t68\\">Select...</div>
+        <div class=\\"css-1g6gooi\\">
+          <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-16-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
@@ -1431,14 +1453,14 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
 </div>"
 `;
 
-exports[`SelectBox should render examples: SelectBox 11`] = `
+exports[`SelectBox should render examples: SelectBox 12`] = `
 "<div>
   <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
     <div class=\\"css-19fknmj needsclick cz__control\\">
       <div class=\\"css-1phseng needsclick cz__value-container\\">
         <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
-          <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-16-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
+          <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-17-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
@@ -1451,7 +1473,7 @@ exports[`SelectBox should render examples: SelectBox 11`] = `
     </div>
     <div class=\\"css-1dhof61 needsclick cz__menu\\">
       <div class=\\"css-11unzgr needsclick cz__menu-list\\">
-        <div id=\\"react-select-16-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
+        <div id=\\"react-select-17-option-0\\" role=\\"option\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
       </div>
     </div>
   </div>

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -428,6 +428,15 @@ $select
     &::-ms-expand
         display  none
 
+$select--disabled
+    @extend $input--disabled
+
+    &:hover
+    &:focus
+        // Border is set to 0, otherwise SelectBox will
+        // get large borders on hover
+        border-width 0
+
 $select--tiny
     @extend $input-text--tiny
     @extend $select-arrow-padding

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -240,6 +240,15 @@ $label
     &.is-error
         color pomegranate
 
+$input--disabled
+    cursor not-allowed
+    background-color paleGrey
+    color charcoalGrey
+
+    &:hover
+    &:focus
+        border rem(1) solid silver
+
 $input-text
     display inline-block
     width 100%
@@ -271,13 +280,7 @@ $input-text
 
     &[aria-disabled]
     &[disabled]
-        cursor not-allowed
-        background-color paleGrey
-        color charcoalGrey
-
-        &:hover
-        &:focus
-            border rem(1) solid silver
+        @extend $input--disabled
 
 
 input-text--tiny =


### PR DESCRIPTION
![capture d ecran 2019-03-08 a 12 46 06](https://user-images.githubusercontent.com/776764/54027003-31f19700-41a0-11e9-9047-15caf758aef9.png)


Solves #857

This PR adds a `disabled` prop to SelectBox, which is mapped to react-select `isDisabled` prop.

I kept `disabled` to be consistent with Field and Input API.

There is still an issue left: the `cursor: not-allowed` property does not work because of the `pointer-events: none` property on the SelectBox's `container` element. Removing the `pointer-events` declaration make react-select unable to position its `menu`.

I see two options to have this `cursor: not-allowed` to work:
* Investigate into react-select code how we may fix this, make a PR
* Wrap our `<ReactSelect />` into an element which will get the `cursor: not-allowed` (potentially breaking changes in our side). By the way it's not the first time that a wrapper on SelectBox could help us, I should need it to handle `KeyUp` events for example.