### PR TITLE
Field: Add missing values for prop type 📝

### DIFF
--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -166,11 +166,19 @@ Field.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string,
   inputRef: PropTypes.func,
-  type: PropTypes.oneOf(['text', 'password', 'email', 'url', 'textarea']),
+  type: PropTypes.oneOf([
+    'date',
+    'email',
+    'password',
+    'select',
+    'textarea',
+    'text',
+    'url'
+  ]),
   value: PropTypes.string,
   placeholder: PropTypes.string,
   error: PropTypes.bool,
-  side: PropTypes.element,
+  side: PropTypes.node,
   size: PropTypes.oneOf(['tiny', 'medium', 'large']),
   secondaryLabels: PropTypes.object
 }


### PR DESCRIPTION
Add `date` and `select` to list of valid values for prop `type`.

This was causing warnings in Jest tests.