### PR TITLE
Enable tree shaking

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  presets: ['cozy-app'],
+  presets: [
+    ['cozy-app', { presetEnv: { modules: false } }]
+  ],
   env: {
     transpilation: {
       plugins: [

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    ['cozy-app', { presetEnv: { modules: false } }]
+    ['cozy-app', { presetEnv: { modules: false }, transformRuntime: { helpers: true }}]
   ],
   env: {
     transpilation: {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "webpack": "^4.17.2"
   },
   "dependencies": {
+    "@babel/runtime": "^7.3.4",
     "body-scroll-lock": "^2.5.8",
     "classnames": "^2.2.5",
     "date-fns": "^1.28.5",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "watch:doc:react": "env BABEL_ENV=transpilation styleguidist server --config docs/styleguide.config.js",
     "watch:doc:kss": "nodemon --ext styl,md --watch stylus --exec 'yarn build:doc:kss && http-server build/styleguide -p 4242'"
   },
+  "sideEffects": false,
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-import { default as labelStyles } from '../Label/styles.styl'
+import labelStyles from '../Label/styles.styl'
 import styles from './styles.styl'
 import Label from '../Label'
 import Input from '../Input'

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"


### PR DESCRIPTION
The idea behind this PR is to enable apps to use tree-shaking with cozy-ui. As of now it is not possible for several reasons : 

- import/exports are transformed into require calls which prevents webpack to do static analysis and to flag unused exports
- sideEffects false is not present

The changes in this PR : 
- Do not touch import/export when transpiling otherwise webpack cannot use tree shaking in downstream apps (this is done via a config flag of babel-preset-cozy-app)
- sideEffects: false enables webpack to eliminate re-exports that are unnecessary in downstream apps. It has to be put on the lib side to tell webpack that the files of the package do not have side effects.

Additionally:

- transformRuntime helpers are imported from babel-runtime instead of being copied each time. This is done via a config flag in babel-preset-cozy-app.


before

```jsx
var _react = _interopRequireDefault(require("react"));

var _Icon = _interopRequireDefault(require("../Icon"));

var _classnames = _interopRequireDefault(require("classnames"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }

function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }

function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
```

after `modules: false`

```jsx
function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }

function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }

function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }

import React from 'react';
import Icon from '../Icon';
import cx from 'classnames';
```

after `helpers: true`

```jsx
import _extends from "@babel/runtime/helpers/extends";
import _objectWithoutProperties from "@babel/runtime/helpers/objectWithoutProperties";
import React from 'react';
import Icon from '../Icon';
import cx from 'classnames';
```

Before

<img width="296" alt="image" src="https://user-images.githubusercontent.com/465582/54339433-19b4c880-4635-11e9-8087-58ab052a0fa7.png">

After

<img width="263" alt="image" src="https://user-images.githubusercontent.com/465582/54339445-26d1b780-4635-11e9-98bf-9b38c93fca9b.png">
