### PR TITLE
chore: Avoid shipping extra files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,11 @@ test
 build
 
 .editorconfig
+.eslintignore
+.eslintrc.json
+.stylintrc
+.travis.yml
+renovate.json
 yarn.lock
 /scripts
 .changelog
@@ -10,3 +15,4 @@ docs
 coverage
 codemods
 loaders
+.github/


### PR DESCRIPTION
Here's what we actually ship: https://unpkg.com/cozy-ui@19.12.0/

I kept some of the babel configuration and helper files, I'm not entirely sure they are useful though.