### PR TITLE
fix: Cross position with header

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -313,6 +313,9 @@ class Modal extends Component {
     const style = Object.assign({}, height && { height }, width && { width })
     const maybeWrapInPortal = children =>
       into ? <Portal into={into}>{children}</Portal> : children
+    const hasModalHeader = children.find(
+      child => child.type.name === 'ModalHeader'
+    )
     return maybeWrapInPortal(
       <div className={cx(styles['c-modal-container'], containerClassName)}>
         <Overlay
@@ -350,7 +353,8 @@ class Modal extends Component {
               {closable && (
                 <ModalCross
                   className={cx(closeBtnClassName, {
-                    [styles['c-modal-close--notitle']]: !title
+                    [styles['c-modal-close--notitle']]:
+                      !title && !hasModalHeader
                   })}
                   onClick={dismissAction}
                   color={closeBtnColor}


### PR DESCRIPTION
The modal cross button is supposed to be close to the top right corner of the modal if there's no title or any other content in the header.

That wasn't the case, it triggered only if the props `title` was undefined but it doesn't mean that there's no header at all, so I fixed this with the expected behaviour.

The method to do so feels a little "dirty". I'm open to suggestions if there's any better ones.
