### PR TITLE
feat: Add Display utility classes

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -699,7 +699,7 @@ Display an chip that represents complex identity
 */
 
 /*
-    Display
+    Hide
 
     Utilities that show or hide an element for a giving viewport size.
 
@@ -712,7 +712,7 @@ Display an chip that represents complex identity
     .u-hide--tablet - Element is hidden on tablet (>1024px)
     .u-hide--mob - Element is hidden on mobile (<1023px)
 
-    Styleguide utilities.display
+    Styleguide utilities.hide
 */
 
 /*
@@ -1254,6 +1254,37 @@ Display an chip that represents complex identity
 */
 
 /*
+    Display
+
+    Classes to change the box model of an element
+
+    NB: `flex` being much more complex, it has its own set of utility classes, see further.
+
+    .u-dn - Display none
+    .u-di - Display inline
+    .u-db - Display block
+    .u-dib - Display inline-block
+    .u-dit - Display inline-table
+    .u-dt - Display table
+    .u-dtc - Display table-cell
+    .u-dt-row - Display table-row
+    .u-dt-row-group - Display table-row-group
+    .u-dt-column - Display table-column
+    .u-dt-column-group - Display table-column-group
+
+    Markup:
+    <div class="{{modifier_class}}" style="margin: 1rem; padding: .125rem .25rem; background-color:gainsboro; border: 1px solid black;">
+        <span>Suspendisse mauris</span>
+        <span>Nulla ex aptent</span>
+        <span>Nullam praesent</span>
+    </div>
+
+    Weight: 1
+
+    Styleguide utilities.display
+*/
+
+/*
     Flexbox display
 
     Classes to make Flexbox containers
@@ -1271,7 +1302,7 @@ Display an chip that represents complex identity
 
     Weight: 1
 
-    Styleguide utilities.flexbox-display
+    Styleguide utilities.flexbox
 */
 
 /*
@@ -1293,7 +1324,7 @@ Display an chip that represents complex identity
 
     Weight: 2
 
-    Styleguide utilities.flexbox-direction
+    Styleguide utilities.flexbox.direction
 */
 
 /*
@@ -1314,7 +1345,7 @@ Display an chip that represents complex identity
 
     Weight: 3
 
-    Styleguide utilities.flexbox-wrap
+    Styleguide utilities.flexbox.wrap
 */
 
 /*
@@ -1337,7 +1368,7 @@ Display an chip that represents complex identity
 
     Weight: 4
 
-    Styleguide utilities.flexbox-items
+    Styleguide utilities.flexbox.items
 */
 
 /*
@@ -1361,7 +1392,7 @@ Display an chip that represents complex identity
 
     Weight: 5
 
-    Styleguide utilities.flexbox-justify
+    Styleguide utilities.flexbox.justify
 */
 
 /*
@@ -1385,7 +1416,7 @@ Display an chip that represents complex identity
 
     Weight: 6
 
-    Styleguide utilities.flexbox-content
+    Styleguide utilities.flexbox.content
 */
 
 /*
@@ -1408,7 +1439,7 @@ Display an chip that represents complex identity
 
     Weight: 7
 
-    Styleguide utilities.flexbox-self
+    Styleguide utilities.flexbox.self
 */
 
 /*
@@ -1443,7 +1474,7 @@ Display an chip that represents complex identity
 
     Weight: 8
 
-    Styleguide utilities.flexbox-order
+    Styleguide utilities.flexbox.order
 */
 
 /*
@@ -1464,7 +1495,7 @@ Display an chip that represents complex identity
 
     Weight: 9
 
-    Styleguide utilities.flexbox-grow
+    Styleguide utilities.flexbox.grow
 */
 
 /*
@@ -1484,5 +1515,5 @@ Display an chip that represents complex identity
 
     Weight: 10
 
-    Styleguide utilities.flexbox-shrink
+    Styleguide utilities.flexbox.shrink
 */

--- a/stylus/settings/breakpoints.styl
+++ b/stylus/settings/breakpoints.styl
@@ -14,6 +14,17 @@ BP-medium      = 1023
 BP-large       = 1200
 BP-extra-large = 1439
 
+// Breakpoints collection for utilities
+breakpoints = {
+    'none': '',
+    'teeny': 'tt',
+    'tiny': 't',
+    'small': 's',
+    'medium': 'm',
+    'large': 'l',
+    'extra-large': 'xl'
+}
+
 /*
     Media Queries mixins
 

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -95,4 +95,26 @@ global(selector, placeholder)
         {selector}
             @extend {placeholder} // @stylint ignore
 
+cssModulesUtils(props, breakpoints)
+    for kProp, vProp in props
+        for kBp, vBp in breakpoints
+            if vBp == ''
+                :global(.u-{vProp})
+                    {kProp}()
+            else
+                @media (max-width: rem(lookup('BP-'+kBp)))
+                    :global(.u-{vProp}-{vBp})
+                        {kProp}()
+
+nativeUtils(props, breakpoints)
+    for kProp, vProp in props
+        for kBp, vBp in breakpoints
+            if vBp == ''
+                .u-{vProp}
+                    {kProp}()
+            else
+                @media (max-width: rem(lookup('BP-'+kBp)))
+                    .u-{vProp}-{vBp}
+                        {kProp}()
+
 // @stylint on

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -47,10 +47,63 @@ $hide--desk
     +gt-mobile()
         display none !important // @stylint ignore
 
-
 // Global classes
 global('.u-visuallyhidden', $visuallyhidden)
 global('.u-hide', $hide)
 global('.u-hide--mob', $hide--mob)
 global('.u-hide--tablet', $hide--tablet)
 global('.u-hide--desk', $hide--desk)
+
+display-none()
+    display none
+
+display-inline()
+    display inline
+
+display-block()
+    display block
+
+display-inline-block()
+    display inline-block
+
+display-inline-table()
+    display inline-table
+
+display-table()
+    display table
+
+display-table-cell()
+    display table-cell
+
+display-table-row()
+    display table-row
+
+display-table-row-group()
+    display table-row-group
+
+display-table-column()
+    display table-column
+
+display-table-column-group()
+    display table-column-group
+
+props = {
+    'display-none': 'dn',
+    'display-inline': 'di',
+    'display-block': 'db',
+    'display-inline-block': 'dib',
+    'display-inline-table': 'dit',
+    'display-table': 'dt',
+    'display-table-cell': 'dtc',
+    'display-table-row': 'dt-row',
+    'display-table-row-group': 'dt-row-group',
+    'display-table-column': 'dt-column',
+    'display-table-column-group': 'dt-column-group'
+}
+
+if cssmodules == true
+    cssModulesUtils(props, breakpoints)
+else
+    nativeUtils(props, breakpoints)
+
+

--- a/stylus/utilities/flexbox.styl
+++ b/stylus/utilities/flexbox.styl
@@ -1,4 +1,5 @@
 @require '../settings/breakpoints'
+@require '../tools/mixins'
 
 flexbox()
     display flex
@@ -110,16 +111,6 @@ flexbox-shrink-1()
 
 // Global classes generation
 
-breakpoints = {
-    'none': '',
-    'teeny': 'tt',
-    'tiny': 't',
-    'small': 's',
-    'medium': 'm',
-    'large': 'l',
-    'extra-large': 'xl'
-}
-
 props = {
     'flexbox': 'flex',
     'inline-flexbox': 'inline-flex',
@@ -169,29 +160,7 @@ props = {
     'flexbox-shrink-1': 'flex-shrink-1'
 }
 
-cssModules()
-    for kProp, vProp in props
-        for kBp, vBp in breakpoints
-            if vBp == ''
-                :global(.u-{vProp})
-                    {kProp}()
-            else
-                @media (max-width: rem(lookup('BP-'+kBp)))
-                    :global(.u-{vProp}-{vBp})
-                        {kProp}()
-
-native()
-    for kProp, vProp in props
-        for kBp, vBp in breakpoints
-            if vBp == ''
-                .u-{vProp}
-                    {kProp}()
-            else
-                @media (max-width: rem(lookup('BP-'+kBp)))
-                    .u-{vProp}-{vBp}
-                        {kProp}()
-
 if cssmodules == true
-    cssModules()
+    cssModulesUtils(props, breakpoints)
 else
-    native()
+    nativeUtils(props, breakpoints)


### PR DESCRIPTION
Added some  `display` utility classes.

- `.u-dn` - Display none
- `.u-di` - Display inline
- `.u-db` - Display block
- `.u-dib` - Display inline-block
- `.u-dit` - Display inline-table
- `.u-dt` - Display table
- `.u-dtc` - Display table-cell
- `.u-dt-row` - Display table-row
- `.u-dt-row-group` - Display table-row-group
- `.u-dt-column` - Display table-column
- `.u-dt-column-group` - Display table-column-group

Also I cleaned up a bit flexbox utilities, moving its stylus loop to `mixin.styl` so it is reusable.