### PR TITLE
feat: Add responsive spacing utility classes

### DIFF
--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -1,6 +1,7 @@
 /*------------------------------------*\
   Space utilities
 \*------------------------------------*/
+@require '../settings/breakpoints'
 @require '../tools/mixins'
 
 // @stylint off
@@ -27,25 +28,102 @@ directions = {
     v: vertical,
     h: horizontal
 }
+
+// Placeholders generation
 for kType, vType in types
     for kSize, vSize in sizes
         for kDir, vDir in directions
             if vDir == all
                 ${kType}-{kSize}
                     {vType}: vSize !important
-                global('.u-'+kType+'-'+kSize, '$'+kType+'-'+kSize)
             else if vDir == vertical
                 ${kType}{kDir}-{kSize}
                     {vType}-top: vSize !important
                     {vType}-bottom: vSize !important
-                global('.u-'+kType+kDir+'-'+kSize, '$'+kType+kDir+'-'+kSize)
             else if vDir == horizontal
                 ${kType}{kDir}-{kSize}
                     {vType}-left: vSize !important
                     {vType}-right: vSize !important
-                global('.u-'+kType+kDir+'-'+kSize, '$'+kType+kDir+'-'+kSize)
             else
                 ${kType}{kDir}-{kSize}
                     {vType}-{vDir}: vSize !important
-                global('.u-'+kType+kDir+'-'+kSize, '$'+kType+kDir+'-'+kSize)
+
+// Classes generation
+cssModulesSpacingUtils()
+    for kType, vType in types
+        for kSize, vSize in sizes
+            for kDir, vDir in directions
+                for kBp, vBp in breakpoints
+                    if vBp == ''
+                        if vDir == all
+                            :global(.u-{kType}-{kSize})
+                                {vType}: vSize !important
+                        else if vDir == vertical
+                            :global(.u-{kType}{kDir}-{kSize})
+                                {vType}-top: vSize !important
+                                {vType}-bottom: vSize !important
+                        else if vDir == horizontal
+                            :global(.u-{kType}{kDir}-{kSize})
+                                {vType}-left: vSize !important
+                                {vType}-right: vSize !important
+                        else
+                            :global(.u-{kType}{kDir}-{kSize})
+                                {vType}-{vDir}: vSize !important
+                    else
+                        @media (max-width: rem(lookup('BP-'+kBp)))
+                            if vDir == all
+                                :global(.u-{kType}-{kSize}-{vBp})
+                                    {vType}: vSize !important
+                            else if vDir == vertical
+                                :global(.u-{kType}{kDir}-{kSize}-{vBp})
+                                    {vType}-top: vSize !important
+                                    {vType}-bottom: vSize !important
+                            else if vDir == horizontal
+                                :global(.u-{kType}{kDir}-{kSize}-{vBp})
+                                    {vType}-left: vSize !important
+                                    {vType}-right: vSize !important
+                            else
+                                :global(.u-{kType}{kDir}-{kSize}-{vBp})
+                                    {vType}-{vDir}: vSize !important
+
+nativeSpacingUtils()
+    for kType, vType in types
+        for kSize, vSize in sizes
+            for kDir, vDir in directions
+                for kBp, vBp in breakpoints
+                    if vBp == ''
+                        if vDir == all
+                            .u-{kType}-{kSize}
+                                {vType}: vSize !important
+                        else if vDir == vertical
+                            .u-{kType}{kDir}-{kSize}
+                                {vType}-top: vSize !important
+                                {vType}-bottom: vSize !important
+                        else if vDir == horizontal
+                            .u-{kType}{kDir}-{kSize}
+                                {vType}-left: vSize !important
+                                {vType}-right: vSize !important
+                        else
+                            .u-{kType}{kDir}-{kSize}
+                                {vType}-{vDir}: vSize !important
+                    else
+                        @media (max-width: rem(lookup('BP-'+kBp)))
+                            if vDir == all
+                                .u-{kType}-{kSize}-{vBp}
+                                    {vType}: vSize !important
+                            else if vDir == vertical
+                                .u-{kType}{kDir}-{kSize}-{vBp}
+                                    {vType}-top: vSize !important
+                                    {vType}-bottom: vSize !important
+                            else if vDir == horizontal
+                                .u-{kType}{kDir}-{kSize}-{vBp}
+                                    {vType}-left: vSize !important
+                                    {vType}-right: vSize !important
+                            else
+                                .u-{kType}{kDir}-{kSize}-{vBp}
+                                    {vType}-{vDir}: vSize !important
+if cssmodules == true
+    cssModulesSpacingUtils()
+else
+    nativeSpacingUtils()
 // @stylint on


### PR DESCRIPTION
Added responsive utility classes for spacing (padding & margin).

Basically, it's the same classes name as before, you just need to add the breakpoint suffix matching your breakpoint of choice. 

| Breakpoint (px size) | Suffix |
| --- | --- |
| `BP-teeny`  (375) | `tt` |
| `BP-tiny`  (543) | `t` |
| `BP-small`  (768) | `s` |
| `BP-medium` (1023) | `m` |
| `BP-large` (1200) | `l` |
| `BP-extra-large` (1439) | `xl` |

e.g. You want an element with `1rem` of margin all around on desktop and only `.5rem` on devices below tablets. 
You will have to set it like this: `<div class="u-m-1 u-m-half-s">My beautiful element</div>`

NB:
This seems a little verbose, I agree, but I had to repeat myself because:
- Stylus doesn't allow extending `$placeholders` inside Media Queries.
- Can't use `{block}` instead either, because, in a loop, it's the same syntax for both `{block}` and `{vars}`, so it just doesn't work.
- Stylus doesn't allow creating `mixins()` in a loop either.

Couldn't find any other solution but I will gladly update this code if someone does.