### PR TITLE
fix: Change loop order to override basic spacing classes

### DIFF
--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -50,10 +50,10 @@ for kType, vType in types
 
 // Classes generation
 cssModulesSpacingUtils()
-    for kType, vType in types
-        for kSize, vSize in sizes
-            for kDir, vDir in directions
-                for kBp, vBp in breakpoints
+    for kBp, vBp in breakpoints
+        for kType, vType in types
+            for kSize, vSize in sizes
+                for kDir, vDir in directions
                     if vBp == ''
                         if vDir == all
                             :global(.u-{kType}-{kSize})
@@ -87,10 +87,10 @@ cssModulesSpacingUtils()
                                     {vType}-{vDir}: vSize !important
 
 nativeSpacingUtils()
-    for kType, vType in types
-        for kSize, vSize in sizes
-            for kDir, vDir in directions
-                for kBp, vBp in breakpoints
+    for kBp, vBp in breakpoints
+        for kType, vType in types
+            for kSize, vSize in sizes
+                for kDir, vDir in directions
                     if vBp == ''
                         if vDir == all
                             .u-{kType}-{kSize}


### PR DESCRIPTION
Before, the loop was creating classes in this order:

```css
.classA { … }

@media (…) { 
    .classA-s {…}
}
.classB { … }

@media (…) { 
    .classB-s {…}
}
```

Which meant that a responsive class such as `.classA-s` wouldn't be able to override a basic class like `.classB` defined after it and since responsive class are pretty much used to override some style it was unconvenient.

Now it outputs the classes like this:


```css
.classA { … }
.classB { … }

@media (…) { 
    .classA-s {…}
}
@media (…) { 
    .classB-s {…}
}
```
