### PR TITLE
feat: Add dimensions utility classes

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1551,6 +1551,114 @@ Display an chip that represents complex identity
 */
 
 /*
+    width/height
+
+    Classes to set width/height on elements
+
+    .u-w-auto - Cancel width
+    .u-w-1 - Apply width 1st step in scale (1rem = 16px)
+    .u-w-2 - Apply width 2nd step in scale (2rem = 32px)
+    .u-w-3 - Apply width 3rd step in scale (4rem = 64px)
+    .u-w-4 - Apply width 4th step in scale (8rem = 128px)
+    .u-w-5 - Apply width 5th step in scale (16rem = 256px)
+    .u-w-6 - Apply width 6th step in scale (32rem = 512px)
+    .u-w-7 - Apply width 7th step in scale (48rem = 768px)
+    .u-w-8 - Apply width 8th step in scale (64rem = 1024px)
+    .u-w-9 - Apply width 9th step in scale (96rem = 1536px)
+    .u-w-100 - Apply width 100%
+    .u-h-auto - Cancel height
+    .u-h-1 - Apply height 1st step in scale (1rem = 16px)
+    .u-h-2 - Apply height 2nd step in scale (2rem = 32px)
+    .u-h-3 - Apply height 3rd step in scale (4rem = 64px)
+    .u-h-4 - Apply height 4th step in scale (8rem = 128px)
+    .u-h-5 - Apply height 5th step in scale (16rem = 256px)
+    .u-h-6 - Apply height 6th step in scale (32rem = 512px)
+    .u-h-7 - Apply height 7th step in scale (48rem = 768px)
+    .u-h-8 - Apply height 8th step in scale (64rem = 1024px)
+    .u-h-9 - Apply height 9th step in scale (96rem = 1536px)
+    .u-h-100 - Apply height 100%
+
+    Markup:
+    <div class="{{modifier_class}}" style="display: inline-block;background-color:gainsboro; border: 1px solid black;">&nbsp;</div>
+
+    Weight: 11
+
+    Styleguide utilities.dimensions
+*/
+
+/*
+    Min-width/height
+
+    Classes to set min-width/height on elements
+
+    .u-miw-none - Cancel min-width
+    .u-miw-1 - Apply min-width 1st step in scale (1rem = 16px)
+    .u-miw-2 - Apply min-width 2nd step in scale (2rem = 32px)
+    .u-miw-3 - Apply min-width 3rd step in scale (4rem = 64px)
+    .u-miw-4 - Apply min-width 4th step in scale (8rem = 128px)
+    .u-miw-5 - Apply min-width 5th step in scale (16rem = 256px)
+    .u-miw-6 - Apply min-width 6th step in scale (32rem = 512px)
+    .u-miw-7 - Apply min-width 7th step in scale (48rem = 768px)
+    .u-miw-8 - Apply min-width 8th step in scale (64rem = 1024px)
+    .u-miw-9 - Apply min-width 9th step in scale (96rem = 1536px)
+    .u-miw-100 - Apply min-width 100%
+    .u-mih-none - Cancel min-height
+    .u-mih-1 - Apply min-height 1st step in scale (1rem = 16px)
+    .u-mih-2 - Apply min-height 2nd step in scale (2rem = 32px)
+    .u-mih-3 - Apply min-height 3rd step in scale (4rem = 64px)
+    .u-mih-4 - Apply min-height 4th step in scale (8rem = 128px)
+    .u-mih-5 - Apply min-height 5th step in scale (16rem = 256px)
+    .u-mih-6 - Apply min-height 6th step in scale (32rem = 512px)
+    .u-mih-7 - Apply min-height 7th step in scale (48rem = 768px)
+    .u-mih-8 - Apply min-height 8th step in scale (64rem = 1024px)
+    .u-mih-9 - Apply min-height 9th step in scale (96rem = 1536px)
+    .u-mih-100 - Apply min-height 100%
+
+    Markup:
+    <div class="{{modifier_class}}" style="display: inline-block;background-color:gainsboro; border: 1px solid black;">&nbsp;</div>
+
+    Weight: 12
+
+    Styleguide utilities.dimensions.min
+*/
+
+/*
+    Max-width/height
+
+    Classes to set max-width/height on elements
+
+    .u-maw-none - Cancel max-width
+    .u-maw-1 - Apply max-width 1st step in scale (1rem = 16px)
+    .u-maw-2 - Apply max-width 2nd step in scale (2rem = 32px)
+    .u-maw-3 - Apply max-width 3rd step in scale (4rem = 64px)
+    .u-maw-4 - Apply max-width 4th step in scale (8rem = 128px)
+    .u-maw-5 - Apply max-width 5th step in scale (16rem = 256px)
+    .u-maw-6 - Apply max-width 6th step in scale (32rem = 512px)
+    .u-maw-7 - Apply max-width 7th step in scale (48rem = 768px)
+    .u-maw-8 - Apply max-width 8th step in scale (64rem = 1024px)
+    .u-maw-9 - Apply max-width 9th step in scale (96rem = 1536px)
+    .u-maw-100 - Apply max-width 100%
+    .u-mah-none - Cancel max-height
+    .u-mah-1 - Apply max-height 1st step in scale (1rem = 16px)
+    .u-mah-2 - Apply max-height 2nd step in scale (2rem = 32px)
+    .u-mah-3 - Apply max-height 3rd step in scale (4rem = 64px)
+    .u-mah-4 - Apply max-height 4th step in scale (8rem = 128px)
+    .u-mah-5 - Apply max-height 5th step in scale (16rem = 256px)
+    .u-mah-6 - Apply max-height 6th step in scale (32rem = 512px)
+    .u-mah-7 - Apply max-height 7th step in scale (48rem = 768px)
+    .u-mah-8 - Apply max-height 8th step in scale (64rem = 1024px)
+    .u-mah-9 - Apply max-height 9th step in scale (96rem = 1536px)
+    .u-mah-100 - Apply max-height 100%
+
+    Markup:
+    <div class="{{modifier_class}}" style="background-color:gainsboro; border: 1px solid black;">&nbsp;</div>
+
+    Weight: 13
+
+    Styleguide utilities.dimensions.max
+*/
+
+/*
     Background-color
 
     Classes to set a background-color on elements

--- a/stylus/utilities/dimensions.styl
+++ b/stylus/utilities/dimensions.styl
@@ -1,0 +1,76 @@
+// @stylint off
+@require '../settings/breakpoints'
+@require '../tools/mixins'
+
+minmax = {
+    'min-width': 'miw',
+    'max-width': 'maw',
+    'min-height': 'mih',
+    'max-height': 'mah'
+}
+
+minmaxscale = {
+ 'none': none,
+ '1': rem(16),
+ '2': rem(32),
+ '3': rem(64),
+ '4': rem(128),
+ '5': rem(256),
+ '6': rem(512),
+ '7': rem(768),
+ '8': rem(1024),
+ '9': rem(1536),
+ '100': 100%
+}
+
+dimensions = {
+    'width': 'w',
+    'height': 'h'
+}
+
+dimensionsscale = {
+ 'auto': auto,
+ '1': rem(16),
+ '2': rem(32),
+ '3': rem(64),
+ '4': rem(128),
+ '5': rem(256),
+ '6': rem(512),
+ '7': rem(768),
+ '8': rem(1024),
+ '9': rem(1536),
+ '100': 100%
+}
+
+cssModulesDimensionsUtils(scale, props, breakpoints)
+    for kBp, vBp in breakpoints
+        for kScale, vScale in scale
+            for kProp, vProp in props
+                if vBp == ''
+                     :global(.u-{vProp}-{kScale})
+                        {kProp}: vScale !important
+                else
+                    @media (max-width: rem(lookup('BP-'+kBp)))
+                         :global(.u-{vProp}-{kScale}-{vBp})
+                            {kProp}: vScale !important
+
+nativeDimensionsUtils(scale, props, breakpoints)
+    for kBp, vBp in breakpoints
+        for kScale, vScale in scale
+            for kProp, vProp in props
+                if vBp == ''
+                    .u-{vProp}-{kScale}
+                        {kProp}: vScale !important
+                else
+                    @media (max-width: rem(lookup('BP-'+kBp)))
+                        .u-{vProp}-{kScale}-{vBp}
+                            {kProp}: vScale !important
+
+if cssmodules == true
+    cssModulesDimensionsUtils(minmaxscale, minmax, breakpoints)
+    cssModulesDimensionsUtils(dimensionsscale, dimensions, breakpoints)
+else
+    nativeDimensionsUtils(minmaxscale, minmax, breakpoints)
+    nativeDimensionsUtils(dimensionsscale, dimensions, breakpoints)
+
+// @stylint on


### PR DESCRIPTION
Add dimensions utilty classes to deal with `width`, `height`, `max-width`, `min-width`, `max-height`& `min-height` based on a given scale according to our design guidelines which would is:

1st step => 16px
2nd step => 32px
3rd step => 64px
4th step => 128px
5th step => 256px
6th step => 512px
7th step => 768px
8th step => 1024px
9th step => 1536px
extra step => 100%

Also you can cancel dimensions with canceling classes such as `u-w-auto` or `u-maw-auto`



