### PR TITLE
fix: Create EmptySubtitle component

### DIFF
--- a/react/Empty/index.jsx
+++ b/react/Empty/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import { Text, MainTitle } from '../Text'
+import { MainTitle, BaseText } from '../Text'
 import Icon, { iconPropType } from '../Icon'
 import styles from './styles.styl'
 
@@ -26,11 +26,7 @@ export const Empty = ({
           {title}
         </MainTitle>
       )}
-      {text && (
-        <Text tag="p" className={styles['c-empty-text']}>
-          {text}
-        </Text>
-      )}
+      {text && <EmptySubTitle tag="p">{text}</EmptySubTitle>}
       <div className={styles['c-empty-text']}>{children}</div>
     </div>
   )
@@ -43,4 +39,7 @@ Empty.propTypes = {
   className: PropTypes.string
 }
 
+export const EmptySubTitle = ({ ...restProps }) => (
+  <BaseText className={styles['c-empty-text']} {...restProps} />
+)
 export default Empty

--- a/react/Text/index.jsx
+++ b/react/Text/index.jsx
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
-const BaseText = props => {
+export const BaseText = props => {
   const { className, children, tag, ellipsis, ...restProps } = props
   const Tag = tag
   return (

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -249,7 +249,7 @@ exports[`Empty should render examples: Empty 1`] = `
         <use xlink:href=\\"#cozy\\"></use>
       </svg>
       <h2 class=\\"styles__u-title-h1___fimho styles__c-empty-title___2HduE\\">This list is empty</h2>
-      <p class=\\"styles__u-text___2UfQa styles__c-empty-text___3HnvR\\">Try adding some content to this list</p>
+      <p class=\\"styles__c-empty-text___3HnvR\\">Try adding some content to this list</p>
       <div class=\\"styles__c-empty-text___3HnvR\\"></div>
     </div>
   </div>
@@ -263,7 +263,7 @@ exports[`Empty should render examples: Empty 2`] = `
         <use xlink:href=\\"#cozy\\"></use>
       </svg>
       <h2 class=\\"styles__u-title-h1___fimho styles__c-empty-title___2HduE\\">An error occured</h2>
-      <p class=\\"styles__u-text___2UfQa styles__c-empty-text___3HnvR\\">It's maybe nothing, just refresh to be sure</p>
+      <p class=\\"styles__c-empty-text___3HnvR\\">It's maybe nothing, just refresh to be sure</p>
       <div class=\\"styles__c-empty-text___3HnvR\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj\\"><span><span>Try refreshing</span></span></button></div>
     </div>
   </div>


### PR DESCRIPTION
Dans un composant Empty, le "text" affiché est complètement différent d'un `Text` car on vient surcharger la couleur, les marges etc https://github.com/cozy/cozy-ui/blob/master/stylus/components/empty.styl#L38).

Donc vu qu'on surcharge via des classes, on est dépendant de l'ordre dans lequel les classes arrivent dans le fichier css généré, et ça, c'est pas cool. 

Plutôt que de se baser là-dessus, il est préférable de faire un propre composant pour ça. 

