### PR TITLE
feat: Add border-radius utility classes

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1286,6 +1286,25 @@ Display an chip that represents complex identity
 */
 
 /*
+    Border
+
+    Border-radius
+
+    .u-bdrs-1 - 1st step of border-radius (2px)
+    .u-bdrs-2 - 2nd step of border-radius (3px)
+    .u-bdrs-3 - 3rd step of border-radius (4px)
+    .u-bdrs-4 - 4th step of border-radius (8px)
+    .u-bdrs-circle - Round element with border-radius (100%)
+
+    Markup:
+    <div class="{{modifier_class}}  u-bg-dodgerBlue" style="width:4rem; height:4rem; "></div>
+
+    Weight: 1
+
+    Styleguide utilities.border
+*/
+
+/*
     Display
 
     Classes to change the box model of an element

--- a/stylus/utilities/border.styl
+++ b/stylus/utilities/border.styl
@@ -1,0 +1,31 @@
+@require '../settings/breakpoints'
+@require '../tools/mixins'
+
+
+bdrs-1()
+    border-radius rem(2)
+
+bdrs-2()
+    border-radius rem(3)
+
+bdrs-3()
+    border-radius rem(4)
+
+bdrs-4()
+    border-radius rem(8)
+
+bdrs-circle()
+    border-radius 100%
+
+props = {
+    'bdrs-1': 'bdrs-1',
+    'bdrs-2': 'bdrs-2',
+    'bdrs-3': 'bdrs-3',
+    'bdrs-4': 'bdrs-4',
+    'bdrs-circle': 'bdrs-circle'
+}
+
+if cssmodules == true
+    cssModulesUtils(props, breakpoints)
+else
+    nativeUtils(props, breakpoints)


### PR DESCRIPTION
Added those utility classes (obviously responsive)

- .u-bdrs-1 - Small border-radius (2px)
- .u-bdrs-2 - Medium border-radius (3px)
- .u-bdrs-3 - Large border-radius (4px)
- .u-bdrs-4 - Extra large border-radius (8px)
- .u-bdrs-circle - Round element with border-radius (100%)

[Preview](https://gooz.github.io/cozy-ui/styleguide/section-utilities.html#kssref-utilities-border)

Refs #867 