### PR TITLE
feat: Remove palette requires and reference CSS variables

### DIFF
--- a/react/ContextHeader/styles.styl
+++ b/react/ContextHeader/styles.styl
@@ -1,11 +1,10 @@
-@require 'settings/palette.styl'
 @require 'settings/breakpoints'
 @require 'tools/mixins'
 
 .context-header
   margin rem(16 32)
-  background paleGrey
-  border rem(1) solid silver
+  background var(--paleGrey)
+  border rem(1) solid var(--silver)
   padding rem(16)
   border-radius rem(5)
   display flex

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -1,10 +1,9 @@
-@require 'settings/palette.styl'
 @require 'tools/mixins'
 
 .infos
   max-width: rem(524)
   min-height: rem(56)
-  background paleGrey
+  background var(--paleGrey)
   display flex
   align-items center
   border-radius rem(8)
@@ -14,7 +13,7 @@
   height rem(16)
   padding-top .2rem
   flex-shrink 0
-  fill slateGrey
+  fill var(--slateGrey)
 
 .infos--text
   text-align left

--- a/react/IntentHeader/styles.styl
+++ b/react/IntentHeader/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette.styl'
 @require 'tools/mixins'
 
 .intentHeader
@@ -6,7 +5,7 @@
     align-items center
     height rem(32)
     padding rem(8 16)
-    background-color paleGrey
+    background-color var(--paleGrey)
     margin 0
     // Keep its height in a flex configuration
     flex-basis auto
@@ -16,7 +15,7 @@
     display flex
     align-items center
     font-size rem(20)
-    color charcoalGrey
+    color var(--charcoalGrey)
 
     span
         font-weight normal

--- a/react/IntentWrapper/styles.styl
+++ b/react/IntentWrapper/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette.styl'
 @require 'tools/mixins'
 @require 'components/modals'
 

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette.styl'
 @require 'components/popover.styl'
 @require 'tools/mixins'
 
@@ -17,7 +16,7 @@
     // cuts the hover background properly (border-radius)
     overflow   hidden
     border     0
-    color      charcoalGrey
+    color      var(--charcoalGrey)
 
 .c-menu--left
     .c-menu__inner
@@ -60,7 +59,7 @@ $paddingItem = rem(8)
 
 .c-menu__item:hover
 .c-menu__item:focus
-    background-color paleGrey
+    background-color var(--paleGrey)
     outline          none
 
 .c-menu__item--disabled

--- a/react/Well/styles.styl
+++ b/react/Well/styles.styl
@@ -1,10 +1,9 @@
-@require 'settings/palette.styl'
 @require 'settings/breakpoints'
 @require 'tools/mixins'
 
 .well
   margin rem(16 32)
-  background paleGrey
+  background var(--paleGrey)
   border rem(1) solid silver
   border-radius rem(5)
 

--- a/react/utilities.js
+++ b/react/utilities.js
@@ -1,0 +1,2 @@
+// Special file for utilities to be included in the transpiled stylesheet
+import palette from '../stylus/utilities/palette.styl' // 130k

--- a/react/utilities.js
+++ b/react/utilities.js
@@ -1,2 +1,4 @@
+/* eslint-disable no-unused-vars */
+
 // Special file for utilities to be included in the transpiled stylesheet
 import palette from '../stylus/utilities/palette.styl' // 130k

--- a/stylus/components/accordion.styl
+++ b/stylus/components/accordion.styl
@@ -1,48 +1,47 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 $accordion
     padding 0
 
 $accordion-item
-    border-bottom: rem(1) solid silver
+    border-bottom: rem(1) solid var(--silver)
     font-size rem(16)
 
 $accordion-title
     display flex
     align-items center
     line-height 2
-    color slateGrey
+    color var(--slateGrey)
     cursor pointer
     outline 0
     padding rem(8) 0
 
     &:hover
     &:focus
-        color charcoalGrey
+        color var(--charcoalGrey)
 
         svg
-            fill slateGrey
+            fill var(--slateGrey)
 
     svg
         margin-right rem(4)
         transform rotate(0)
         transition transform 300ms ease
-        fill coolGrey
+        fill var(--coolGrey)
 
 $accordion-title--active
-    color charcoalGrey
+    color var(--charcoalGrey)
 
     svg
         transform rotate(90deg)
-        fill coolGrey
+        fill var(--coolGrey)
 
 $accordion-body
     height auto
     max-height 0
     overflow hidden
     line-height 1.3
-    color charcoalGrey
+    color var(--charcoalGrey)
     transition max-height 300ms ease-out
 
     &:after

--- a/stylus/components/action-menu.styl
+++ b/stylus/components/action-menu.styl
@@ -1,6 +1,5 @@
 @require './popover.styl'
 @require '../tools/mixins'
-@require '../settings/palette'
 
 $actionmenu
     @extend        $popover
@@ -22,7 +21,7 @@ $actionmenu
 
 $actionmenu-header
     box-sizing border-box
-    border-bottom rem(1) solid silver
+    border-bottom rem(1) solid var(--silver)
     padding rem(16)
     min-height rem(64)
 
@@ -31,4 +30,4 @@ $actionmenu-item
     cursor pointer
 
     &:hover
-        background-color paleGrey
+        background-color var(--paleGrey)

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -40,7 +40,7 @@ $alert-wrapper
     box-sizing border-box
     width 100%
     box-shadow 0 rem(6) rem(18) 0 rgba(50, 54, 63, .23)
-    background-color emerald
+    background-color var(--emerald)
     padding rem(13 16)
     pointer-events auto
 
@@ -70,10 +70,10 @@ $alert-title
     font-weight bold
 
 $alert--error
-    background-color pomegranate
+    background-color var(--pomegranate)
 
 $alert--success
-    background-color emerald
+    background-color var(--emerald)
 
 $alert--info
-    background-color slateGrey
+    background-color var(--slateGrey)

--- a/stylus/components/avatar.styl
+++ b/stylus/components/avatar.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 $avatar
@@ -9,8 +8,8 @@ $avatar
     overflow hidden
     width rem(40)
     height rem(40)
-    background-color paleGrey
-    color silver
+    background-color var(--paleGrey)
+    color var(--silver)
     font-size rem(18)
 
     svg

--- a/stylus/components/badge.styl
+++ b/stylus/components/badge.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 size = rem(14)
@@ -28,13 +27,13 @@ $badge
     cursor inherit
 
 $badge--new
-    color zircon
-    background-color dodgerBlue
+    color var(--zircon)
+    background-color var(--dodgerBlue)
 
 $badge--normal
-    color paleGrey
-    background-color charcoalGrey
+    color var(--paleGrey)
+    background-color var(--charcoalGrey)
 
 $badge--error
-    color chablis
-    background-color pomegranate
+    color var(--chablis)
+    background-color var(--pomegranate)

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -430,7 +430,7 @@ $actionbtn--error
     actionbtnVariant(chablis, var(--pomegranate), var(--yourPink))
 
 $actionbtn--new
-    actionbtnVariant(zircon, var(--dodgerBlue), var(--frenchPass))
+    actionbtnVariant(var(--zircon), var(--dodgerBlue), var(--frenchPass))
     border-width rem(1)
     border-style dashed
 

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -424,7 +424,7 @@ actionbtnVariant(bgColor, txtColor, bdColor)
         background-color bgColor
 
 $actionbtn--normal
-    actionbtnVariant(paleGrey, var(--charcoalGrey), var(--silver))
+    actionbtnVariant(var(--paleGrey), var(--charcoalGrey), var(--silver))
 
 $actionbtn--error
     actionbtnVariant(chablis, var(--pomegranate), var(--yourPink))

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -544,7 +544,7 @@ $button-subtle--regular
 
 $button-subtle--secondary
     // Not using themedBtnSubtle(secondaryTheme) because
-    // var(--silver) color for a single text was too bright
+    // silver color for a single text was too bright
     color var(--slateGrey)
 
     &[aria-busy=true] > span::after

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../settings/icons'
 @require '../utilities/display'
 @require '../utilities/text'
@@ -8,26 +7,26 @@
   Variants
 \*------------------------------------*/
 regularTheme = {
-    primaryColor: dodgerBlue, secondaryColor: dodgerBlue, activeColor: scienceBlue, contrastColor: white
+    primaryColor: var(--dodgerBlue), secondaryColor: var(--dodgerBlue), activeColor: var(--scienceBlue), contrastColor: var(--white)
 }
 
 highlightTheme = {
-    primaryColor: emerald, secondaryColor: emerald, activeColor: malachite, contrastColor: white
+    primaryColor: var(--emerald), secondaryColor: var(--emerald), activeColor: var(--malachite), contrastColor: var(--white)
 }
 dangerTheme = {
-    primaryColor: pomegranate, secondaryColor: pomegranate, activeColor: monza, contrastColor: white
+    primaryColor: var(--pomegranate), secondaryColor: var(--pomegranate), activeColor: var(--monza), contrastColor: var(--white)
 }
 alphaTheme = {
-    primaryColor: transparent, secondaryColor: white, activeColor: scienceBlue, contrastColor: white
+    primaryColor: transparent, secondaryColor: var(--white), activeColor: var(--scienceBlue), contrastColor: var(--white)
 }
 secondaryTheme = {
-    primaryColor: white, secondaryColor: silver, activeColor: silver, contrastColor: black
+    primaryColor: var(--white), secondaryColor: var(--silver), activeColor: var(--silver), contrastColor: var(--black)
 }
 dangerOutlineTheme = {
-    primaryColor: white, secondaryColor: yourPink, activeColor: yourPink, contrastColor: pomegranate
+    primaryColor: var(--white), secondaryColor: var(--yourPink), activeColor: var(--yourPink), contrastColor: var(--pomegranate)
 }
 text = {
-    primaryColor: transparent, secondaryColor: transparent, activeColor: transparent, contrastColor: dodgerBlue
+    primaryColor: transparent, secondaryColor: transparent, activeColor: transparent, contrastColor: var(--dodgerBlue)
 }
 
 // We turn stylint off since without semicolons, stylus fails to
@@ -144,7 +143,7 @@ $button--secondary
 $button--text
     &:hover
     &:focus
-        color scienceBlue
+        color var(--scienceBlue)
 
     &[aria-busy=true]
         > span::after
@@ -195,26 +194,26 @@ $button-alert
 
 $button-alert--error
     @extend $button-alert
-    color   pomegranate
+    color   var(--pomegranate)
 
     &:visited
-        color pomegranate
+        color var(--pomegranate)
 
     &:active
     &:hover
     &:focus
-        color  monza
-        background-color yourPink
+        color  var(--monza)
+        background-color var(--yourPink)
 
 $button-alert--info
     @extend           $button-alert
-    background-color  coolGrey
     color             white
+    background-color  var(--coolGrey)
 
     &[disabled]
     &[aria-disabled=true]
         &:hover
-            background-color coolGrey
+            background-color var(--coolGrey)
 
     &:visited
         color white
@@ -222,20 +221,20 @@ $button-alert--info
     &:active
     &:hover
     &:focus
-        background-color charcoalGrey
+        background-color var(--charcoalGrey)
 
 $button-alert--success
     @extend $button-alert
-    color   emerald
+    color   var(--emerald)
 
     &:visited
-        color emerald
+        color var(--emerald)
 
     &:active
     &:hover
     &:focus
-        color malachite
-        background-color grannyApple
+        color var(--malachite)
+        background-color var(--grannyApple)
 
 $button-client
     @extend $button
@@ -252,10 +251,10 @@ $button-client
     font-size         rem(13)
     font-weight       bold
     line-height       1.3
-    color             slateGrey
+    color             var(--slateGrey)
 
     &:visited
-        color slateGrey
+        color var(--slateGrey)
 
     &:before
         content           ''
@@ -271,7 +270,7 @@ $button-client-mobile
     @extend $button-client
     display          flex
     justify-content  flex-start
-    background-color dodgerBlue
+    background-color var(--dodgerBlue)
     border           0
     border-radius    0
     padding          rem(8 48 8 16)
@@ -284,7 +283,7 @@ $button-client-mobile
     &[disabled]
     &[aria-disabled=true]
         &:hover
-            background-color dodgerBlue
+            background-color var(--dodgerBlue)
 
     &:visited
         color white
@@ -292,7 +291,7 @@ $button-client-mobile
     &:active
     &:hover
     &:focus
-        background-color dodgerBlue
+        background-color var(--dodgerBlue)
 
     &:before
         flex                0 0 rem(44)
@@ -359,7 +358,7 @@ $button--round
 \*------------------------------------*/
 $actionbtn
     @extend $button
-    border-color silver
+    border-color var(--silver)
     text-transform none
     max-width rem(200)
     min-height rem(32)
@@ -374,7 +373,7 @@ $actionbtn
         flex-wrap nowrap
 
     [data-action='icon']
-        border-left rem(1) solid silver
+        border-left rem(1) solid var(--silver)
 
     &:not([disabled]):hover
     &:not([disabled]):focus
@@ -404,7 +403,7 @@ $actionbtn--compact
 
     &:hover
     &:focus
-        background-color paleGrey
+        background-color var(--paleGrey)
         border 0
 
 actionbtnVariant(bgColor, txtColor, bdColor)
@@ -425,13 +424,13 @@ actionbtnVariant(bgColor, txtColor, bdColor)
         background-color bgColor
 
 $actionbtn--normal
-    actionbtnVariant(paleGrey, charcoalGrey, silver)
+    actionbtnVariant(paleGrey, var(--charcoalGrey), var(--silver))
 
 $actionbtn--error
-    actionbtnVariant(chablis, pomegranate, yourPink)
+    actionbtnVariant(chablis, var(--pomegranate), var(--yourPink))
 
 $actionbtn--new
-    actionbtnVariant(zircon, dodgerBlue, frenchPass)
+    actionbtnVariant(zircon, var(--dodgerBlue), var(--frenchPass))
     border-width rem(1)
     border-style dashed
 
@@ -507,7 +506,7 @@ $button-subtle
     &:hover
     &:focus
     &:visited
-        color scienceBlue
+        color var(--scienceBlue)
         background transparent
 
     &[aria-busy=true] > span::after
@@ -545,8 +544,8 @@ $button-subtle--regular
 
 $button-subtle--secondary
     // Not using themedBtnSubtle(secondaryTheme) because
-    // silver color for a single text was too bright
-    color slateGrey
+    // var(--silver) color for a single text was too bright
+    color var(--slateGrey)
 
     &[aria-busy=true] > span::after
         @extend $icon-spinner-grey
@@ -554,9 +553,9 @@ $button-subtle--secondary
     &:active
     &:focus
     &:hover
-        color charcoalGrey
+        color var(--charcoalGrey)
         svg
-             color slateGrey
+             color var(--slateGrey)
     svg
-        color coolGrey
+        color var(--coolGrey)
 // @stylint on

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -427,7 +427,7 @@ $actionbtn--normal
     actionbtnVariant(var(--paleGrey), var(--charcoalGrey), var(--silver))
 
 $actionbtn--error
-    actionbtnVariant(chablis, var(--pomegranate), var(--yourPink))
+    actionbtnVariant(var(--chablis), var(--pomegranate), var(--yourPink))
 
 $actionbtn--new
     actionbtnVariant(var(--zircon), var(--dodgerBlue), var(--frenchPass))

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -7,7 +7,7 @@ $chip-font-size = rem(16)
 $chip
     border-radius ($chip-height / 2)
     height $chip-height
-    background paleGrey
+    background var(--paleGrey)
     padding (($chip-height - $chip-font-size) / 2)
     box-sizing border-box
     line-height 1
@@ -23,7 +23,7 @@ $round-chip
 
 $chip-separator
     width rem(1)
-    border-left rem(1) solid silver
+    border-left rem(1) solid var(--silver)
     display inline-block
     height 100%
     margin-left rem(8)
@@ -31,7 +31,7 @@ $chip-separator
 
 $chip-button
     cursor pointer
-    color slateGrey
+    color var(--slateGrey)
 
 $chip-button--disabled
-    color coolGrey
+    color var(--coolGrey)

--- a/stylus/components/circle.styl
+++ b/stylus/components/circle.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 $circle
@@ -7,8 +6,8 @@ $circle
     justify-content center
     border-radius 50%
     overflow hidden
-    background-color dodgerBlue
     color white
+    background-color var(--dodgerBlue)
 
 $circle--medium
     width rem(40)

--- a/stylus/components/empty.styl
+++ b/stylus/components/empty.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../settings/breakpoints'
 @require '../tools/mixins'
 @require '../objects/layouts'
@@ -38,7 +37,7 @@ $empty-title
 $empty-text
     margin   rem(5) auto 0
     max-width    rem(1008)
-    color        coolGrey
+    color        var(--coolGrey)
     line-height  1.5
 
     +medium-screen()

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -5,7 +5,6 @@
     This file contains all needs for forms, inputs, labels...
 \*------------------------------------*/
 
-@require '../settings/palette'
 @require '../components/button'
 @require '../tools/mixins'
 
@@ -17,7 +16,7 @@ $form
 
         a,
         a:visited
-            color            dodgerBlue
+            color            var(--dodgerBlue)
             text-decoration  none
 
         a:hover,
@@ -38,17 +37,17 @@ $form
     .coz-form-label // Deprecated
         display         block
         text-transform  uppercase
-        color           coolGrey
+        color           var(--coolGrey)
         font-size       rem(12)
         padding         rem(9) 0
         margin-top      rem(16)
 
     .coz-form-label--error // Deprecated
         display  none
-        color    pomegranate
+        color    var(--pomegranate)
 
     .coz-form-errors
-        color  pomegranate
+        color  var(--pomegranate)
 
 $form-button
     .coz-form-controls
@@ -92,23 +91,23 @@ $form-text
         padding        rem(14) rem(12) rem(12) rem(14)
         box-sizing     border-box
         border-radius  rem(2)
-        border         rem(1) solid silver
         background     white
-        color          black
+        border         rem(1) solid var(--silver)
+        color          var(--black)
 
         &::placeholder
-            color      coolGrey
+            color      var(--coolGrey)
             font-size  rem(16)
 
         &:focus
-            border      rem(1) solid dodgerBlue
+            border      rem(1) solid var(--dodgerBlue)
             outline     0
 
         &:hover
-            border  rem(1) solid coolGrey
+            border  rem(1) solid var(--coolGrey)
 
         &.error
-            border      rem(1) solid pomegranate
+            border      rem(1) solid var(--pomegranate)
 
 
 $form-textarea
@@ -117,23 +116,23 @@ $form-textarea
         padding        rem(14 12 12 14)
         box-sizing     border-box
         border-radius  rem(2)
-        border         rem(1) solid silver
         background     white
-        color          black
+        border         rem(1) solid var(--silver)
+        color          var(--black)
 
         &::placeholder
-            color      coolGrey
+            color      var(--coolGrey)
             font-size  rem(16)
 
         &:focus
-            border      rem(1) solid dodgerBlue
+            border      rem(1) solid var(--dodgerBlue)
             outline     0
 
         &:hover
-            border  rem(1) solid coolGrey
+            border  rem(1) solid var(--coolGrey)
 
         &.error
-            border      rem(1) solid pomegranate
+            border      rem(1) solid var(--pomegranate)
 
 
 $form-select
@@ -142,9 +141,9 @@ $form-select
         padding              rem(12 12 14)
         border-radius        rem(4)
         box-sizing           border-box
-        border               rem(1) solid silver
         background           white
-        color                black
+        border               rem(1) solid var(--silver)
+        color                var(--black)
         appearance           none
         background-image     embedurl('../../assets/icons/ui/arrow.svg')
         background-position  right rem(8) center
@@ -154,17 +153,17 @@ $form-select
             display  none
 
         &::placeholder
-            color      slateGrey
+            color      var(--slateGrey)
             font-size  rem(17)
 
         &:focus
-            border      rem(1) solid dodgerBlue
+            border      rem(1) solid var(--dodgerBlue)
 
         &:hover
-            border  rem(1) solid coolGrey
+            border  rem(1) solid var(--coolGrey)
 
         &.error
-            border      rem(1) solid pomegranate
+            border      rem(1) solid var(--pomegranate)
             background  none
 
 
@@ -207,30 +206,30 @@ $form-progress
         margin         rem(8) 0
         width          100%
         height         rem(8)
-        color          dodgerBlue
-        background     paleGrey
+        color          var(--dodgerBlue)
+        background     var(--paleGrey)
         border         0
         border-radius  rem(18)
 
         // chrome and safari
         &::-webkit-progress-bar
-            background     paleGrey
+            background     var(--paleGrey)
             border-radius  rem(18)
 
         &::-webkit-progress-value
-            background     charcoalGrey
+            background     var(--charcoalGrey)
             border-radius  rem(18)
 
         // firefox
         &::-moz-progress-bar
-            background     charcoalGrey
+            background     var(--charcoalGrey)
             border-radius  rem(18)
 
 // New styles
 $label
     display block
     text-transform uppercase
-    color coolGrey
+    color var(--coolGrey)
     font-size rem(13)
     font-weight bold
     line-height rem(16)
@@ -238,16 +237,16 @@ $label
     margin-top rem(16)
 
     &.is-error
-        color pomegranate
+        color var(--pomegranate)
 
 $input--disabled
     cursor not-allowed
-    background-color paleGrey
-    color charcoalGrey
+    background-color var(--paleGrey)
+    color var(--charcoalGrey)
 
     &:hover
     &:focus
-        border rem(1) solid silver
+        border rem(1) solid var(--silver)
 
 $input-text
     display inline-block
@@ -256,27 +255,27 @@ $input-text
     padding rem(13 16)
     box-sizing border-box
     border-radius rem(3)
-    border rem(1) solid silver
     background white
+    border rem(1) solid var(--silver)
     font-size rem(16)
     line-height 1.25
-    color charcoalGrey
+    color var(--charcoalGrey)
     outline 0
 
     &::placeholder
-        color coolGrey
+        color var(--coolGrey)
         font-size rem(16)
 
     &:hover
-        border rem(1) solid coolGrey
+        border rem(1) solid var(--coolGrey)
 
     &:focus
-        border rem(1) solid dodgerBlue
+        border rem(1) solid var(--dodgerBlue)
         outline 0
 
     &.is-error
     &:not(:focus):invalid
-        border rem(1) solid pomegranate
+        border rem(1) solid var(--pomegranate)
 
     &[aria-disabled]
     &[disabled]
@@ -331,11 +330,11 @@ $checkbox
 
         &::before
             transition box-shadow 350ms cubic-bezier(0, .89, .44, 1)
-            box-shadow inset 0 0 0 rem(2) silver
             background-color white
+            box-shadow inset 0 0 0 rem(2) var(--silver)
 
         &:hover::before
-            box-shadow inset 0 0 0 rem(2) dodgerBlue
+            box-shadow inset 0 0 0 rem(2) var(--dodgerBlue)
 
         &::after
             background-image embedurl('../../assets/icons/ui/check-white.svg')
@@ -353,17 +352,17 @@ $checkbox
             cursor not-allowed
 
         :hover::before
-            box-shadow inset 0 0 0 rem(2) silver
+            box-shadow inset 0 0 0 rem(2) var(--silver)
 
         ::before
-            background-color paleGrey
+            background-color var(--paleGrey)
 
     input
         hide()
 
         &:checked
             & + span::before
-                box-shadow inset 0 0 0 checkbox-size dodgerBlue
+                box-shadow inset 0 0 0 checkbox-size var(--dodgerBlue)
 
             & + span::after
                 opacity 1
@@ -374,11 +373,11 @@ $checkbox
             transform scale(0)
 
     &.is-error span
-        color pomegranate
+        color var(--pomegranate)
 
         &::before
-            box-shadow inset 0 0 0 rem(2) pomegranate
-            background-color yourPink
+            box-shadow inset 0 0 0 rem(2) var(--pomegranate)
+            background-color var(--yourPink)
 
 $radio
     @extend $checkbox

--- a/stylus/components/list.styl
+++ b/stylus/components/list.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 $list-text

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../settings/z-index'
 @require '../settings/breakpoints'
 @require '../objects/layouts'
@@ -65,7 +64,7 @@ $modal
     max-height 100%
     max-width 100%
     background-color white
-    color charcoalGrey
+    color var(--charcoalGrey)
 
 for size in 'small' 'medium' 'large' 'xlarge' 'xxlarge'
     $modal--{size}
@@ -157,7 +156,7 @@ $modal-header-app
     display flex
     align-items center
     font-size rem(20)
-    color charcoalGrey
+    color var(--charcoalGrey)
 
 $modal-header-app-editor
     font-weight normal
@@ -167,7 +166,7 @@ $modal-header-app-icon
     margin-right rem(8)
 
 $modal-content-fixed
-    border-bottom rem(1) solid silver
+    border-bottom rem(1) solid var(--silver)
     flex 0 0 auto
     padding 0 medium-padding
 
@@ -234,7 +233,7 @@ $modal-footer--button
             min-width calc(50% - .5rem)
 
 $modal-section
-    border-top rem(1) solid silver
+    border-top rem(1) solid var(--silver)
 
 cross-size=rem(40)
 

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -1,6 +1,5 @@
 @require '../settings/breakpoints'
 @require '../settings/z-index'
-@require '../settings/palette'
 @require '../tools/mixins'
 
 /*------------------------------------*\
@@ -33,7 +32,7 @@ $nav-item
         left 0
         right rem(16)
         bottom 0
-        background     silver
+        background     var(--silver)
 
         // Prevent double tap on tablets
         @media (hover: none)
@@ -52,14 +51,14 @@ $nav-item
 $nav-item-icon
     display inline-block
     margin-right rem(11)
-    color coolGrey
+    color var(--coolGrey)
     fill currentColor
 
     .is-active &
-        color dodgerBlue
+        color var(--dodgerBlue)
 
     :hover > &
-        color charcoalGrey
+        color var(--charcoalGrey)
 
     +medium-screen()
         display block
@@ -83,7 +82,7 @@ $nav-link
     padding-right        rem(16)
     line-height          1.5
     text-decoration      none
-    color                slateGrey
+    color                var(--slateGrey)
     height               100%
     align-items          center
     flex                 1
@@ -91,25 +90,25 @@ $nav-link
     background-position  rem(24) center
 
     &:visited
-        color  slateGrey
+        color  var(--slateGrey)
 
     &:hover
-        color  charcoalGrey
+        color  var(--charcoalGrey)
 
     &.active // deprecated
     &.is-active
-        box-shadow   inset rem(4) 0 0 0 dodgerBlue
+        box-shadow   inset rem(4) 0 0 0 var(--dodgerBlue)
         font-weight  bold
 
         .c-nav-icon
-            color dodgerBlue
+            color var(--dodgerBlue)
 
     +medium-screen()
         display              block
         height               auto
         padding              0
         text-align           center
-        color                slateGrey
+        color                var(--slateGrey)
         font-size            rem(10)
         line-height          1
         background-position  center top
@@ -120,9 +119,9 @@ $nav-link
         &:hover
             box-shadow   none
             font-weight  normal
-            color        charcoalGrey
+            color        var(--charcoalGrey)
 
     // Prevent double tap on tablets
     @media not all and (pointer: fine)
         &:hover
-            color slateGrey
+            color var(--slateGrey)

--- a/stylus/components/overlay.styl
+++ b/stylus/components/overlay.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../settings/z-index'
 
 $overlay
@@ -8,6 +7,6 @@ $overlay
     left        0
     height      100%
     width       100%
-    background  overlay
+    background  var(--overlay)
     visibility  visible
     transition  opacity .3s, visibility 0s ease-out

--- a/stylus/components/panels.styl
+++ b/stylus/components/panels.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/utilities/spaces.styl'
-@require 'settings/palette.styl'
 @require 'settings/breakpoints.styl'
 
 $panel-group
@@ -15,7 +14,7 @@ $panel-main
 
 $panel-side
     flex 0 0 35%
-    background paleGrey
+    background var(--paleGrey)
     overflow auto
 
 $panel-main, $panel-side

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../settings/z-index'
 @require '../tools/mixins'
 
@@ -11,29 +10,29 @@
 
 $popover
     z-index           $popover-index
-    border            rem(1) solid silver
+    border            rem(1) solid var(--silver)
     border-radius     rem(4)
     box-shadow        rem(0 1 3 0) rgba(50, 54, 63, .19), rem(0 6 18 0) rgba(50, 54, 63, .19)
-    background-color  white
+    background-color  var(--white)
     // @stylint off
     // because Stylint doesn't support custom elements
     b-item:hover
     b-item:focus
-        background-color paleGrey
+        background-color var(--paleGrey)
         outline          none
     // @stylint on
 
     hr
         margin      rem(5) 0
         border      0
-        border-top  rem(1) solid silver
+        border-top  rem(1) solid var(--silver)
 
     a
     button
     [role=button]
         display          block
         padding          rem(8 32 8 40)
-        color            charcoalGrey
+        color            var(--charcoalGrey)
         text-decoration  none
         white-space      nowrap
         cursor           pointer

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -23,8 +23,8 @@ $selectionbar
         align-items       center
         width             100%
         height            rem(52)
-        background-color  slateGrey
         color             white
+        background-color  var(--slateGrey)
         font-weight       bold
 
         .coz-selectionbar-separator

--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -1,5 +1,4 @@
 @require '../settings/breakpoints'
-@require '../settings/palette'
 @require '../settings/z-index'
 @require '../tools/mixins'
 
@@ -10,7 +9,7 @@ $table
     flex 1 1 100%
     height 100%
     text-align left
-    color coolGrey
+    color var(--coolGrey)
 
 $table-head
     flex 0 0 rem(32)
@@ -35,16 +34,16 @@ $table-row
     flex 0 0 auto
     height rem(48)
     width 100%
-    border-top rem(1) solid silver
+    border-top rem(1) solid var(--silver)
 
     &:hover
-        background-color paleGrey
+        background-color var(--paleGrey)
         // Prevent hover effect when scrolling on touch devices
         @media (hover: none)
             background-color transparent
 
     &:last-child
-        border-bottom rem(1) solid silver
+        border-bottom rem(1) solid var(--silver)
 
     +medium-screen()
         max-width 100vw
@@ -62,7 +61,7 @@ $table-row-head
 $table-row-selected
     &
     &:hover
-        background-color zircon
+        background-color var(--zircon)
 
 $table-cell
     box-sizing border-box
@@ -87,7 +86,7 @@ $table-cell--primary
     @extend $table-ellipsis
     font-size rem(16)
     line-height 1.15
-    color charcoalGrey
+    color var(--charcoalGrey)
 
     +small-screen()
         flex 1 1 auto
@@ -96,12 +95,12 @@ $table-divider
     position sticky
     z-index $low-index
     top 0
-    background-color zircon
+    background-color var(--zircon)
     text-indent rem(32)
     font-weight bold
     font-size rem(12)
     line-height 1.33
-    color coolGrey
+    color var(--coolGrey)
 
     & + * // @stylint ignore
         border-top 0
@@ -115,7 +114,7 @@ $table--legacy
     width 100%
     border 0
     text-align left
-    color coolGrey
+    color var(--coolGrey)
     border-collapse collapse
 
     tr
@@ -136,14 +135,14 @@ $table-divider--legacy
     border 0
     width auto
     height auto
-    background-color zircon
+    background-color var(--zircon)
 
     &::before
         content none
 
     td
         font-weight bold
-        color coolGrey
+        color var(--coolGrey)
         padding 0
         font-size rem(12)
         line-height 1.33

--- a/stylus/components/tabs.styl
+++ b/stylus/components/tabs.styl
@@ -1,9 +1,8 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 $tabs-base
     .coz-tab-list
-        border-bottom  rem(1) solid silver
+        border-bottom  rem(1) solid var(--silver)
 
     .coz-tab
         display        inline-block
@@ -11,14 +10,14 @@ $tabs-base
         text-transform uppercase
         font-size      rem(13)
         cursor         pointer
-        color          coolGrey
+        color          var(--coolGrey)
 
         &:hover
             text-decoration none
 
     .coz-tab--active
-        border-bottom rem(2) solid dodgerBlue
-        color         dodgerBlue
+        border-bottom rem(2) solid var(--dodgerBlue)
+        color         var(--dodgerBlue)
 
     .coz-tab-panel
         padding-top rem(20)

--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -1,6 +1,5 @@
 @require '../tools/mixins'
 @require '../settings/breakpoints'
-@require '../settings/palette'
 @require '../objects/layouts'
 @require '../components/forms'
 @require '../components/button'
@@ -16,8 +15,8 @@ $wizard
     justify-content center
     align-items center
     width 100%
-    background-color white
-    color charcoalGrey
+    background-color var(--white)
+    color var(--charcoalGrey)
     text-align center
 
     +small-device()
@@ -25,8 +24,8 @@ $wizard
         justify-content flex-start
 
 $wizard--waiting
-    background-color dodgerBlue
     color white
+    background-color var(--dodgerBlue)
 
 $wizard--scroll
     position absolute
@@ -80,8 +79,8 @@ $wizard-dual
 
     &:first-child
         justify-content flex-end
-        background-color dodgerBlue
         color white
+        background-color var(--dodgerBlue)
 
 $wizard-errors
     order 1
@@ -180,8 +179,8 @@ $wizard-logo-badge
     right rem(16)
     width rem(32)
     height rem(32)
-    background-color dodgerBlue
     border .125rem solid white
+    background-color var(--dodgerBlue)
     border-radius 50%
 
 $wizard-header-help
@@ -205,16 +204,16 @@ $wizard-disclaimer
     span
         flex 0 0 auto
         margin-right rem(16)
-        background-color grannyApple
+        background-color var(--grannyApple)
         padding rem(8)
         border-radius 50%
 
     svg
         display block
-        fill emerald
+        fill var(--emerald)
 
     strong
-        color emerald
+        color var(--emerald)
 
     +small-device()
         display none
@@ -224,12 +223,12 @@ $wizard-desc
     line-height 1.5
 
     a
-        color dodgerBlue
+        color var(--dodgerBlue)
         text-decoration none
 
         &:hover
         &:focus
-            color scienceBlue
+            color var(--scienceBlue)
 
     +small-device()
         margin rem(24) 0 0
@@ -250,7 +249,7 @@ $wizard-header-fixed
 $wizard-previous
     margin 0
     padding rem(10) rem(16)
-    color coolGrey
+    color var(--coolGrey)
 
 $wizard-brand
     margin-left rem(32)
@@ -272,7 +271,7 @@ $wizard-brand-with
         left 0
         top 50%
         height rem(24)
-        border-left rem(1) solid silver
+        border-left rem(1) solid var(--silver)
         transform translateY(-50%)
 
 $wizard-next
@@ -313,8 +312,8 @@ $wizard-dual-btn
 
     &:hover
     &:focus
-        background-color emerald
-        border-color emerald
+        background-color var(--emerald)
+        border-color var(--emerald)
 
 $wizard-waiting-icon
     margin 0 0 rem(32)
@@ -403,25 +402,25 @@ $wizard-showbutton
     padding 0
     min-width auto
     background-color transparent
-    color coolGrey
+    color var(--coolGrey)
 
     &:hover
     &:focus
         background-color inherit
-        color charcoalGrey
+        color var(--charcoalGrey)
 
 $wizard-dualfield
     display flex
     flex-direction row
     align-items stretch
-    border rem(1) solid silver
+    border rem(1) solid var(--silver)
     border-radius rem(2)
 
 $wizard-dualfield--focus
-    border-color dodgerBlue
+    border-color var(--dodgerBlue)
 
 $wizard-dualfield--error
-    border-color pomegranate
+    border-color var(--pomegranate)
 
 $wizard-dualfield-wrapper
     flex 1 1 auto
@@ -443,8 +442,8 @@ $wizard-dualfield-input
 $wizard-protocol
     display flex
     align-items center
-    background-color paleGrey
-    border-right rem(1) solid silver
+    background-color var(--paleGrey)
+    border-right rem(1) solid var(--silver)
     padding 0 rem(16)
 
     svg
@@ -471,7 +470,7 @@ $wizard-select
     &:focus
         position relative
         z-index 1
-        background-color paleGrey
+        background-color var(--paleGrey)
         border 0
         outline 0
 
@@ -489,7 +488,7 @@ $wizard-requirements
     list-style disc inside
     line-height 1.5
     font-style italic
-    color coolGrey
+    color var(--coolGrey)
 
     span
         display inline-block
@@ -520,10 +519,10 @@ $wizard-agreements-item
     flex-direction column
     flex 1 1 calc(100% / 6 - .5rem)
     margin rem(16 4 0)
-    border rem(1) solid silver
+    border rem(1) solid var(--silver)
     border-radius rem(8)
     padding rem(16)
-    color slateGrey
+    color var(--slateGrey)
 
     +medium-screen()
         flex-direction row
@@ -543,13 +542,13 @@ $wizard-agreements-desc
 
     +medium-screen()
         flex 1 1 100%
-        border-bottom rem(1) solid silver
+        border-bottom rem(1) solid var(--silver)
         padding-bottom rem(16)
         font-size rem(16)
         line-height 1.5
 
 $wizard-agreements-icon
-    --bgcolor dodgerBlue // @stylint ignore
+    --bgcolor var(--dodgerBlue) // @stylint ignore
     box-sizing border-box
     display flex
     align-items center
@@ -619,13 +618,13 @@ $wizard-notice
         margin 0
 
     a
-        color dodgerBlue
+        color var(--dodgerBlue)
         text-decoration none
         font-weight bold
 
         &:hover
         &:focus
-            color scienceBlue
+            color var(--scienceBlue)
 
     +tiny-screen('min')
         margin rem(32) 0 0

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -64,11 +64,11 @@ body
 
     label::before
         border-radius 50%
-        border        rem(2) solid coolGrey
+        border        rem(2) solid var(--coolGrey)
         box-shadow    inset 0 0 0 checkbox-size transparent
 
     input[type=radio]:checked + label::before
-        box-shadow inset 0 0 0 rem(3) paleGrey, inset 0 0 0 checkbox-size dodgerBlue
+        box-shadow inset 0 0 0 rem(3) var(--paleGrey), inset 0 0 0 checkbox-size var(--dodgerBlue)
 
 
 [data-input=checkbox]
@@ -80,11 +80,11 @@ body
             border-radius rem(2)
 
         &::before
-            box-shadow        inset 0 0 0 rem(2) silver
             background-color  white
+            box-shadow        inset 0 0 0 rem(2) var(--silver)
 
             &:hover
-                box-shadow inset 0 0 0 rem(2) dodgerBlue
+                box-shadow inset 0 0 0 rem(2) var(--dodgerBlue)
 
         &::after
             background-image  embedurl('../../assets/icons/ui/check-white.svg')
@@ -97,7 +97,7 @@ body
     input[type=checkbox]
         &:checked
             & + label::before
-                box-shadow inset 0 0 0 checkbox-size dodgerBlue
+                box-shadow inset 0 0 0 checkbox-size var(--dodgerBlue)
 
             & + label::after
                 opacity   1

--- a/stylus/generic/typography.styl
+++ b/stylus/generic/typography.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../settings/breakpoints'
 @require '../tools/mixins'
 
@@ -12,7 +11,7 @@
 
 $title-default
     font-weight bold
-    color charcoalGrey
+    color var(--charcoalGrey)
 
 $title-h1
     @extend $title-default
@@ -38,7 +37,7 @@ $title-h4
     font-size rem(16)
     +small-screen()
         font-weight bold
-        color charcoalGrey
+        color var(--charcoalGrey)
 
 /*------------------------------------*\
   Text content
@@ -47,25 +46,25 @@ $title-h4
 $text
     font-size rem(16)
     line-height 1.3
-    color charcoalGrey
+    color var(--charcoalGrey)
 
 $caption
     font-size rem(12)
     line-height 1.2
-    color coolGrey
+    color var(--coolGrey)
 
 /*------------------------------------*\
   Link
 \*------------------------------------*/
 $link
     &:link
-        color dodgerBlue
+        color var(--dodgerBlue)
         text-decoration none
 
     &:visited
     &:active
     &:hover
     &:focus
-        color scienceBlue
+        color var(--scienceBlue)
 
 global('.u-link', $link)

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -1,7 +1,6 @@
 @require '../tools/mixins'
 @require '../settings/breakpoints'
 @require '../settings/z-index'
-@require '../settings/palette'
 @require '../elements/defaults'
 
 /*------------------------------------*\

--- a/stylus/objects/sidebar.styl
+++ b/stylus/objects/sidebar.styl
@@ -1,5 +1,4 @@
 @require '../settings/breakpoints'
-@require '../settings/palette'
 @require '../tools/mixins'
 
 /*------------------------------------*\
@@ -8,13 +7,13 @@
 
 $sidebar
     width rem(220)
-    border-right rem(1) solid silver
-    background-color paleGrey
+    border-right rem(1) solid var(--silver)
+    background-color var(--paleGrey)
 
     +medium-screen()
         justify-content space-between
         border 0
-        border-top rem(1) solid silver
+        border-top rem(1) solid var(--silver)
         height rem(48)
         width 100%
         // iPhone X environment tweak

--- a/stylus/utilities/bgcolor.styl
+++ b/stylus/utilities/bgcolor.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 colors=json('../settings/palette.json', { hash: true })

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -1,4 +1,3 @@
-@require '../settings/palette'
 @require '../tools/mixins'
 
 /*------------------------------------*\
@@ -6,7 +5,7 @@
 \*------------------------------------*/
 
 $error
-    color  pomegranate
+    color  var(--pomegranate)
 
 $error-warning
     &:before
@@ -19,10 +18,10 @@ $error-warning
         vertical-align  text-bottom
 
 $valid
-    color  malachite
+    color  var(--malachite)
 
 $warn
-    color  texasRose
+    color  var(--texasRose)
 
 colors=json('../settings/palette.json', { hash: true })
 


### PR DESCRIPTION
We rely now on CSS variables for colors and no longer have to rely
on the values of stylus variables. This lets us remove the `require`s
to `palette.styl` which are generating duplicate declarations of colors. 

`:root { var(--dodgerBlue): #279ef1;... }`

Visible here : https://ptbrowne.github.io/cozy-ui/react/