### PR TITLE
fix: Cannot pass boolean for function

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -316,7 +316,7 @@ class Modal extends Component {
     return maybeWrapInPortal(
       <div className={cx(styles['c-modal-container'], containerClassName)}>
         <Overlay
-          onEscape={closable && dismissAction}
+          onEscape={closable ? dismissAction : undefined}
           className={overlayClassName}
         >
           <div
@@ -328,7 +328,7 @@ class Modal extends Component {
               wrapperClassName
             )}
             style={style}
-            onClick={closable && this.handleOutsideClick}
+            onClick={closable ? this.handleOutsideClick : undefined}
           >
             <div
               className={cx(


### PR DESCRIPTION
To fix the warnings

```
Warning: Expected `onClick` listener to be a function,
instead got `false`.

If you used to conditionally omit it with onClick={condition && value},
pass onClick={condition ? value : undefined} instead.
```