### PR TITLE
feat(I18n): Don't crash if the default lang can't be found

### DIFF
--- a/react/I18n/format.jsx
+++ b/react/I18n/format.jsx
@@ -1,15 +1,23 @@
 import format from 'date-fns/format'
 import { DEFAULT_LANG } from '.'
 
+const getWarningMessage = lang =>
+  `The "${lang}" locale isn't supported by date-fns. or has not been included in the build. Check if you have configured a ContextReplacementPlugin that is too restrictive.`
+
 export const initFormat = (lang, defaultLang = DEFAULT_LANG) => {
-  const locales = {
-    [defaultLang]: require(`date-fns/locale/${defaultLang}/index.js`)
+  const locales = {}
+
+  try {
+    locales[defaultLang] = require(`date-fns/locale/${defaultLang}/index.js`)
+  } catch (err) {
+    console.warn(getWarningMessage(defaultLang))
   }
+
   if (lang && lang !== defaultLang) {
     try {
       locales[lang] = require(`date-fns/locale/${lang}/index.js`)
     } catch (e) {
-      console.warn(`The "${lang}" locale isn't supported by date-fns`)
+      console.warn(getWarningMessage(lang))
     }
   }
   return (date, formatStr) => format(date, formatStr, { locale: locales[lang] })

--- a/react/I18n/format.spec.jsx
+++ b/react/I18n/format.spec.jsx
@@ -1,0 +1,7 @@
+import { initFormat } from './format'
+
+describe('initFormat', () => {
+  it('should not throw if a date-fns locale can not be found', () => {
+    expect(() => initFormat('unknown-lang', 'unknown-default')).not.toThrow()
+  })
+})


### PR DESCRIPTION
An error is thrown if the date-fns locale corresponding to the default
lang can't be found, and it make the whole app crash. It should warn the
user that the locale can't be found in date-fns, but not crash the app.