### PR TITLE
fix: Remove warning of deprecated typography

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -7,8 +7,9 @@ const defaultValues = {
 
 export const theme = createMuiTheme({
   typography: {
+    useNextVariants: true,
     fontFamily: getCssVariableValue('primaryFont'),
-    title: {
+    h6: {
       color: 'white'
     }
   },


### PR DESCRIPTION
On cozy-banks we use material-ui theme from cozy-ui and we show this
warning every time we launch this app:
> Warning: Material-UI: you are using the deprecated typography
> variants that will be removed in the next major release.
> Please read the migration guide under
> https://material-ui.com/style/typography#migration-to-typography-v2"
