### PR TITLE
fix: SelectionBar button label

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -64,6 +64,8 @@ const SelectionBar = ({
         className={styles['coz-action-close']}
         onClick={hideSelectionBar}
         extension="narrow"
+        label={t('SelectionBar.close')}
+        iconOnly
       >
         <Icon icon="cross" />
       </Button>


### PR DESCRIPTION
Since `Button` has to have a `label` for accessibility, we should add a label to the selection bar. 

We have to create a new translation string in our app that use SelectionBar 