### PR TITLE
fix: Remove unused rules on u-flex-auto class

### DIFF
--- a/stylus/utilities/flexbox.styl
+++ b/stylus/utilities/flexbox.styl
@@ -7,12 +7,8 @@ flexbox()
 inline-flexbox()
     display inline-flex
 
-/* 1 Fix for Chrome 44 bug.
- * https//code.google.com/p/chromium/issues/detail?id=506893 */
 flexbox-auto()
     flex 1 1 auto
-    min-width 0 /* 1 */
-    min-height 0 /* 1 */
 
 flexbox-none()
     flex none


### PR DESCRIPTION
These rules were interfering with other `min-height` and `min-width` rules without us being in the clear about what problem they solve.