### PR TITLE
fix: label prop is required in Button

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -43,7 +43,7 @@ class FieldWithFocus extends React.Component {
             inputRef={c => this.component = c}
             label="I can have focus"
             placeholder="Focus please" />
-        <Button onClick={this.setFocus}>Set Focus</Button>
+        <Button label="Focus!" onClick={this.setFocus}>Set Focus</Button>
       </div>
     )
   }

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -59,6 +59,8 @@ const SelectionBar = ({
         />
       ))}
       <Button
+        iconOnly
+        label={t('SelectionBar.close')}
         type="button"
         theme="close"
         className={styles['coz-action-close']}

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -281,7 +281,7 @@ exports[`Field should render examples: Field 1`] = `
 exports[`Field should render examples: Field 2`] = `
 "<div>
   <div>
-    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I can have focus</label><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"Focus please\\" value=\\"\\"></div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj\\"><span>Set Focus</span></button>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I can have focus</label><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"Focus please\\" value=\\"\\"></div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj\\"><span><span>Focus!</span>Set Focus</span></button>
   </div>
 </div>"
 `;


### PR DESCRIPTION
Now that `label` prop is required in `Button` component, we have warning in our apps because `SelectionBar` renders a `Button` without `label`. We could add an empty string as `defaultProp` for `label` but I think that the idea is to force users to make it explicit.