### PR TITLE
fix: Default popover state

### DIFF
--- a/react/Popover/Popover.jsx
+++ b/react/Popover/Popover.jsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import { getScrollParent } from '../utils/dom'
 export default class Popover extends Component {
+  state = {
+    style: {}
+  }
+
   constructor(props) {
     super(props)
     this.defaultStyle = {


### PR DESCRIPTION
Prevents an error when used with react.

@Crash-- This component is used in Drive, but is otherwise marked as not ready; what is missing from it to be ready for broader use ?