### PR TITLE
Revert "fix: Selectionbar button label (#897)"

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -66,8 +66,6 @@ const SelectionBar = ({
         className={styles['coz-action-close']}
         onClick={hideSelectionBar}
         extension="narrow"
-        label={t('SelectionBar.close')}
-        iconOnly
       >
         <Icon icon="cross" />
       </Button>


### PR DESCRIPTION
This reverts commit 882efa8664a4fca213bf7a1ce025f1e8fa013346.

It was already done before and was breaking the CI.