### PR TITLE
fix: AppLinker use native URL to construct url

### DIFF
--- a/react/AppLinker/native.js
+++ b/react/AppLinker/native.js
@@ -9,12 +9,8 @@ export const getUniversalLinkDomain = () => {
 */
 export const generateUniversalLink = ({ slug, nativePath, fallbackUrl }) => {
   if (!nativePath.startsWith('/')) nativePath = '/' + nativePath
-  return (
-    getUniversalLinkDomain() +
-    '/' +
-    slug +
-    nativePath +
-    '&fallback=' +
-    fallbackUrl
-  )
+  let url = getUniversalLinkDomain() + '/' + slug + nativePath
+  const urlObj = new URL(url)
+  urlObj.searchParams.append('fallback', fallbackUrl)
+  return urlObj.toString()
 }

--- a/react/AppLinker/native.spec.js
+++ b/react/AppLinker/native.spec.js
@@ -1,4 +1,4 @@
-import { generateUniversalLink, getUniversalLinkDomain } from './native'
+import { generateUniversalLink } from './native'
 
 describe('native functions', () => {
   it('should generate the universalink', () => {
@@ -8,8 +8,19 @@ describe('native functions', () => {
       fallbackUrl: 'https://drive.cozy.tools/files/1'
     })
     const endLink =
-      getUniversalLinkDomain() +
-      '/drive/files/1&fallback=https://drive.cozy.tools/files/1'
+      'https://links.mycozy.cloud/drive/files/1?fallback=https%3A%2F%2Fdrive.cozy.tools%2Ffiles%2F1'
+
+    expect(universalLink).toEqual(endLink)
+  })
+
+  it('should generate the universalink with several search params', () => {
+    const universalLink = generateUniversalLink({
+      slug: 'drive',
+      nativePath: '/files/1?viewer=test',
+      fallbackUrl: 'https://drive.cozy.tools/files/1?viewer=test'
+    })
+    const endLink =
+      'https://links.mycozy.cloud/drive/files/1?viewer=test&fallback=https%3A%2F%2Fdrive.cozy.tools%2Ffiles%2F1%3Fviewer%3Dtest'
     expect(universalLink).toEqual(endLink)
   })
 
@@ -20,7 +31,7 @@ describe('native functions', () => {
       fallbackUrl: 'https://drive.cozy.tools/'
     })
     const endLink =
-      'https://links.mycozy.cloud/drive/&fallback=https://drive.cozy.tools/'
+      'https://links.mycozy.cloud/drive/?fallback=https%3A%2F%2Fdrive.cozy.tools%2F'
     expect(universalLink).toEqual(endLink)
   })
 
@@ -31,7 +42,8 @@ describe('native functions', () => {
       fallbackUrl: 'https://drive.cozy.tools/'
     })
     const endLink =
-      getUniversalLinkDomain() + '/drive/&fallback=https://drive.cozy.tools/'
+      'https://links.mycozy.cloud/drive/?fallback=https%3A%2F%2Fdrive.cozy.tools%2F'
+
     expect(universalLink).toEqual(endLink)
   })
 })


### PR DESCRIPTION
Native `URL` is way better than me. 

