### PR TITLE
Field: Inject name prop

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -51,6 +51,21 @@ class FieldWithFocus extends React.Component {
 ;<FieldWithFocus />
 ```
 
+- `name`
+
+Name of the form field, injected into `Input`, `TextArea` or `SelectBox` component.
+
+##### Exemple
+
+```
+<form>
+  <Field
+    label="I got a name"
+    name="foo"
+  />
+</form>
+```
+
 #### Field when there's an error
 
 ```
@@ -128,4 +143,3 @@ const options = [
   />
 </form>
 ```
-

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -80,6 +80,7 @@ const Field = props => {
     label,
     id,
     inputRef,
+    name,
     type,
     value,
     placeholder,
@@ -109,6 +110,7 @@ const Field = props => {
           <Textarea
             disabled={disabled}
             id={id}
+            name={name}
             placeholder={placeholder}
             value={value}
             error={error}
@@ -125,6 +127,7 @@ const Field = props => {
             fullwidth={fullwidth}
             id={id}
             inputRef={inputRef}
+            name={name}
             type={type}
             placeholder={placeholder}
             value={value}
@@ -148,6 +151,7 @@ const Field = props => {
             fullwidth={fullwidth}
             id={id}
             inputRef={inputRef}
+            name={name}
             type={type}
             placeholder={placeholder}
             value={value}
@@ -189,6 +193,7 @@ Field.propTypes = {
   fullwidth: PropTypes.bool,
   label: PropTypes.string.isRequired,
   id: PropTypes.string,
+  name: PropTypes.string,
   type: PropTypes.oneOf([
     'date',
     'email',

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -273,6 +273,7 @@ class SelectBox extends Component {
       styles: reactSelectStyles,
       breakpoints: { isMobile },
       classNamePrefix,
+      name,
       ...props
     } = this.props
     const showOverlay = this.state.isOpen && isMobile
@@ -304,6 +305,7 @@ class SelectBox extends Component {
         // but this behavior will soon be removed. For the moment, we
         // cancel it by setting it to empty string
         classNamePrefix={classNamePrefix || ''}
+        selectProps={{ name }}
       />
     )
   }
@@ -314,6 +316,7 @@ SelectBox.propTypes = {
   components: PropTypes.object,
   disabled: PropTypes.bool,
   fullwidth: PropTypes.bool,
+  name: PropTypes.string,
   size: PropTypes.oneOf(['tiny', 'medium', 'large']),
   styles: PropTypes.object
 }

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -289,12 +289,20 @@ exports[`Field should render examples: Field 2`] = `
 exports[`Field should render examples: Field 3`] = `
 "<div>
   <form>
-    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldError\\" class=\\"styles__c-label___o4ozG\\">I'm an error label</label><input type=\\"text\\" id=\\"idFieldError\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ styles__c-input-text--large___28EaR\\" placeholder=\\"I'm an error input[type=text]\\" value=\\"\\"></div>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I got a name</label><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"\\" name=\\"foo\\" value=\\"\\"></div>
   </form>
 </div>"
 `;
 
 exports[`Field should render examples: Field 4`] = `
+"<div>
+  <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldError\\" class=\\"styles__c-label___o4ozG\\">I'm an error label</label><input type=\\"text\\" id=\\"idFieldError\\" class=\\"styles__c-input-text___3TAv1 styles__is-error___3lsCJ styles__c-input-text--large___28EaR\\" placeholder=\\"I'm an error input[type=text]\\" value=\\"\\"></div>
+  </form>
+</div>"
+`;
+
+exports[`Field should render examples: Field 5`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'am a SelectBox</label>
@@ -339,7 +347,7 @@ exports[`Field should render examples: Field 4`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 5`] = `
+exports[`Field should render examples: Field 6`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldPassword\\" class=\\"styles__c-label___o4ozG\\">I'm a password label</label>
@@ -351,7 +359,7 @@ exports[`Field should render examples: Field 5`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 6`] = `
+exports[`Field should render examples: Field 7`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'm a label</label>
@@ -361,7 +369,7 @@ exports[`Field should render examples: Field 6`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 7`] = `
+exports[`Field should render examples: Field 8`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG\\">I'm a label</label>


### PR DESCRIPTION
Until now, we were not passing `name` prop to `Input`, `TextArea`, and `SelectBox` components.

Having it allows us a better management of inputs from ancestor component, like in Harvest were we need to know which fied has focus.

Inject name prop into Input, Textarea and SelectBox
components.

Related to https://github.com/cozy/cozy-libs/pull/396