### PR TITLE
fix(infos): Better handling text bottom margin

### DIFF
--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -32,7 +32,11 @@ const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
           {title}
         </SubTitle>
       )}
-      <div className="u-flex u-mv-1 u-w-100">
+      <div
+        className={cx('u-flex', 'u-w-100', 'u-mt-1', {
+          'u-mb-1': !!actionButton
+        })}
+      >
         {icon && (
           <Icon
             icon={icon}

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1033,14 +1033,14 @@ exports[`Infos should render examples: Infos 1`] = `
 "<div>
   <div>
     <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-p-1 u-bg-paleGrey u-ta-left\\">
-      <div class=\\"u-flex u-mv-1 u-w-100\\">
+      <div class=\\"u-flex u-w-100 u-mt-1\\">
         <div class=\\"styles__u-text___2UfQa u-ta-left\\">My small persistent information! </div>
       </div>
       <div class=\\"u-flex-shrink-0\\"></div>
     </div>
     <div style=\\"height: 10px;\\"></div>
     <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-p-1 u-bg-paleGrey u-ta-left\\">
-      <div class=\\"u-flex u-mv-1 u-w-100\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+      <div class=\\"u-flex u-w-100 u-mt-1\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#info\\"></use>
         </svg>
         <div class=\\"styles__u-text___2UfQa u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>
@@ -1050,7 +1050,7 @@ exports[`Infos should render examples: Infos 1`] = `
     <div style=\\"height: 10px;\\"></div>
     <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-p-1 u-bg-paleGrey u-ta-left u-bg-chablis\\">
       <div class=\\"styles__u-title-h3___1ZGqN u-pomegranate\\">Infos breaking news</div>
-      <div class=\\"u-flex u-mv-1 u-w-100\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+      <div class=\\"u-flex u-w-100 u-mt-1 u-mb-1\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#warning\\"></use>
         </svg>
         <div class=\\"styles__u-text___2UfQa u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>


### PR DESCRIPTION
If no button, before:
<img width="617" alt="Screenshot 2019-04-30 at 15 48 27" src="https://user-images.githubusercontent.com/10224453/56966903-5e061480-6b60-11e9-80bd-cf717f42a4bc.png">

After
<img width="602" alt="Screenshot 2019-04-30 at 15 51 00" src="https://user-images.githubusercontent.com/10224453/56966911-63635f00-6b60-11e9-8136-4cbb17c14a91.png">

Nothing changes if there is a button
<img width="595" alt="Screenshot 2019-04-30 at 15 55 06" src="https://user-images.githubusercontent.com/10224453/56966922-69594000-6b60-11e9-8e93-e82faa2aca4c.png">
