### PR TITLE
fix(AppLinker): Slug is in props

### DIFF
--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -42,7 +42,7 @@ export class AppLinker extends React.Component {
   }
 
   async checkAppAvailability() {
-    const { slug } = this.props.app
+    const { slug } = this.props
     const appInfo = NATIVE_APP_INFOS[slug]
     if (appInfo) {
       const nativeAppIsAvailable = Boolean(await memoizedCheckApp(appInfo))


### PR DESCRIPTION
I test new cozy-banks on custom mobile and I found this error: `Cannot read property 'slug' of undefined`.