### PR TITLE
Fix fullwidth prop for InputPassword

### DIFF
--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -51,7 +51,11 @@ class InputPassword extends React.Component {
             {visible ? hideLabel : showLabel}
           </div>
         )}
-        <Input {...restProps} type={visible ? 'text' : 'password'} />
+        <Input
+          {...restProps}
+          fullwidth={fullwidth}
+          type={visible ? 'text' : 'password'}
+        />
       </div>
     )
   }


### PR DESCRIPTION
Fullwidth prop has been accidentally removed in 05bce5d31d0530ee845c3beddae3003024db5923

Before this PR

![Capture d’écran 2019-05-02 à 17 25 16](https://user-images.githubusercontent.com/776764/57086891-444f0380-6cff-11e9-82dc-a78e2299644e.png)

After this PR

![Capture d’écran 2019-05-02 à 17 15 13](https://user-images.githubusercontent.com/776764/57086760-0356ef00-6cff-11e9-915f-4dbfa9a7f330.png)
