### PR TITLE
fix: Update valid color to emerald

### DIFF
--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -18,7 +18,7 @@ $error-warning
         vertical-align  text-bottom
 
 $valid
-    color  var(--malachite)
+    color  var(--emerald)
 
 $warn
     color  var(--texasRose)


### PR DESCRIPTION
Change valid color to `emerald`. It was a mistake from a long time ago.

- `emerald` is the base color for valid elements
- `malachite` is the hover color for valid elements (if there's any hover state)