### PR TITLE
fix: Add breakword utility class to Chip component

### DIFF
--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -7,7 +7,12 @@ class Chip extends React.PureComponent {
     const { children, className, ...restProps } = this.props
     return (
       <div
-        className={cx(styles['c-chip'], className, this.constructor.className)}
+        className={cx(
+          styles['c-chip'],
+          'u-breakword',
+          className,
+          this.constructor.className
+        )}
         {...restProps}
       >
         {children}


### PR DESCRIPTION
Chip component will break automatically is its content doesn't contain any space.