### PR TITLE
chore: Add icon sprite on all styleguidist examples

### DIFF
--- a/docs/IconSpriteInjector.jsx
+++ b/docs/IconSpriteInjector.jsx
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+import DefaultSectionsRenderer from 'react-styleguidist/lib/rsg-components/Sections/SectionsRenderer';
+import IconSprite from '../react/Icon/Sprite'
+
+export default class IconSpriteInjector extends Component {
+  render() {
+    return (
+      <>
+        <DefaultSectionsRenderer>
+          {this.props.children}
+        </DefaultSectionsRenderer>
+        <IconSprite />
+      </>
+    )
+  }
+}

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -112,6 +112,9 @@ module.exports = {
       ]
     }
   },
+  styleguideComponents: {
+    SectionsRenderer: path.join(__dirname, 'IconSpriteInjector.jsx')
+  },
   theme: {
     fontFamily: {
       base: 'Lato, sans-serif'


### PR DESCRIPTION
We currently have a small bug in our styleguidist, noticed [here](https://github.com/cozy/cozy-ui/pull/962#issuecomment-490662542), where icons for the example page of an individual component don't show up, for example the [Badge component here](https://docs.cozy.io/cozy-ui/react/#!/Badge).

The icons only show up in the list because the `IconSprite` component is renderer (but not documented). This PR properly adds the `IconSprite` on the page, including standalone examples.