### PR TITLE
fix: Remove margin-top on text when no title

### DIFF
--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -14,7 +14,8 @@ const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
         'u-maw-6',
         'u-mih-2',
         'u-bdrs-4',
-        'u-p-1',
+        'u-ph-1',
+        'u-pt-1',
         'u-bg-paleGrey',
         'u-ta-left',
         {
@@ -25,18 +26,14 @@ const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
     >
       {!!title && (
         <SubTitle
-          className={cx({
+          className={cx('u-mb-1', {
             'u-pomegranate': isImportant
           })}
         >
           {title}
         </SubTitle>
       )}
-      <div
-        className={cx('u-flex', 'u-w-100', 'u-mt-1', {
-          'u-mb-1': !!actionButton
-        })}
-      >
+      <div className={cx('u-flex', 'u-w-100', 'u-mb-1')}>
         {icon && (
           <Icon
             icon={icon}
@@ -56,7 +53,9 @@ const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
           {text}
         </Text>
       </div>
-      <div className="u-flex-shrink-0">{!!actionButton && actionButton}</div>
+      {!!actionButton && (
+        <div className="u-flex-shrink-0 u-mb-1">{actionButton}</div>
+      )}
     </div>
   )
 }

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1048,30 +1048,28 @@ exports[`Icon should render examples: Icon 3`] = `
 exports[`Infos should render examples: Infos 1`] = `
 "<div>
   <div>
-    <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-p-1 u-bg-paleGrey u-ta-left\\">
-      <div class=\\"u-flex u-w-100 u-mt-1\\">
+    <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-ph-1 u-pt-1 u-bg-paleGrey u-ta-left\\">
+      <div class=\\"u-flex u-w-100 u-mb-1\\">
         <div class=\\"styles__u-text___2UfQa u-ta-left\\">My small persistent information! </div>
       </div>
-      <div class=\\"u-flex-shrink-0\\"></div>
     </div>
     <div style=\\"height: 10px;\\"></div>
-    <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-p-1 u-bg-paleGrey u-ta-left\\">
-      <div class=\\"u-flex u-w-100 u-mt-1\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+    <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-ph-1 u-pt-1 u-bg-paleGrey u-ta-left\\">
+      <div class=\\"u-flex u-w-100 u-mb-1\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#info\\"></use>
         </svg>
         <div class=\\"styles__u-text___2UfQa u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>
       </div>
-      <div class=\\"u-flex-shrink-0\\"></div>
     </div>
     <div style=\\"height: 10px;\\"></div>
-    <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-p-1 u-bg-paleGrey u-ta-left u-bg-chablis\\">
-      <div class=\\"styles__u-title-h3___1ZGqN u-pomegranate\\">Infos breaking news</div>
-      <div class=\\"u-flex u-w-100 u-mt-1 u-mb-1\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+    <div class=\\"u-flex u-flex-column u-maw-6 u-mih-2 u-bdrs-4 u-ph-1 u-pt-1 u-bg-paleGrey u-ta-left u-bg-chablis\\">
+      <div class=\\"styles__u-title-h3___1ZGqN u-mb-1 u-pomegranate\\">Infos breaking news</div>
+      <div class=\\"u-flex u-w-100 u-mb-1\\"><svg class=\\"styles__infos--icon___2XWQm u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#warning\\"></use>
         </svg>
         <div class=\\"styles__u-text___2UfQa u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>
       </div>
-      <div class=\\"u-flex-shrink-0\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C\\"><span>A CTA button</span></button></div>
+      <div class=\\"u-flex-shrink-0 u-mb-1\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C\\"><span>A CTA button</span></button></div>
     </div>
   </div>
 </div>"


### PR DESCRIPTION
Before:
<img width="516" alt="Screenshot 2019-05-09 17 17 37" src="https://user-images.githubusercontent.com/1280069/57465722-82a86d80-727f-11e9-8f48-4aae0c7fc3e0.png">

After:
<img width="516" alt="Screenshot 2019-05-09 17 22 13" src="https://user-images.githubusercontent.com/1280069/57465750-8cca6c00-727f-11e9-9780-eaa04a9a25db.png">

Preview: https://gooz.github.io/cozy-ui/react/#infos