### PR TITLE
feat: Use static method for AppLinker

### DIFF
--- a/react/AppLinker/index.spec.jsx
+++ b/react/AppLinker/index.spec.jsx
@@ -64,10 +64,7 @@ describe('app icon', () => {
         throw new Error(message)
       }
     })
-    openNativeFromNativeSpy = jest.spyOn(
-      AppLinker.prototype,
-      'openNativeFromNative'
-    )
+    openNativeFromNativeSpy = jest.spyOn(AppLinker, 'openNativeFromNative')
     isMobileApp.mockReturnValue(false)
     isMobile.mockReturnValue(false)
     isAndroid.mockReturnValue(false)


### PR DESCRIPTION
We need to override the behavior in some context. Having static methods makes it easier