### PR TITLE
fix: AppLinker use full path

### DIFF
--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -10,10 +10,13 @@ import {
   openDeeplinkOrRedirect,
   isAndroid
 } from 'cozy-device-helper'
-import { generateUniversalLink, getUniversalLinkDomain } from './native'
+import {
+  generateUniversalLink,
+  getUniversalLinkDomain
+} from 'cozy-ui/transpiled/react/AppLinker/native'
 
 import { NATIVE_APP_INFOS } from 'cozy-ui/transpiled/react/AppLinker/native.config'
-import expiringMemoize from './expiringMemoize'
+import expiringMemoize from 'cozy-ui/transpiled/react/AppLinker/expiringMemoize'
 
 const expirationDelay = 10 * 1000
 const memoizedCheckApp = expiringMemoize(

--- a/react/AppLinker/index.spec.jsx
+++ b/react/AppLinker/index.spec.jsx
@@ -9,7 +9,7 @@ import {
 } from 'cozy-device-helper'
 
 import AppLinker from './index'
-import { generateUniversalLink } from './native'
+import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker/native'
 jest.useFakeTimers()
 
 const tMock = x => x
@@ -34,8 +34,8 @@ class AppItem extends React.Component {
     )
   }
 }
-jest.mock('./native', () => ({
-  ...require.requireActual('./native'),
+jest.mock('cozy-ui/transpiled/react/AppLinker/native', () => ({
+  ...require.requireActual('cozy-ui/transpiled/react/AppLinker/native'),
   generateUniversalLink: jest.fn()
 }))
 


### PR DESCRIPTION
Since we override this file, we remove relative path 