### PR TITLE
fix: Export the default viewer module

### DIFF
--- a/react/Viewer/ViewerExposer.js
+++ b/react/Viewer/ViewerExposer.js
@@ -1,6 +1,6 @@
 let defaultViewer
 if (process.env.USE_REACT) {
-  defaultViewer = require('./index')
+  defaultViewer = require('./index').default
 } else {
   defaultViewer = ''
 }


### PR DESCRIPTION
The current export exports the whole Viewer module, so we can't do `import { Viewer } from 'cozy-ui/react/transpiled'`.