### PR TITLE
fix: Double-field line button position

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -474,12 +474,15 @@ $double-field--with-button
     position relative
     padding-right 2.5rem
 
+$double-field-line
+    position relative
+
 $double-field-label
     min-height rem(40)
 
 $double-field-button
     position absolute
-    right 0
+    right rem(-40)
     top rem(10)
 
 $double-field-wrapper


### PR DESCRIPTION
I missed something. The delete line button should be placed according to the line it is supposed to delete.
That'll do it.