### PR TITLE
fix: CozyClient is now a peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "commitlint": "7.6.1",
     "commitlint-config-cozy": "0.3.24",
     "copyfiles": "1.2.0",
+    "cozy-client": "6.31.1",
     "cozy-device-helper": "1.7.1",
     "css-loader": "0.28.11",
     "cssnano": "4.1.10",
@@ -113,7 +114,6 @@
     "@babel/runtime": "^7.3.4",
     "body-scroll-lock": "^2.5.8",
     "classnames": "^2.2.5",
-    "cozy-client": "6.26.0",
     "date-fns": "^1.28.5",
     "hammerjs": "^2.0.8",
     "node-polyglot": "^2.2.2",
@@ -125,6 +125,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "3.9.3",
+    "cozy-client": "*",
     "cozy-device-helper": "1.7.1",
     "piwik-react-router": "^0.8.2",
     "preact": "^8.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3887,10 +3887,10 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.1, cosmiconfig@^5.2.0:
     js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
-cozy-client@6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.26.0.tgz#6d8882a190d0dfbed46ed2240bc04f446e408a80"
-  integrity sha512-Zw/bnQ03YxfK9+nHWxGEdPN1gdlmwv1xbLF5DhSOCHDk3oXL5dSnGIqaA+DPIC/vetemIxdm9skMIaOT0k7Q+Q==
+cozy-client@6.31.1:
+  version "6.31.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.31.1.tgz#d6d953e7ca573bfe16456686e483cfebfa290762"
+  integrity sha512-TmvdkJZGVjKvnumOHSj9cp3y0NFzS8ygdFjNuGGI9rZgBjU5DyqdB7hdQXkIn/ImiN9dQhPwj89BR8qH1RnmLg==
   dependencies:
     cozy-device-helper "1.6.3"
     cozy-stack-client "^6.25.0"


### PR DESCRIPTION
This is a way to standardize how our libs consume our other libs.

I've put "*" for cozy-client since we don't have any blocker in terms of API yet (we just use withClient()). 