### PR TITLE
fix: Don't use setState if unmouting

### DIFF
--- a/react/AppIcon/index.jsx
+++ b/react/AppIcon/index.jsx
@@ -22,9 +22,14 @@ export class AppIcon extends Component {
       icon: preloaded,
       status: preloaded ? DONE : FETCHING
     }
+    this.isUnmounting = false
   }
 
+  componentWillUnmount() {
+    this.isUnmounting = true
+  }
   componentDidMount() {
+    this.isUnmounting = false
     this.load()
   }
 
@@ -38,15 +43,15 @@ export class AppIcon extends Component {
     } catch (error) {
       loadError = error
     }
-
-    this.setState({
-      error: loadError,
-      icon: loadedUrl,
-      status: loadError ? ERRORED : DONE
-    })
-
-    if (typeof onReady === 'function') {
-      onReady()
+    if (!this.isUnmounting) {
+      this.setState({
+        error: loadError,
+        icon: loadedUrl,
+        status: loadError ? ERRORED : DONE
+      })
+      if (typeof onReady === 'function') {
+        onReady()
+      }
     }
   }
 


### PR DESCRIPTION
I had a few warnings about : 
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in AppIcon (created by AppLinker)
```

