### PR TITLE
feat: Add Standard breakpoints for utility classes

### DIFF
--- a/stylus/settings/breakpoints.styl
+++ b/stylus/settings/breakpoints.styl
@@ -8,21 +8,18 @@
 // variables
 
 BP-teeny       =  375
-BP-tiny        =  543
+BP-tiny        =  480
 BP-small       =  768
 BP-medium      = 1023
 BP-large       = 1200
 BP-extra-large = 1439
 
-// Breakpoints collection for utilities
+// Standard breakpoints collection for utilities
 breakpoints = {
     'none': '',
-    'teeny': 'tt',
     'tiny': 't',
     'small': 's',
     'medium': 'm',
-    'large': 'l',
-    'extra-large': 'xl'
 }
 
 /*
@@ -32,7 +29,8 @@ breakpoints = {
     the desired a `max-width` media-query. Use the direction argument
     to set it to `min`.
 
-    tiny          -  543px
+    teeny         -  375px
+    tiny          -  480px
     small         -  768px
     medium        -  1023px
     large         -  1200px
@@ -63,8 +61,8 @@ teeny-screen(direction='max')
 /*
     tiny-screen()
 
-    tiny-screen() Refers to (max-width: 543px)
-    tiny-screen('min') Refers to (min-width: 544px)
+    tiny-screen() Refers to (max-width: 480px)
+    tiny-screen('min') Refers to (min-width: 481px)
 
     Weight: -5
 


### PR DESCRIPTION
- [x] Change `tiny` breakpoint from 543px to 480px
- [x] Set the standard breakpoints for utility classes
  - 480px (tiny)
  - 768px (small)
  - 1023px (medium)

There now should be 4 versions of a utility class: `foo`, `foo-t`, `foo-s`, `foo-m` instead of the previous 7.