### PR TITLE
fix: Use flex-start instead of start

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -458,7 +458,7 @@ $field
 
 $field-inline
     display flex
-    align-items start
+    align-items flex-start
     flex-direction row
     margin rem(8 0 8 24)
 


### PR DESCRIPTION
The compiler sends us a warning : 
```
start value has mixed support, consider using flex-start instead
```

