### PR TITLE
fix: Checkbox alignment

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -324,7 +324,7 @@ $checkbox
             content ''
             position absolute
             left 0
-            top rem(3)
+            top 50%
             box-sizing border-box
             width checkbox-size
             height checkbox-size
@@ -334,6 +334,7 @@ $checkbox
             transition box-shadow 350ms cubic-bezier(0, .89, .44, 1)
             background-color white
             box-shadow inset 0 0 0 rem(2) var(--silver)
+            transform translateY(-50%)
 
         &:hover::before
             box-shadow inset 0 0 0 rem(2) var(--dodgerBlue)
@@ -368,11 +369,11 @@ $checkbox
 
             & + span::after
                 opacity 1
-                transform scale(1)
+                transform translateY(-50%) scale(1)
 
         &:not(:checked) + span::after
             opacity 0
-            transform scale(0)
+            transform translateY(-50%) scale(0)
 
     &.is-error span
         color var(--pomegranate)


### PR DESCRIPTION
<img width="174" alt="Screenshot 2019-05-23 14 51 38" src="https://user-images.githubusercontent.com/1280069/58254107-4fc7a480-7d6a-11e9-88f9-f4d78ae932ff.png">

Checkbox and label have now a much better alignment.