### PR TITLE
Add sizes, variants and themes to Chip

### DIFF
--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -75,3 +75,25 @@ const ContactChip = ({ contact }) => (
   <Chip variant="dashed">This is a dashed Chip</Chip>
 </div>
 ```
+
+### Themes
+
+```
+<div>
+  <div>
+    <Chip theme="normal">This is a normal Chip (default)</Chip>
+    <Chip theme="primary">This is a primary Chip</Chip>
+    <Chip theme="error">This is an error Chip</Chip>
+  </div>
+  <div>
+    <Chip theme="normal" variant="outlined">This is a normal Chip (default)</Chip>
+    <Chip theme="primary" variant="outlined">This is a primary Chip</Chip>
+    <Chip theme="error" variant="outlined">This is an error Chip</Chip>
+  </div>
+  <div>
+    <Chip theme="normal" variant="dashed">This is a normal Chip (default)</Chip>
+    <Chip theme="primary" variant="dashed">This is a primary Chip</Chip>
+    <Chip theme="error" variant="dashed">This is an error Chip</Chip>
+  </div>
+</div>
+```

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -51,7 +51,8 @@ const ContactChip = ({ contact }) => (
 
 ```
 <div>
-  <Chip component="button">This is a button</Chip>
+  <Chip component="button" onClick={() => alert('You clicked')}>This is a button</Chip>
+  <Chip component="button" disabled>This is a disabled button</Chip>
   <Chip component="span">This is a span</Chip>
 </div>
 ```

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -56,3 +56,12 @@ const ContactChip = ({ contact }) => (
   <Chip component="span">This is a span</Chip>
 </div>
 ```
+
+### Sizes
+
+```
+<div>
+  <Chip size="small">This is a small Chip</Chip>
+  <Chip size="normal">This is a normal Chip (default)</Chip>
+</div>
+```

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -46,3 +46,12 @@ const ContactChip = ({ contact }) => (
   <Chip.Button disabled><Icon icon='back' /></Chip.Button>
 </div>
 ```
+
+### Specify underlying tag/component
+
+```
+<div>
+  <Chip component="button">This is a button</Chip>
+  <Chip component="span">This is a span</Chip>
+</div>
+```

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -97,3 +97,25 @@ const ContactChip = ({ contact }) => (
   </div>
 </div>
 ```
+
+### Mix sizes, variants and themes
+
+```
+<div>
+  <div>
+    <Chip theme="normal" size="small">This is a normal Chip</Chip>
+    <Chip theme="primary" size="small">This is a primary Chip</Chip>
+    <Chip theme="error" size="small">This is an error Chip</Chip>
+  </div>
+  <div>
+    <Chip theme="normal" variant="outlined" size="small">This is a normal Chip</Chip>
+    <Chip theme="primary" variant="outlined" size="small">This is a primary Chip</Chip>
+    <Chip theme="error" variant="outlined" size="small">This is an error Chip</Chip>
+  </div>
+  <div>
+    <Chip theme="normal" variant="dashed" size="small">This is a normal Chip</Chip>
+    <Chip theme="primary" variant="dashed" size="small">This is a primary Chip</Chip>
+    <Chip theme="error" variant="dashed" size="small">This is an error Chip</Chip>
+  </div>
+</div>
+```

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -65,3 +65,13 @@ const ContactChip = ({ contact }) => (
   <Chip size="normal">This is a normal Chip (default)</Chip>
 </div>
 ```
+
+### Variants
+
+```
+<div>
+  <Chip variant="normal">This is a normal Chip (default)</Chip>
+  <Chip variant="outlined">This is an outlined Chip</Chip>
+  <Chip variant="dashed">This is a dashed Chip</Chip>
+</div>
+```

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -4,14 +4,16 @@ import styles from './styles.styl'
 
 class Chip extends React.PureComponent {
   render() {
-    const { children, className, ...restProps } = this.props
+    const { children, className, rounded, ...restProps } = this.props
     return (
       <div
         className={cx(
           styles['c-chip'],
           'u-breakword',
-          className,
-          this.constructor.className
+          {
+            [styles['c-chip--round']]: rounded
+          },
+          className
         )}
         {...restProps}
       >
@@ -21,11 +23,9 @@ class Chip extends React.PureComponent {
   }
 }
 
-export class RoundChip extends Chip {
-  static className = styles['c-chip--round']
-}
-
 export default Chip
+
+export const RoundChip = props => <Chip {...props} rounded />
 
 const disabledChipButtonStyle = styles['c-chip-button--disabled']
 export class ChipButton extends React.PureComponent {

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -28,8 +28,8 @@ class Chip extends React.PureComponent {
       <Component
         className={cx(
           styles['c-chip'],
-          styles[`c-chip--${size}`],
-          styles[`c-chip--${variant}`],
+          styles[`c-chip--${size}Size`],
+          styles[`c-chip--${variant}Variant`],
           styles[`c-chip--${theme}Theme`],
           'u-breakword',
           {

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -34,7 +34,7 @@ class Chip extends React.PureComponent {
           'u-breakword',
           {
             [styles['c-chip--round']]: rounded,
-            'u-c-pointer': onClick && !disabled,
+            [styles['c-chip--clickable']]: onClick && !disabled,
             [styles['c-chip-button--disabled']]: onClick && disabled
           },
           className

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -4,7 +4,8 @@ import styles from './styles.styl'
 
 class Chip extends React.PureComponent {
   static defaultProps = {
-    component: 'div'
+    component: 'div',
+    size: 'normal'
   }
 
   render() {
@@ -15,6 +16,7 @@ class Chip extends React.PureComponent {
       component: Component,
       onClick,
       disabled,
+      size,
       ...restProps
     } = this.props
 
@@ -22,6 +24,7 @@ class Chip extends React.PureComponent {
       <Component
         className={cx(
           styles['c-chip'],
+          styles[`c-chip--${size}`],
           'u-breakword',
           {
             [styles['c-chip--round']]: rounded,

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -5,7 +5,8 @@ import styles from './styles.styl'
 class Chip extends React.PureComponent {
   static defaultProps = {
     component: 'div',
-    size: 'normal'
+    size: 'normal',
+    variant: 'normal'
   }
 
   render() {
@@ -17,6 +18,7 @@ class Chip extends React.PureComponent {
       onClick,
       disabled,
       size,
+      variant,
       ...restProps
     } = this.props
 
@@ -25,6 +27,7 @@ class Chip extends React.PureComponent {
         className={cx(
           styles['c-chip'],
           styles[`c-chip--${size}`],
+          styles[`c-chip--${variant}`],
           'u-breakword',
           {
             [styles['c-chip--round']]: rounded,

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -6,7 +6,8 @@ class Chip extends React.PureComponent {
   static defaultProps = {
     component: 'div',
     size: 'normal',
-    variant: 'normal'
+    variant: 'normal',
+    theme: 'normal'
   }
 
   render() {
@@ -19,6 +20,7 @@ class Chip extends React.PureComponent {
       disabled,
       size,
       variant,
+      theme,
       ...restProps
     } = this.props
 
@@ -28,6 +30,7 @@ class Chip extends React.PureComponent {
           styles['c-chip'],
           styles[`c-chip--${size}`],
           styles[`c-chip--${variant}`],
+          styles[`c-chip--${theme}Theme`],
           'u-breakword',
           {
             [styles['c-chip--round']]: rounded,

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -13,18 +13,25 @@ class Chip extends React.PureComponent {
       className,
       rounded,
       component: Component,
+      onClick,
+      disabled,
       ...restProps
     } = this.props
+
     return (
       <Component
         className={cx(
           styles['c-chip'],
           'u-breakword',
           {
-            [styles['c-chip--round']]: rounded
+            [styles['c-chip--round']]: rounded,
+            'u-c-pointer': onClick && !disabled,
+            [styles['c-chip-button--disabled']]: onClick && disabled
           },
           className
         )}
+        onClick={onClick}
+        disabled={disabled}
         {...restProps}
       >
         {children}

--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -3,10 +3,20 @@ import React from 'react'
 import styles from './styles.styl'
 
 class Chip extends React.PureComponent {
+  static defaultProps = {
+    component: 'div'
+  }
+
   render() {
-    const { children, className, rounded, ...restProps } = this.props
+    const {
+      children,
+      className,
+      rounded,
+      component: Component,
+      ...restProps
+    } = this.props
     return (
-      <div
+      <Component
         className={cx(
           styles['c-chip'],
           'u-breakword',
@@ -18,7 +28,7 @@ class Chip extends React.PureComponent {
         {...restProps}
       >
         {children}
-      </div>
+      </Component>
     )
   }
 }

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -12,6 +12,12 @@
 .c-chip--normal
     @extend $normal-chip
 
+.c-chip--outlined
+    @extend $outlined-chip
+
+.c-chip--dashed
+    @extend $dashed-chip
+
 .c-chip-separator
     @extend $chip-separator
 

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -18,6 +18,15 @@
 .c-chip--dashed
     @extend $dashed-chip
 
+.c-chip--normalTheme
+    @extend $normal-theme-chip
+
+.c-chip--primaryTheme
+    @extend $primary-theme-chip
+
+.c-chip--errorTheme
+    @extend $error-theme-chip
+
 .c-chip-separator
     @extend $chip-separator
 

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -31,6 +31,9 @@
     border-color var(--silver)
     color var(--charcoalGrey)
 
+.c-chip--clickable
+    @extend $chip--clickable
+
 .c-chip-separator
     @extend $chip-separator
 

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -6,17 +6,17 @@
 .c-chip--round
     @extend $round-chip
 
-.c-chip--small
-    @extend $small-chip
+.c-chip--smallSize
+    @extend $small-size-chip
 
-.c-chip--normal
-    @extend $normal-chip
+.c-chip--normalSize
+    @extend $normal-size-chip
 
-.c-chip--outlined
-    @extend $outlined-chip
+.c-chip--outlinedVariant
+    @extend $outlined-variant-chip
 
-.c-chip--dashed
-    @extend $dashed-chip
+.c-chip--dashedVariant
+    @extend $dashed-variant-chip
 
 .c-chip--normalTheme
     @extend $normal-theme-chip

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -27,6 +27,10 @@
 .c-chip--errorTheme
     @extend $error-theme-chip
 
+.c-chip--outlinedVariant.c-chip--normalTheme
+    border-color var(--silver)
+    color var(--charcoalGrey)
+
 .c-chip-separator
     @extend $chip-separator
 

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -6,6 +6,12 @@
 .c-chip--round
     @extend $round-chip
 
+.c-chip--small
+    @extend $small-chip
+
+.c-chip--normal
+    @extend $normal-chip
+
 .c-chip-separator
     @extend $chip-separator
 

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -21,21 +21,22 @@ $round-chip
     text-align center
     justify-content center
 
-$small-chip
+$small-size-chip
     height $chip-height-small
     padding (($chip-height-small - $chip-font-size-small) / 2)
     border-radius ($chip-height-small / 2)
+    font-size $chip-font-size-small
 
-$normal-chip
+$normal-size-chip
     height $chip-height-normal
     padding (($chip-height-normal - $chip-font-size-normal) / 2)
     border-radius ($chip-height-normal / 2)
 
-$outlined-chip
+$outlined-variant-chip
     border 1px solid
     background-color transparent !important
 
-$dashed-chip
+$dashed-variant-chip
     border 1px dashed
 
 $normal-theme-chip

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -33,6 +33,14 @@ $normal-chip
     padding (($chip-height-normal - $chip-font-size-normal) / 2)
     border-radius ($chip-height-normal / 2)
 
+$outlined-chip
+    border 1px solid var(--silver)
+    background-color var(--white)
+    color var(--coolGrey)
+
+$dashed-chip
+    border 1px dashed var(--coolGrey)
+
 $chip-separator
     width rem(1)
     border-left rem(1) solid var(--silver)

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -15,6 +15,8 @@ $chip
     align-items center
     margin-right rem(4)
     margin-bottom rem(4)
+    border-width 0
+    color inherit
 
 $round-chip
     width $chip-height

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -14,7 +14,7 @@ $chip
     align-items center
     margin-right rem(4)
     margin-bottom rem(4)
-    border-width 0
+    border 0
 
 $round-chip
     width $chip-height-normal

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -8,7 +8,6 @@ $chip-height-normal = rem(40)
 $chip-font-size-normal = rem(16)
 
 $chip
-    background var(--paleGrey)
     box-sizing border-box
     line-height 1
     display inline-flex
@@ -16,7 +15,6 @@ $chip
     margin-right rem(4)
     margin-bottom rem(4)
     border-width 0
-    color inherit
 
 $round-chip
     width $chip-height-normal
@@ -34,12 +32,23 @@ $normal-chip
     border-radius ($chip-height-normal / 2)
 
 $outlined-chip
-    border 1px solid var(--silver)
-    background-color var(--white)
-    color var(--coolGrey)
+    border 1px solid
+    background-color transparent !important
 
 $dashed-chip
-    border 1px dashed var(--coolGrey)
+    border 1px dashed
+
+$normal-theme-chip
+    background var(--paleGrey)
+    color inherit
+
+$primary-theme-chip
+    background-color var(--zircon)
+    color var(--dodgerBlue)
+
+$error-theme-chip
+    background-color var(--chablis)
+    color var(--pomegranate)
 
 $chip-separator
     width rem(1)

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -42,7 +42,7 @@ $dashed-variant-chip
     border 1px dashed
 
 $normal-theme-chip
-    background var(--paleGrey)
+    background-color var(--paleGrey)
     color inherit
 
 $primary-theme-chip

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -53,6 +53,9 @@ $error-theme-chip
     background-color var(--chablis)
     color var(--pomegranate)
 
+$chip--clickable
+    cursor pointer
+
 $chip-separator
     width rem(1)
     border-left rem(1) solid var(--silver)

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -1,14 +1,14 @@
 @require 'settings/palette'
 @require 'tools/mixins'
 
-$chip-height = rem(40)
-$chip-font-size = rem(16)
+$chip-height-small = rem(32)
+$chip-font-size-small = rem(14)
+
+$chip-height-normal = rem(40)
+$chip-font-size-normal = rem(16)
 
 $chip
-    border-radius ($chip-height / 2)
-    height $chip-height
     background var(--paleGrey)
-    padding (($chip-height - $chip-font-size) / 2)
     box-sizing border-box
     line-height 1
     display inline-flex
@@ -19,9 +19,19 @@ $chip
     color inherit
 
 $round-chip
-    width $chip-height
+    width $chip-height-normal
     text-align center
     justify-content center
+
+$small-chip
+    height $chip-height-small
+    padding (($chip-height-small - $chip-font-size-small) / 2)
+    border-radius ($chip-height-small / 2)
+
+$normal-chip
+    height $chip-height-normal
+    padding (($chip-height-normal - $chip-font-size-normal) / 2)
+    border-radius ($chip-height-normal / 2)
 
 $chip-separator
     width rem(1)

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -34,7 +34,9 @@ $normal-size-chip
 
 $outlined-variant-chip
     border 1px solid
-    background-color transparent !important
+    // important is here because this variant needs to have a transparent
+    // background, no matter with which theme it is used
+    background-color transparent !important // @stylint ignore
 
 $dashed-variant-chip
     border 1px dashed


### PR DESCRIPTION
This PR introduces 3 new props for the `Chip` component:

* `size`: add the `small` size. Existing size is `normal`
* `variant`: add `outlined` and `dashed` variants. Existing styles are `normal` variant
* `theme`: add `primary` and `error` variant. Existing colors are `normal` variant

You can see all this on https://drazik.github.io/cozy-ui/react/#chip