### PR TITLE
feat(Sections): Add initial search prop

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -20,12 +20,13 @@ module.exports = {
   ],
   env: {
     transpilation: {
-      plugins: plugins
+      plugins: plugins,
+      ignore: ['**/*.spec.jsx', '**/*.spec.js']
     },
     test: {
       presets: [['cozy-app', { transformRuntime: { helpers: true } }]],
       plugins: plugins
     }
   },
-  ignore: ['examples/**/*', '**/*.spec.jsx', '**/*.spec.js']
+  ignore: ['examples/**/*']
 }

--- a/react/AppSections/Sections.jsx
+++ b/react/AppSections/Sections.jsx
@@ -51,7 +51,7 @@ export class Sections extends Component {
   constructor(props, context) {
     super(props, context)
     this.state = {
-      search: {}
+      search: props.initialSearch || {}
     }
     this.handleCategoryChange = this.handleCategoryChange.bind(this)
   }
@@ -167,10 +167,18 @@ export class Sections extends Component {
 
 Sections.propTypes = {
   t: PropTypes.func.isRequired,
+
+  /** List of apps that will be displayed into categories */
   apps: PropTypes.array.isRequired,
   error: PropTypes.object,
+
   onAppClick: PropTypes.func.isRequired,
-  hasNav: PropTypes.bool
+
+  /** Whether to display the category selector */
+  hasNav: PropTypes.bool,
+
+  /** An initial search object. Changing it after mounting will do nothing. */
+  initialSearch: PropTypes.object
 }
 
 Sections.defaultProps = {


### PR DESCRIPTION
It is convenient to be able to give Sections an initialSearch and then let it
manage it internally. This way we have a middle ground before controlled and
uncontrolled.