### PR TITLE
Add object-fit contain on app icons

### DIFF
--- a/react/AppIcon/styles.styl
+++ b/react/AppIcon/styles.styl
@@ -29,6 +29,7 @@
     // Prevent flex-grow and flex-shrink
     flex-grow 0
     flex-shrink 0
+    object-fit contain
 }
 
 .c-app-icon-default {


### PR DESCRIPTION
Before:
<img width="607" alt="Screenshot 2019-05-29 at 11 47 42" src="https://user-images.githubusercontent.com/10224453/58547422-9b190180-8207-11e9-8e2a-2bc366d311ee.png">
After:
<img width="609" alt="Screenshot 2019-05-29 at 11 47 49" src="https://user-images.githubusercontent.com/10224453/58547431-9f451f00-8207-11e9-82b1-69ba61be1bf7.png">
