### PR TITLE
feat(Chip): Update outlined themes

### DIFF
--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -33,6 +33,10 @@ class Chip extends React.PureComponent {
           styles[`c-chip--${theme}Theme`],
           'u-breakword',
           {
+            [styles['c-chip--outlinedNormalTheme']]:
+              variant === 'outlined' && theme === 'normal',
+            [styles['c-chip--outlinedErrorTheme']]:
+              variant === 'outlined' && theme === 'error',
             [styles['c-chip--round']]: rounded,
             [styles['c-chip--clickable']]: onClick && !disabled,
             [styles['c-chip-button--disabled']]: onClick && disabled

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -18,6 +18,12 @@
 .c-chip--dashedVariant
     @extend $dashed-variant-chip
 
+.c-chip--outlinedNormalTheme
+    @extend $chip--outlinedNormalTheme
+
+.c-chip--outlinedErrorTheme
+    @extend $chip--outlinedErrorTheme
+
 .c-chip--normalTheme
     @extend $normal-theme-chip
 
@@ -26,10 +32,6 @@
 
 .c-chip--errorTheme
     @extend $error-theme-chip
-
-.c-chip--outlinedVariant.c-chip--normalTheme
-    border-color var(--silver)
-    color var(--charcoalGrey)
 
 .c-chip--clickable
     @extend $chip--clickable

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -53,6 +53,13 @@ $error-theme-chip
     background-color var(--chablis)
     color var(--pomegranate)
 
+$chip--outlinedNormalTheme
+    border-color var(--silver)
+    color var(--charcoalGrey)
+
+$chip--outlinedErrorTheme
+    border-color var(--yourPink)
+
 $chip--clickable
     cursor pointer
 


### PR DESCRIPTION
Some updates to normal and error themes for outlined variant on the Chip component. We want special colors for these cases, so I added specific classes for them.

See https://drazik.github.io/cozy-ui/react