### PR TITLE
feat: Ability to use a function for withLocales arg

### DIFF
--- a/react/I18n/withLocales.jsx
+++ b/react/I18n/withLocales.jsx
@@ -2,16 +2,27 @@ import React from 'react'
 import { I18n, translate } from './'
 import omit from 'lodash/omit'
 
-const withLocales = locales => Component => {
+/**
+ *
+ * @param  {Function|Object} localesOrRequire - Either a function returning the locale for a lang,
+ *                                              or an object containing all the locales
+ * @return {Component}
+ */
+const withLocales = localesOrRequire => Component => {
   // The inner components needs to receive t
   const Translated = translate()(Component)
+
+  const requireLocale =
+    typeof localesOrRequire === 'function'
+      ? localesOrRequire
+      : localeCode => localesOrRequire[localeCode]
 
   class Wrapped extends React.Component {
     render() {
       // Do not pass t downwards
       const { lang, ...rest } = omit(this.props, 't')
       return (
-        <I18n dictRequire={localeCode => locales[localeCode]} lang={lang}>
+        <I18n dictRequire={requireLocale} lang={lang}>
           <Translated {...rest} />
         </I18n>
       )

--- a/react/I18n/withLocales.spec.jsx
+++ b/react/I18n/withLocales.spec.jsx
@@ -26,21 +26,32 @@ class Component extends React.Component {
     return <div>{t('hello-world')}</div>
   }
 }
-const TComponent = withLocales(componentLocales)(Component)
 
 describe('with locales', () => {
   let root
-  const setup = ({ lang }) => {
+  const setup = ({ lang, Component }) => {
     root = mount(
       <I18n lang={lang} dictRequire={localeCode => globalLocales[localeCode]}>
-        <TComponent />
+        <Component />
       </I18n>
     )
   }
-  it('should provide t with correct locale strings', () => {
-    setup({ lang: 'en' })
-    expect(root.text()).toBe('Hello local world !')
-    setup({ lang: 'fr' })
-    expect(root.text()).toBe('Bonjour le monde local !')
-  })
+
+  const testComponent = (Component, description) => {
+    describe(description, () => {
+      it('should provide t with correct locale strings', () => {
+        setup({ lang: 'en', Component })
+        expect(root.text()).toBe('Hello local world !')
+        setup({ lang: 'fr', Component })
+        expect(root.text()).toBe('Bonjour le monde local !')
+      })
+    })
+  }
+
+  const TComponentObj = withLocales(componentLocales)(Component)
+  const requireLang = lang => componentLocales[lang]
+  const TComponentFunc = withLocales(requireLang)(Component)
+
+  testComponent(TComponentObj, 'locales from object')
+  testComponent(TComponentFunc, 'locales from require function')
 })


### PR DESCRIPTION
It is useful to be able to pass a function that requires the locale so
that require contexts in webpack and "normal" dynamic require from node
can be used instead of listing all locales that have to be required.

Now withLocales can be used with an object or a function.

```jsx
// static require, need to list manually all langs
const locales = { en: require('en.json') }
withLocales(locales)

// dynamic require (automatic webpack context or via node)
withLocales(lang => require(lang + '.json'))
```