### PR TITLE
feat(Chip): Add hover and focus states

### DIFF
--- a/react/Chip/index.jsx
+++ b/react/Chip/index.jsx
@@ -35,8 +35,12 @@ class Chip extends React.PureComponent {
           {
             [styles['c-chip--outlinedNormalTheme']]:
               variant === 'outlined' && theme === 'normal',
-            [styles['c-chip--outlinedErrorTheme']]:
-              variant === 'outlined' && theme === 'error',
+            [styles['c-chip--hoverableNormalTheme']]:
+              variant !== 'normal' && theme === 'normal',
+            [styles['c-chip--hoverablePrimaryTheme']]:
+              variant !== 'normal' && theme === 'primary',
+            [styles['c-chip--hoverableErrorTheme']]:
+              variant !== 'normal' && theme === 'error',
             [styles['c-chip--round']]: rounded,
             [styles['c-chip--clickable']]: onClick && !disabled,
             [styles['c-chip-button--disabled']]: onClick && disabled

--- a/react/Chip/styles.styl
+++ b/react/Chip/styles.styl
@@ -18,12 +18,6 @@
 .c-chip--dashedVariant
     @extend $dashed-variant-chip
 
-.c-chip--outlinedNormalTheme
-    @extend $chip--outlinedNormalTheme
-
-.c-chip--outlinedErrorTheme
-    @extend $chip--outlinedErrorTheme
-
 .c-chip--normalTheme
     @extend $normal-theme-chip
 
@@ -32,6 +26,18 @@
 
 .c-chip--errorTheme
     @extend $error-theme-chip
+
+.c-chip--outlinedNormalTheme
+    @extend $chip--outlinedNormalTheme
+
+.c-chip--hoverableNormalTheme
+    @extend $chip--hoverableNormalTheme
+
+.c-chip--hoverablePrimaryTheme
+    @extend $chip--hoverablePrimaryTheme
+
+.c-chip--hoverableErrorTheme
+    @extend $chip--hoverableErrorTheme
 
 .c-chip--clickable
     @extend $chip--clickable

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -34,31 +34,44 @@ $normal-size-chip
 
 $outlined-variant-chip
     border 1px solid
-    // important is here because this variant needs to have a transparent
-    // background, no matter with which theme it is used
-    background-color transparent !important // @stylint ignore
 
 $dashed-variant-chip
     border 1px dashed
 
 $normal-theme-chip
+    border-color var(--silver)
     background-color var(--paleGrey)
     color inherit
 
 $primary-theme-chip
+    border-color var(--frenchPass)
     background-color var(--zircon)
     color var(--dodgerBlue)
 
 $error-theme-chip
+    border-color var(--yourPink)
     background-color var(--chablis)
     color var(--pomegranate)
 
-$chip--outlinedNormalTheme
-    border-color var(--silver)
+$chip--hoverableNormalTheme
     color var(--charcoalGrey)
 
-$chip--outlinedErrorTheme
-    border-color var(--yourPink)
+    &:hover,
+    &:focus
+        background-color var(--silver)
+
+$chip--hoverablePrimaryTheme
+    &:hover,
+    &:focus
+        background-color var(--frenchPass)
+
+$chip--hoverableErrorTheme
+    &:hover,
+    &:focus
+        background-color var(--yourPink)
+
+$chip--outlinedNormalTheme
+    background-color transparent
 
 $chip--clickable
     cursor pointer


### PR DESCRIPTION
Add hover and focus states for Chips. Only outlined and dashed variant have these states.

See https://drazik.github.io/cozy-ui/react