### PR TITLE
feat: Fallback URL is generated automatically

### DIFF
--- a/react/AppLinker/native.js
+++ b/react/AppLinker/native.js
@@ -2,12 +2,31 @@ import { UNIVERSAL_LINK_URL } from 'cozy-ui/transpiled/react/AppLinker/native.co
 export const getUniversalLinkDomain = () => {
   return UNIVERSAL_LINK_URL
 }
-/*
-  slug string drive 
-  path : /path/to/view
-  fallbackUrl: string : https://...mycozy.cloud
-*/
-export const generateUniversalLink = ({ slug, nativePath, fallbackUrl }) => {
+
+/**
+ * Returns a universal link for an app + native path
+ *
+ * @param  {string} options.slug        - eg: drive
+ * @param  {string} options.nativePath  - /path/to/view
+ * @param  {string} options.fallbackUrl - https://...mycozy.cloud, optional if cozyUrl is passed
+ * @param  {string} options.cozyUrl     - https://name.mycozy.cloud, optional if fallbackUrl is passed
+ * @return {string}                     - https://links.cozy.cloud/drive/?fallback...
+ */
+export const generateUniversalLink = ({
+  slug,
+  nativePath,
+  fallbackUrl,
+  cozyUrl
+}) => {
+  if (cozyUrl && !fallbackUrl) {
+    fallbackUrl = new URL(cozyUrl)
+    fallbackUrl.host = fallbackUrl.host
+      .split('.')
+      .map((x, i) => (i === 0 ? x + '-' + slug : x))
+      .join('.')
+    fallbackUrl.hash = nativePath
+    fallbackUrl = fallbackUrl.toString()
+  }
   if (!nativePath.startsWith('/')) nativePath = '/' + nativePath
   let url = getUniversalLinkDomain() + '/' + slug + nativePath
   const urlObj = new URL(url)

--- a/react/AppLinker/native.spec.js
+++ b/react/AppLinker/native.spec.js
@@ -46,4 +46,15 @@ describe('native functions', () => {
 
     expect(universalLink).toEqual(endLink)
   })
+
+  it('should automatically generate fallbackUrl if provided with cozyUrl', () => {
+    const universalLink = generateUniversalLink({
+      slug: 'drive',
+      nativePath: '/files',
+      cozyUrl: 'https://name.cozy.tools/'
+    })
+    const endLink =
+      'https://links.mycozy.cloud/drive/files?fallback=https%3A%2F%2Fname-drive.cozy.tools%2F%23%2Ffiles'
+    expect(universalLink).toEqual(endLink)
+  })
 })


### PR DESCRIPTION
It is easier for apps to provide only the cozyURL and not the fallback URL.

Now the fallback URL is generated automatically if `options.cozyUrl` is passed.