### PR TITLE
fix(Chip): Better alignment

### DIFF
--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -119,3 +119,19 @@ const ContactChip = ({ contact }) => (
   </div>
 </div>
 ```
+
+### Complete example
+
+```
+<Chip
+  size="small"
+  variant="outlined"
+  theme="primary"
+  onClick={() => alert('you clicked')}
+>
+  <Icon icon="file" size={16} style={{ marginRight: '0.5rem' }} />
+  1 invoice
+  <Chip.Separator />
+  <Icon icon="openwith" size={16} />
+</Chip>
+```

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -23,13 +23,13 @@ $round-chip
 
 $small-size-chip
     height $chip-height-small
-    padding (($chip-height-small - $chip-font-size-small) / 2)
+    padding 0 (($chip-height-small - $chip-font-size-small) / 2)
     border-radius ($chip-height-small / 2)
     font-size $chip-font-size-small
 
 $normal-size-chip
     height $chip-height-normal
-    padding (($chip-height-normal - $chip-font-size-normal) / 2)
+    padding 0 (($chip-height-normal - $chip-font-size-normal) / 2)
     border-radius ($chip-height-normal / 2)
 
 $outlined-variant-chip
@@ -80,7 +80,7 @@ $chip-separator
     width rem(1)
     border-left rem(1) solid var(--silver)
     display inline-block
-    height 100%
+    height 40%
     margin-left rem(8)
     margin-right rem(8)
 


### PR DESCRIPTION
We had an alignment issue on the `Chip` component when the content of the Chip was taller than the real content area:

![chip01](https://user-images.githubusercontent.com/1606068/58867993-b8dcdf80-86bb-11e9-9135-848557b89171.png)
![image](https://user-images.githubusercontent.com/1606068/58868009-c1351a80-86bb-11e9-8df2-2012bce987fe.png)



The solution I used here is to remove the vertical paddings. Since we already have a fixed `height` and use `display: flex` and `align-items: center` to vertically center the content, this padding was not really useful.

You can see it on https://drazik.github.io/cozy-ui/react/#chip. I added an example using 2 `Icon`s and a `Chip.Separator` so we can easily test alignment. I tested it on a lot of configurations in Browserstack and didn't see any issue.