### PR TITLE
feat: Keep radio elements centered

### DIFF
--- a/react/Radio/Readme.md
+++ b/react/Radio/Readme.md
@@ -5,6 +5,7 @@
   <div>
     <Radio name="radioForm" value="radioValue1" label="This is a radio button" />
     <Radio name="radioForm" value="radioValue2" label="This is also a radio button" />
+    <Radio style={{ background: 'cadetblue',  padding: '0.5rem', height: '3rem' }} name="radioForm" value="radioValue2" label="This is a radio button with a custom style" />
   </div>
 </form>
 ```

--- a/react/Radio/index.jsx
+++ b/react/Radio/index.jsx
@@ -4,7 +4,16 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
 const Radio = props => {
-  const { className, value, name, label, error, disabled, ...restProps } = props
+  const {
+    className,
+    value,
+    name,
+    label,
+    error,
+    disabled,
+    style,
+    ...restProps
+  } = props
   return (
     <label
       className={cx(
@@ -15,6 +24,7 @@ const Radio = props => {
         className
       )}
       aria-disabled={disabled}
+      style={style}
     >
       <input
         type="radio"

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1312,7 +1312,7 @@ exports[`MuiCozyTheme/Menus should render examples: MuiCozyTheme/Menus 1`] = `"<
 exports[`Radio should render examples: Radio 1`] = `
 "<div>
   <form>
-    <div><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue1\\"><span>This is a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is also a radio button</span></label></div>
+    <div><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue1\\"><span>This is a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is also a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\" style=\\"background: cadetblue; padding: 0.5rem; height: 3rem;\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is a radio button with a custom style</span></label></div>
   </form>
 </div>"
 `;

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -311,6 +311,7 @@ $checkbox
     // To make sure that checkbox's wrapper have the height of the checkbox
     display flex
     margin-bottom rem(8)
+    align-items center
 
     span
         position relative


### PR DESCRIPTION
If the height of the label is customised, for example to have a larger
clic area, the text was not aligned with the checkbox circle.

View it on http://ptbrowne.github.io/cozy-ui/react/#!/Radio