### PR TITLE
fix: Use style to assign bg color to select box

### DIFF
--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -19,7 +19,9 @@ const heights = {
 const customStyles = props => ({
   control: (base, state) => ({
     ...base,
-    backgroundColor: 'transparent',
+    // The gray background color is managed via the select--disabled
+    // class applied below
+    backgroundColor: props.disabled ? 'transparent' : 'white',
     border: state.isFocused
       ? `.0625rem solid ${dodgerBlue}`
       : `.0625rem solid ${silver}`,
@@ -302,8 +304,6 @@ class SelectBox extends Component {
         {...props}
         isDisabled={disabled}
         className={classNames(
-          // Ensure the selectbox has white background
-          'u-bg-white',
           {
             [styles['select__overlay']]: showOverlay,
             [styles['select--autowidth']]: !fullwidth,

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -368,8 +368,8 @@ exports[`Field should render examples: Field 5`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'am a SelectBox</label>
-      <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-19fknmj\\">
+      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
+        <div class=\\"css-2zgoaw\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-1492t68\\">Select ...</div>
             <div class=\\"css-1g6gooi\\">
@@ -387,8 +387,8 @@ exports[`Field should render examples: Field 5`] = `
       </div>
     </div>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'am a SelectBox with a value</label>
-      <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-19fknmj\\">
+      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\" id=\\"\\">
+        <div class=\\"css-2zgoaw\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">Choice 2</div>
             <div class=\\"css-1g6gooi\\">
@@ -1332,8 +1332,8 @@ exports[`Radio should render examples: Radio 3`] = `
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div style=\\"background: whitesmoke; padding: .5em;\\">
-    <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-      <div class=\\"css-19fknmj\\">
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
@@ -1355,8 +1355,8 @@ exports[`SelectBox should render examples: SelectBox 1`] = `
 
 exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-2zgoaw\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1383,8 +1383,8 @@ exports[`SelectBox should render examples: SelectBox 2`] = `
 exports[`SelectBox should render examples: SelectBox 3`] = `
 "<div>
   <div style=\\"height: 12rem; padding: .5rem; overflow: auto;\\">Container height: 12rem. <button>Change container height</button>
-    <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-      <div class=\\"css-19fknmj\\">
+    <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+      <div class=\\"css-2zgoaw\\">
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
           <div class=\\"css-1g6gooi\\">
@@ -1406,7 +1406,7 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 
 exports[`SelectBox should render examples: SelectBox 4`] = `
 "<div>
-  <div class=\\"css-1sontr1 u-bg-white styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
+  <div class=\\"css-1sontr1 styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
     <div class=\\"css-adwy96\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
@@ -1428,8 +1428,8 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
 
 exports[`SelectBox should render examples: SelectBox 5`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--fullwidth___2l_xM\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-10nd86i styles__select--fullwidth___2l_xM\\">
+    <div class=\\"css-2zgoaw\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1451,7 +1451,7 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
 exports[`SelectBox should render examples: SelectBox 6`] = `
 "<div>
   <div>
-    <div class=\\"css-1sontr1 u-bg-white styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
+    <div class=\\"css-1sontr1 styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
       <div class=\\"css-adwy96\\">
         <div class=\\"css-1phseng\\">
           <div class=\\"css-1492t68\\">Select...</div>
@@ -1476,8 +1476,8 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 "<div>
   <div>
     <div class=\\"u-mb-1\\">
-      <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-        <div class=\\"css-1472sn5\\">
+      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+        <div class=\\"css-1rg8gyn\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a tiny SelectBox</div>
             <div class=\\"css-1g6gooi\\">
@@ -1495,8 +1495,8 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
       </div>
     </div>
     <div class=\\"u-mb-1\\">
-      <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-        <div class=\\"css-4oellt\\">
+      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+        <div class=\\"css-15w89vh\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a medium SelectBox</div>
             <div class=\\"css-1g6gooi\\">
@@ -1514,8 +1514,8 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
       </div>
     </div>
     <div class=\\"u-mb-1\\">
-      <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-        <div class=\\"css-19fknmj\\">
+      <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+        <div class=\\"css-2zgoaw\\">
           <div class=\\"css-1phseng\\">
             <div class=\\"css-xp4uvy\\">I am a large SelectBox</div>
             <div class=\\"css-1g6gooi\\">
@@ -1538,7 +1538,7 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 
 exports[`SelectBox should render examples: SelectBox 8`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
     <div><button>toggle options</button>
       <div class=\\"styles__select-control__input___1xDlj\\">
         <div class=\\"css-1phseng\\">
@@ -1562,8 +1562,8 @@ exports[`SelectBox should render examples: SelectBox 8`] = `
 
 exports[`SelectBox should render examples: SelectBox 9`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-2zgoaw\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1584,8 +1584,8 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
 
 exports[`SelectBox should render examples: SelectBox 10`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-2zgoaw\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1606,8 +1606,8 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
 
 exports[`SelectBox should render examples: SelectBox 11`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-2zgoaw\\">
       <div class=\\"css-1phseng\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1666,8 +1666,8 @@ exports[`SelectBox should render examples: SelectBox 11`] = `
 
 exports[`SelectBox should render examples: SelectBox 12`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-2zgoaw\\">
       <div class=\\"css-1phseng needsclick\\">
         <div class=\\"css-1492t68\\">Select...</div>
         <div class=\\"css-1g6gooi\\">
@@ -1688,8 +1688,8 @@ exports[`SelectBox should render examples: SelectBox 12`] = `
 
 exports[`SelectBox should render examples: SelectBox 13`] = `
 "<div>
-  <div class=\\"css-10nd86i u-bg-white styles__select--autowidth___16AEp\\">
-    <div class=\\"css-19fknmj needsclick cz__control\\">
+  <div class=\\"css-10nd86i styles__select--autowidth___16AEp\\">
+    <div class=\\"css-2zgoaw needsclick cz__control\\">
       <div class=\\"css-1phseng needsclick cz__value-container\\">
         <div class=\\"css-1492t68 needsclick cz__placeholder\\">Select...</div>
         <div class=\\"css-1g6gooi\\">


### PR DESCRIPTION
Using an utility class makes it impossible to override bg color.