### PR TITLE
Chore: transpiled stylesheet does not have hashes

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ const plugins = [
       extensions: ['.styl'],
       preprocessCss: './preprocess',
       extractCss: './transpiled/react/stylesheet.css',
-      generateScopedName: '[name]__[local]___[hash:base64:5]'
+      generateScopedName: 'ui-[local]'
     }
   ],
   ['inline-json-import', {}]


### PR DESCRIPTION
This will enable the bar and the app to rely on the same
stylesheet.