### PR TITLE
fix: Do not require children for Text

### DIFF
--- a/react/Text/index.jsx
+++ b/react/Text/index.jsx
@@ -42,7 +42,7 @@ export const Caption = ({ className, ...restProps }) => (
 
 // Props
 const commonProps = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   className: PropTypes.string,
   tag: PropTypes.string,
   ellipsis: PropTypes.bool


### PR DESCRIPTION
dangerouslySetInnerHTML can be used instead, for example when displaying markdown.

In Banks we had a warning because we were using `<Text/>` without children, I changed the Text to a `<p>` but drazik made the point that the isRequired could also be removed from the `children` . https://github.com/cozy/cozy-banks/pull/1240#discussion_r290489849proptype.