### PR TITLE
feat: Add List component based on MUI

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -100,6 +100,7 @@ module.exports = {
         '../react/MuiCozyTheme/index.jsx',
         '../react/MuiCozyTheme/Buttons',
         '../react/MuiCozyTheme/Menus',
+        '../react/MuiCozyTheme/List',
         '../react/MuiCozyTheme/ExpansionPanel'
       ]
     }

--- a/react/ListItemText/styles.styl
+++ b/react/ListItemText/styles.styl
@@ -2,3 +2,6 @@
 
 .c-list-text
     @extend $list-text
+
+.c-list-text + .c-list-text
+    margin-left rem(32)

--- a/react/MuiCozyTheme/List/Readme.md
+++ b/react/MuiCozyTheme/List/Readme.md
@@ -1,0 +1,155 @@
+# List
+Displays a List of items, with several metadata
+
+## props
+`dense`: boolean (`false` by default)
+
+### Default usage
+```
+const MuiCozyTheme = require('..').default;
+const List = require('.').default;
+const ListItem = require('../ListItem').default;
+const ListItemIcon = require('../ListItemIcon').default;
+const ListItemText = require('../../ListItemText').default;
+const ListItemSecondaryAction = require('../ListItemSecondaryAction').default;
+const Icon = require('../../Icon').default;
+const Menus = require('../Menus').default;
+const MenuItem = require('@material-ui/core/MenuItem').default;
+const Button = require('../../Button').default;
+
+<MuiCozyTheme>
+  <List>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="folder" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text"/>
+      <ListItemText secondaryText="metadata"/>
+      <ListItemText secondaryText="metadata"/>
+      <ListItemSecondaryAction>
+        <Menu
+          component={
+            <Button
+              label='Click for more !'
+              theme="text"
+              icon="dots"
+              extension="narrow"
+              iconOnly
+              className="u-m-0"
+            />
+          }
+        >
+          <MenuItem>Profile</MenuItem>
+          <MenuItem>My account</MenuItem>
+          <hr />
+          <MenuItem>Logout</MenuItem>
+        </Menu>
+      </ListItemSecondaryAction>
+    </ListItem>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="file" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text" secondaryText="I'm a secondary text"/>
+    </ListItem>
+    <ListItem>
+      <ListItemText primaryText="I'm a primary text" />
+    </ListItem>
+  </List>
+</MuiCozyTheme>
+```
+
+### dense
+Reduce the space around a list item
+```
+const MuiCozyTheme = require('..').default
+const List = require('.').default
+const ListItem = require('../ListItem').default;
+const ListItemIcon = require('../ListItemIcon').default;
+const ListItemText = require('../../ListItemText').default;
+const Icon = require('../../Icon').default;
+
+<MuiCozyTheme>
+  <List dense={true}>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="folder" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text"/>
+    </ListItem>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="file" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text" secondaryText="I'm a secondary text"/>
+    </ListItem>
+    <ListItem>
+      <ListItemText primaryText="I'm a primary text" />
+    </ListItem>
+  </List>
+</MuiCozyTheme>
+```
+
+## Use cases
+### List item selected
+Highlight a selected item from the list
+```
+const MuiCozyTheme = require('..').default
+const List = require('.').default
+const ListItem = require('../ListItem').default;
+const ListItemIcon = require('../ListItemIcon').default;
+const ListItemText = require('../../ListItemText').default;
+const Icon = require('../../Icon').default;
+
+<MuiCozyTheme>
+  <List>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="folder" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text"/>
+    </ListItem>
+    <ListItem selected={true}>
+      <ListItemIcon>
+        <Icon icon="file" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text" secondaryText="I'm a secondary text"/>
+    </ListItem>
+    <ListItem>
+      <ListItemText primaryText="I'm a primary text" />
+    </ListItem>
+  </List>
+</MuiCozyTheme>
+```
+### List with sub header
+Adds a sub header as a list divider
+```
+const MuiCozyTheme = require('..').default
+const List = require('.').default
+const ListItem = require('../ListItem').default;
+const ListItemIcon = require('../ListItemIcon').default;
+const ListItemText = require('../../ListItemText').default;
+const ListSubheader = require('../ListSubheader').default;
+const Icon = require('../../Icon').default;
+
+<MuiCozyTheme>
+  <List>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="folder" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text"/>
+    </ListItem>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="file" width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primaryText="I'm a primary text" secondaryText="I'm a secondary text"/>
+    </ListItem>
+    <ListSubheader>I'm a subheader</ListSubheader>
+    <ListItem>
+      <ListItemText primaryText="I'm a primary text" />
+    </ListItem>
+  </List>
+</MuiCozyTheme>
+```

--- a/react/MuiCozyTheme/List/index.js
+++ b/react/MuiCozyTheme/List/index.js
@@ -1,0 +1,3 @@
+import List from '@material-ui/core/List'
+
+export default List

--- a/react/MuiCozyTheme/ListItem/index.js
+++ b/react/MuiCozyTheme/ListItem/index.js
@@ -1,0 +1,3 @@
+import ListItem from '@material-ui/core/ListItem'
+
+export default ListItem

--- a/react/MuiCozyTheme/ListItemIcon/index.js
+++ b/react/MuiCozyTheme/ListItemIcon/index.js
@@ -1,0 +1,3 @@
+import ListItemIcon from '@material-ui/core/ListItemIcon'
+
+export default ListItemIcon

--- a/react/MuiCozyTheme/ListItemSecondaryAction/index.js
+++ b/react/MuiCozyTheme/ListItemSecondaryAction/index.js
@@ -1,0 +1,3 @@
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+
+export default ListItemSecondaryAction

--- a/react/MuiCozyTheme/ListSubheader/index.js
+++ b/react/MuiCozyTheme/ListSubheader/index.js
@@ -1,0 +1,3 @@
+import ListSubheader from '@material-ui/core/ListSubheader'
+
+export default ListSubheader

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -91,17 +91,73 @@ export const theme = createMuiTheme({
       }
     },
     MuiListItem: {
+      root: {
+        borderTop: '1px solid var(--silver)',
+        minHeight: '4rem',
+        paddingTop: '.5rem',
+        paddingBottom: '.5rem',
+        '&:last-child': {
+          borderBottom: '1px solid var(--silver)'
+        },
+        '&$selected, &$selected:hover': {
+          backgroundColor: 'var(--zircon)'
+        },
+        '&:hover, &:focus': {
+          backgroundColor: 'var(--paleGrey)'
+        }
+      },
+      gutters: {
+        paddingLeft: '1rem',
+        paddingRight: '1rem'
+      },
+      dense: {
+        minHeight: '3.5rem'
+      },
+      secondaryAction: {
+        paddingRight: '.5rem'
+      },
       button: {
         '&:hover': {
           backgroundColor: getCssVariableValue('paleGrey')
         }
       }
     },
+    MuiListSubheader: {
+      root: {
+        borderTop: '1px solid transparent',
+        borderBottom: '1px solid var(--zircon)',
+        marginBottom: '-1px',
+        padding: 0,
+        backgroundColor: 'var(--zircon)',
+        textIndent: '2rem',
+        fontWeight: 'bold',
+        fontSize: '.75rem',
+        lineHeight: 1.33,
+        color: 'var(--coolGrey)'
+      },
+      gutters: {
+        paddingLeft: 0,
+        paddingRight: 0
+      },
+      sticky: {
+        backgroundColor: 'var(--zircon)'
+      }
+    },
+    MuiListItemSecondaryAction: {
+      root: {
+        zIndex: 1
+      }
+    },
     MuiMenuItem: {
       root: {
+        minHeight: 'auto',
         paddingTop: 4,
         paddingBottom: 4,
-        color: getCssVariableValue('charcoalGrey')
+        color: getCssVariableValue('charcoalGrey'),
+        border: 0,
+        '&:last-child': {
+          borderBottom: 0
+        }
       },
       gutters: {
         paddingLeft: 24,

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -1316,6 +1316,14 @@ exports[`MuiCozyTheme/ExpansionPanel should render examples: MuiCozyTheme/Expans
 
 exports[`MuiCozyTheme/ExpansionPanel should render examples: MuiCozyTheme/ExpansionPanel 2`] = `"<div></div>"`;
 
+exports[`MuiCozyTheme/List should render examples: MuiCozyTheme/List 1`] = `"<div></div>"`;
+
+exports[`MuiCozyTheme/List should render examples: MuiCozyTheme/List 2`] = `"<div></div>"`;
+
+exports[`MuiCozyTheme/List should render examples: MuiCozyTheme/List 3`] = `"<div></div>"`;
+
+exports[`MuiCozyTheme/List should render examples: MuiCozyTheme/List 4`] = `"<div></div>"`;
+
 exports[`MuiCozyTheme/Menus should render examples: MuiCozyTheme/Menus 1`] = `"<div></div>"`;
 
 exports[`Radio should render examples: Radio 1`] = `

--- a/react/examples.spec.jsx
+++ b/react/examples.spec.jsx
@@ -19,6 +19,7 @@ const testComponent = ComponentName => {
 
 testComponent('MuiCozyTheme/Buttons')
 testComponent('MuiCozyTheme/Menus')
+testComponent('MuiCozyTheme/List')
 testComponent('MuiCozyTheme/ExpansionPanel')
 testComponent('ActionMenu')
 testComponent('AppTitle')


### PR DESCRIPTION
Added the `List` component based on Mui's `List`.

With it I updated the style of `ListItem`, `ListItemIcon`, `ListItemSecondaryAction` and `ListSubheader`
Thought I didn't change [ListItemAvatar](https://v3-9-0.material-ui.com/api/list-item-avatar/) because I didn't need it and it's kinda buggy.

[Preview](https://gooz.github.io/cozy-ui/react/#!/List)