### PR TITLE
fix(Checkbox): Check icon position when multiline label

### DIFF
--- a/react/Checkbox/styles.styl
+++ b/react/Checkbox/styles.styl
@@ -11,7 +11,7 @@
 .c-input-checkbox-icon
     position absolute
     left 0
-    top rem(3)
+    top 50%
     box-sizing border-box
     width checkbox-size
     height checkbox-size
@@ -21,8 +21,8 @@
 
 .c-input-checkbox input:not(:checked) + span .c-input-checkbox-icon
     opacity 0
-    transform scale(0)
+    transform scale(0) translateY(-50%)
 
 .c-input-checkbox input:checked + span .c-input-checkbox-icon
     opacity 1
-    transform scale(1)
+    transform scale(1) translateY(-50%)


### PR DESCRIPTION
When a checkbox have a label long enough to be on multiple lines, the `check` icon is misplaced (it's actually top aligned and white on white so you can't see it)

Before:
<img width="756" alt="Screenshot 2019-06-13 11 30 05" src="https://user-images.githubusercontent.com/1280069/59422960-7ad56f00-8dd1-11e9-843c-8ddedfb1ec24.png">

After:
<img width="751" alt="Screenshot 2019-06-13 11 30 15" src="https://user-images.githubusercontent.com/1280069/59422980-83c64080-8dd1-11e9-864c-dd892864b380.png">
