### PR TITLE
fix(Field): Correctly handling select value proptype

### DIFF
--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -206,7 +206,30 @@ Field.propTypes = {
     'text',
     'url'
   ]),
-  value: PropTypes.string,
+  // value should be an object for type=select and string for others
+  value: function(props, propName, componentName) {
+    // not a required props
+    if (typeof props[propName] === 'undefined') return
+    if (props.type === 'select' && typeof props[propName] !== 'object') {
+      return new Error(
+        'Invalid prop `' +
+          propName +
+          '` supplied to' +
+          ' `' +
+          componentName +
+          '`. Expected an object for a Field value with type=select.'
+      )
+    } else if (props.type !== 'select' && typeof props[propName] !== 'string') {
+      return new Error(
+        'Invalid prop `' +
+          propName +
+          '` supplied to' +
+          ' `' +
+          componentName +
+          '`. Expected value to be a string.'
+      )
+    }
+  },
   placeholder: PropTypes.string,
   error: PropTypes.bool,
   side: PropTypes.node,

--- a/react/Field/index.spec.js
+++ b/react/Field/index.spec.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import Field from './'
+import { shallow } from 'enzyme'
+
+describe('Field component', () => {
+  beforeEach(() => {
+    // by default, proptypes checking just log errors
+    jest.spyOn(console, 'error').mockImplementation(message => {
+      throw new Error(message)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it('should expect object type value for type=select', () => {
+    expect(() =>
+      shallow(<Field label="mock field" type="select" value={{}} />)
+    ).not.toThrowError()
+    expect(() =>
+      shallow(<Field label="mock field" type="select" value="wrong" />)
+    ).toThrowError()
+  })
+
+  it('should expect string type value for all types but select', () => {
+    expect(() =>
+      shallow(<Field label="mock field" type="text" value="good" />)
+    ).not.toThrowError()
+    expect(() =>
+      shallow(<Field label="mock field" type="text" value={{}} />)
+    ).toThrowError()
+  })
+})


### PR DESCRIPTION
The Field value props should be a string for all types except for the `select` where the value should be an object.
Add also a test for that.