### PR TITLE
feat: Label class name

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -158,3 +158,20 @@ const options = [
   />
 </form>
 ```
+
+#### Class names
+
+You can use `className`, `labelClassName` to further customize the elements of the Field.
+
+```
+<form>
+  <Field
+    className='u-mt-0'
+    labelClassName='u-mt-0'
+    label="I'm a label"
+    side="(optional)"
+    fullwidth={true}
+  />
+</form>
+```
+

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -93,7 +93,8 @@ const Field = props => {
     readOnly,
     secondaryLabels,
     side,
-    size
+    size,
+    labelClassName
   } = props
 
   const inputType = type => {
@@ -174,7 +175,9 @@ const Field = props => {
 
   return (
     <div className={cx(styles['o-field'], className)}>
-      <Label htmlFor={id}>{label}</Label>
+      <Label className={labelClassName} htmlFor={id}>
+        {label}
+      </Label>
       {side && (
         <div
           className={cx(styles['o-side'], labelStyles['c-label'], {


### PR DESCRIPTION
Try to add the ability to remove the margin of the inner `<Label>`. The optional label is misaligned unfortunately.

See https://ptbrowne.github.io/cozy-ui/react/#!/Field/19