### PR TITLE
Support input[type=number]

### DIFF
--- a/react/Input/Readme.md
+++ b/react/Input/Readme.md
@@ -6,6 +6,7 @@
   <p><Input type="password" placeholder="This is a input[type=password]" /></p>
   <p><Input type="email" placeholder="This is a input[type=email]" /></p>
   <p><Input type="url" placeholder="This is a input[type=url]" /></p>
+  <p><Input type="number" placeholder="This is a input[type=number]" min="10" max="100" step="10" /></p>
 </form>
 ```
 

--- a/react/Input/__snapshots__/index.spec.jsx.snap
+++ b/react/Input/__snapshots__/index.spec.jsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input component should support number type 1`] = `
+<input
+  className="styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR"
+  onChange={[MockFunction]}
+  type="number"
+  value="42"
+/>
+`;

--- a/react/Input/index.jsx
+++ b/react/Input/index.jsx
@@ -45,10 +45,18 @@ const Input = props => {
 Input.propTypes = {
   autoComplete: PropTypes.string,
   disabled: PropTypes.bool,
-  type: PropTypes.oneOf(['date', 'email', 'password', 'text', 'url', 'tel']),
+  type: PropTypes.oneOf([
+    'date',
+    'email',
+    'number',
+    'password',
+    'text',
+    'url',
+    'tel'
+  ]),
   id: PropTypes.string,
   className: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   placeholder: PropTypes.string,
   error: PropTypes.bool,
   size: PropTypes.oneOf(['tiny', 'medium', 'large']),

--- a/react/Input/index.spec.jsx
+++ b/react/Input/index.spec.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+import Input from './index'
+
+describe('Input component', () => {
+  it('should support number type', () => {
+    const component = shallow(
+      <Input type="number" value="42" onChange={jest.fn()} />
+    ).getElement()
+    expect(component).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
`Input` component now supports `number` type: https://developer.mozilla.org/fr/docs/Web/HTML/Element/Input/number

No fancy stuff here. See https://cedricmessiant.github.io/cozy-ui/react/#input for an example