### PR TITLE
fix: Move dimension props from wrapper to modal

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -327,7 +327,6 @@ class Modal extends Component {
               },
               wrapperClassName
             )}
-            style={style}
             onClick={closable ? this.handleOutsideClick : undefined}
           >
             <div
@@ -342,6 +341,7 @@ class Modal extends Component {
                 },
                 className
               )}
+              style={style}
               role="dialog"
               aria-modal="true"
               aria-labelledby={title ? titleID : null}


### PR DESCRIPTION
Move the `style` prop (which contains `width` & `height` props) from the Modal wrapper to the Modal itself.

Originally, those props were added to force a modal height for Intent and it worked for them but it couldn't be used for regular modals.
Now it can & still works for Intent modals.

Fixes #899