### PR TITLE
fix: Limit expansion of Empty

### DIFF
--- a/stylus/components/empty.styl
+++ b/stylus/components/empty.styl
@@ -12,6 +12,7 @@ $empty
     align-self       center
     padding          rem(16) 0
     text-align       center
+    max-width        100%
 
     +medium-screen()
         margin-top 'calc(50vh - %s)' % contentHeight


### PR DESCRIPTION
Add max-width to Empty so that it cannot grow larger than its container.

Fix #1064