### PR TITLE
chore: Don't ignore codemods directory when publishing on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,6 +13,5 @@ yarn.lock
 examples
 docs
 coverage
-codemods
 loaders
 .github/


### PR DESCRIPTION
When an app developer needs to execute a codemod on his codebase, (s)he
doesn't want to clone the cozy-ui repository to get them. Publishing the
codemods on npm allows him to reach it from
`node_modules/cozy-ui/codemods` in his project directory.

This way we could give a command like the following in the release notes:

```
npx jscodeshift --parser babel -t ./node_modules/cozy-ui/codemods/new-icons.js --extensions js,jsx src/
```

And the developer would just have to copy/paste it instead of cloning cozy-ui or copy/pasting the codemod code from github.