### PR TITLE
feat: Invert Preact/React flag so that React becomes the default

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -1,5 +1,5 @@
 /**
- * preact plugin that provides an I18n helper using a Higher Order Component.
+ * Provides an I18n helper using a Higher Order Component.
  */
 
 'use strict'

--- a/react/Portal/index.jsx
+++ b/react/Portal/index.jsx
@@ -1,12 +1,12 @@
 let Portal
-if (process.env.USE_REACT) {
+if (process.env.USE_PREACT) {
+  Portal = require('preact-portal')
+} else {
   const ReactDOM = require('react-dom')
   Portal = ({ into, children }) => {
     const targetElement = document.querySelector(into)
     return ReactDOM.createPortal(children, targetElement)
   }
-} else {
-  Portal = require('preact-portal')
 }
 
 export default Portal


### PR DESCRIPTION
BREAKING CHANGE

I  changed the environment variable from USE_REACT=true to USE_PREACT so that apps using React have the least amount of job to do.