### PR TITLE
fix(Modal): Use border-box box-sizing on fullscreen variant

### DIFF
--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -85,6 +85,7 @@ $modal--fullscreen
         height 100%
         width 100%
         border-radius 0
+        box-sizing border-box
 
 $modal-header
     @extend $elastic-bar


### PR DESCRIPTION
In banks, we needed to add vertical padding on a `Modal` with `mobileFullscreen` prop set to `true`. But it made the modal overflows because the paddings were added to the `100%` height. The easiest solution is to add a `box-sizing: border-box` to the fullscreen modals, so the height and width include the padding.