### PR TITLE
chore: Create icon sprite before running styleguidist

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "posttranspile": "postcss transpiled/react/stylesheet.css --replace",
     "travis-deploy-once": "travis-deploy-once",
     "watch:css": "yarn build:css --watch",
+    "prewatch:doc:react": "yarn sprite",
     "watch:doc:react": "env BABEL_ENV=transpilation styleguidist server --config docs/styleguide.config.js",
     "watch:doc:kss": "nodemon --ext styl,md --watch stylus --exec 'yarn build:doc:kss && http-server build/styleguide -p 4242'"
   },


### PR DESCRIPTION
This way, the icon sprite is always up to date in the styleguidist.