### PR TITLE
fix: Icons used in React components & examples

### DIFF
--- a/react/Accordion/index.jsx
+++ b/react/Accordion/index.jsx
@@ -40,7 +40,7 @@ class AccordionItem extends Component {
             aria-expanded={selected}
             aria-controls={contentID}
           >
-            <Icon icon="forward" />
+            <Icon icon="right" />
             {label}
           </div>
         </div>

--- a/react/ActionMenu/Readme.md
+++ b/react/ActionMenu/Readme.md
@@ -12,7 +12,7 @@ const hideMenu = () => setState({ menuDisplayed: false });
     <ActionMenu
       onClose={hideMenu}>
       <ActionMenuItem left={<Icon icon='file' />}>Item 1</ActionMenuItem>
-      <ActionMenuItem left={<Icon icon='forward' />}>Item 2</ActionMenuItem>
+      <ActionMenuItem left={<Icon icon='right' />}>Item 2</ActionMenuItem>
       <ActionMenuItem left={<Icon icon='file' />}>Item 3</ActionMenuItem>
   </ActionMenu>}
 </div>
@@ -36,7 +36,7 @@ const hideMenu = () => setState({ menuDisplayed: false });
         <Filename icon="file" filename="my_awesome_paper" extension=".pdf" />
       </ActionMenuHeader>
       <ActionMenuItem left={<Icon icon='file' />}>Item 1</ActionMenuItem>
-      <ActionMenuItem left={<Icon icon='forward' />}>Item 2</ActionMenuItem>
+      <ActionMenuItem left={<Icon icon='right' />}>Item 2</ActionMenuItem>
       <ActionMenuItem left={<Icon icon='file' />}>Item 3</ActionMenuItem>
   </ActionMenu>}
 </div>

--- a/react/AppSections/components/DropdownFilter.jsx
+++ b/react/AppSections/components/DropdownFilter.jsx
@@ -9,7 +9,7 @@ import cx from 'classnames'
 const SmallArrow = () => (
   <Icon
     className={cx(styles.DropdownFilter__icon, 'u-mr-1')}
-    icon="small-arrow"
+    icon="bottom"
     color="var(--coolGrey)"
     width={16}
     height={16}

--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -123,7 +123,7 @@ If you want a button with only an icon as content, you must set the `iconOnly` p
 ```
 const { Button } = require('./index');
 <div>
-  <Button theme="danger" icon='delete' label='delete' />
+  <Button theme="danger" icon='trash' label='delete' />
   <Button theme="secondary" icon='dots' iconOnly label="See more" extension='narrow' />
 </div>
 ```
@@ -133,7 +133,7 @@ You can also pass an Icon directly if you need more flexibility.
 ```
 const { Button } = require('./index');
 <div>
-  <Button theme="danger" icon={ <Icon icon='delete' color='yellow' /> } label='delete' />
+  <Button theme="danger" icon={ <Icon icon='trash' color='yellow' /> } label='delete' />
 </div>
 ```
 

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -24,7 +24,7 @@ const ContactChip = ({ contact }) => (
 
 ```
 <Chip.Round>
-  <Icon icon='forward'/>
+  <Icon icon='right'/>
 </Chip.Round>
 ```
 
@@ -42,8 +42,8 @@ const ContactChip = ({ contact }) => (
 
 ```
 <div>
-  <Chip.Button><Icon icon='forward' /></Chip.Button>
-  <Chip.Button disabled><Icon icon='back' /></Chip.Button>
+  <Chip.Button><Icon icon='right' /></Chip.Button>
+  <Chip.Button disabled><Icon icon='left' /></Chip.Button>
 </div>
 ```
 

--- a/react/Icon/Readme.md
+++ b/react/Icon/Readme.md
@@ -49,7 +49,7 @@ Use `spin` and `rotate` if you want you to turn your icons upside down 🙃.
 ```
 <div>
   <Icon icon='spinner' color='#0bda51' spin/>{'\u00A0'}
-  <Icon icon='forward' color='#c30017' rotate={45}/>
+  <Icon icon='right' color='#c30017' rotate={45}/>
 </div>
 ```
 

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -165,7 +165,7 @@ const Option = ({
       <span className={withPrefix(cx, styles['select-option__checkmark'])}>
         {isSelected && (
           <Icon
-            icon="check-circleless"
+            icon="check"
             color={dodgerBlue}
             className={withPrefix(cx, 'u-ph-half')}
           />

--- a/react/Viewer/ViewerControls.jsx
+++ b/react/Viewer/ViewerControls.jsx
@@ -155,7 +155,7 @@ class ViewerControls extends Component {
             onMouseLeave={this.hideControls}
           >
             <Icon
-              icon="arrow-left"
+              icon="previous"
               size="24"
               className={styles['viewer-nav-arrow']}
             />
@@ -177,7 +177,7 @@ class ViewerControls extends Component {
             onMouseLeave={this.hideControls}
           >
             <Icon
-              icon="arrow-right"
+              icon="next"
               size="24"
               className={styles['viewer-nav-arrow']}
             />

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -210,13 +210,13 @@ exports[`Button should render examples: Button 9`] = `
 
 exports[`Button should render examples: Button 10`] = `
 "<div>
-  <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"#delete\\"></use></svg><span>delete</span></span></button><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--narrow___27FHD styles__c-btn--center___16_Xh\\" title=\\"See more\\"><span><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"#dots\\"></use></svg><span class=\\"u-visuallyhidden\\">See more</span></span></button></div>
+  <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"#trash\\"></use></svg><span>delete</span></span></button><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--narrow___27FHD styles__c-btn--center___16_Xh\\" title=\\"See more\\"><span><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use xlink:href=\\"#dots\\"></use></svg><span class=\\"u-visuallyhidden\\">See more</span></span></button></div>
 </div>"
 `;
 
 exports[`Button should render examples: Button 11`] = `
 "<div>
-  <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><svg class=\\"styles__icon___23x3R\\" style=\\"fill: yellow;\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#delete\\"></use></svg><span>delete</span></span></button></div>
+  <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><svg class=\\"styles__icon___23x3R\\" style=\\"fill: yellow;\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#trash\\"></use></svg><span>delete</span></span></button></div>
 </div>"
 `;
 
@@ -3004,7 +3004,7 @@ exports[`Icon should render examples: Icon 3`] = `
   <div><svg class=\\"styles__icon___23x3R styles__icon--spin___ybfC1\\" style=\\"fill: #0bda51;\\" width=\\"16\\" height=\\"16\\">
       <use xlink:href=\\"#spinner\\"></use>
     </svg>&nbsp;<svg class=\\"styles__icon___23x3R\\" style=\\"fill: #c30017; transform: rotate(45deg);\\" width=\\"16\\" height=\\"16\\">
-      <use xlink:href=\\"#forward\\"></use>
+      <use xlink:href=\\"#right\\"></use>
     </svg></div>
 </div>"
 `;


### PR DESCRIPTION
Fix all icons used in components & styleguidist examples.

[Preview](https://gooz.github.io/cozy-ui/react/)

Fixes: #1073 