### PR TITLE
fix(nav): Fix Icon alignment

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -54,6 +54,9 @@ $nav-item-icon
     color var(--coolGrey)
     fill currentColor
 
+    svg
+        display block
+
     .is-active &
         color var(--dodgerBlue)
 


### PR DESCRIPTION
Icons in nav were not correctly aligned.

**Avant:**
![Screenshot 2019-07-02 15 26 16](https://user-images.githubusercontent.com/1280069/60516330-d2367300-9cdd-11e9-82a5-7bf6da2c16bd.png)

**Après:**
![Screenshot 2019-07-02 15 26 24](https://user-images.githubusercontent.com/1280069/60516375-eaa68d80-9cdd-11e9-9cfe-586b156789a0.png)
