### PR TITLE
fix(Nav): Icon alignement on mobile

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -67,9 +67,9 @@ $nav-item-icon
         display block
         font-size rem(24)
         margin-right 0
-        text-align center
 
         svg
+            margin 0 auto
             width rem(24)
             height rem(24)
 

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -222,32 +222,32 @@
         <ul class="c-nav">
             <li class="c-nav-item">
                 <a class="c-nav-link is-active" href="#">
-                    <span class="c-nav-item__icon">
+                    <span class="c-nav-icon">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                             <path d="M14,5c0,-1.656 -1.344,-3 -3,-3l-6,0c-1.656,0 -3,1.344 -3,3l0,6c0,1.656 1.344,3 3,3l6,0c1.656,0 3,-1.344 3,-3l0,-6Z"/>
                         </svg>
                     </span>
-                    <span class="c-nav-item__text">Link 1</span>
+                    <span class="c-nav-text">Link 1</span>
                 </a>
             </li>
             <li class="c-nav-item">
                 <a class="c-nav-link" href="#">
-                    <span class="c-nav-item__icon">
+                    <span class="c-nav-icon">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                             <path d="M14,5c0,-1.656 -1.344,-3 -3,-3l-6,0c-1.656,0 -3,1.344 -3,3l0,6c0,1.656 1.344,3 3,3l6,0c1.656,0 3,-1.344 3,-3l0,-6Z"/>
                         </svg>
                     </span>
-                    <span class="c-nav-item__text">Link 2</span>
+                    <span class="c-nav-text">Link 2</span>
                 </a>
             </li>
             <li class="c-nav-item">
                 <a class="c-nav-link" href="#">
-                    <span class="c-nav-item__icon">
+                    <span class="c-nav-icon">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                             <path d="M14,5c0,-1.656 -1.344,-3 -3,-3l-6,0c-1.656,0 -3,1.344 -3,3l0,6c0,1.656 1.344,3 3,3l6,0c1.656,0 3,-1.344 3,-3l0,-6Z"/>
                         </svg>
                     </span>
-                    <span class="c-nav-item__text">Link 3</span>
+                    <span class="c-nav-text">Link 3</span>
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
#1083 introduced a regression on mobile navigation. Icons weren't correctly aligned anymore.
So here's the fix. 

Also the styleguide example wasn't using the right classnames, so It's fixed too.