### PR TITLE
fix(Viewer): Use getStackClient().uri to get uri

### DIFF
--- a/react/Viewer/ImageLoader.jsx
+++ b/react/Viewer/ImageLoader.jsx
@@ -90,7 +90,7 @@ class ImageLoader extends React.Component {
 
       if (!link) throw new Error(`${size} link is not available`)
 
-      const src = client.options.uri + link
+      const src = client.getStackClient().uri + link
       await this.checkImageSource(src)
       if (this._mounted) {
         this.setState({


### PR DESCRIPTION
I think client.options.uri works when we're not in an OAuth client, but let's use StackClient to be able to get the uri anytime ?