### PR TITLE
fix(label): Remove required for htmlFor

### DIFF
--- a/react/Label/index.jsx
+++ b/react/Label/index.jsx
@@ -24,7 +24,7 @@ const Label = props => {
 
 Label.propTypes = {
   children: PropTypes.node.isRequired,
-  htmlFor: PropTypes.string.isRequired,
+  htmlFor: PropTypes.string,
   className: PropTypes.string,
   error: PropTypes.bool,
   block: PropTypes.bool


### PR DESCRIPTION
It seems that `for` is not mandatory in the HTML Spec. In some case, we use the label without any input.
