### PR TITLE
fix: Don't crash when TARGET is missing

### DIFF
--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -33,7 +33,7 @@ export class AppLinker extends React.Component {
   }
 
   componentDidMount() {
-    if (__TARGET__ === 'mobile') {
+    if (typeof __TARGET__ !== 'undefined' && __TARGET__ === 'mobile') {
       this.checkAppAvailability()
     }
   }


### PR DESCRIPTION
If the global `__TARGET__` variable is non existant, the AppLinker simply crashes.

Sadly no unit test to cover the fix, because the bug is only in the transpiled version as far as I can tell.