### PR TITLE
Fixes in wizard styles

### DIFF
--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -176,7 +176,7 @@ $wizard-logo-badge
     justify-content center
     position absolute
     bottom rem(6)
-    right rem(16)
+    right rem(-6)
     width rem(32)
     height rem(32)
     border .125rem solid white

--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -166,17 +166,17 @@ $wizard-logo
     position relative
     margin 0 auto
     width rem(120)
-    height rem(120)
 
 $wizard-logo-img
     width 100%
+    vertical-align center
 
 $wizard-logo-badge
     display flex
     align-items center
     justify-content center
     position absolute
-    bottom rem(6)
+    bottom rem(-6)
     right rem(-6)
     width rem(32)
     height rem(32)

--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -101,11 +101,12 @@ $wizard-header
     flex-direction column
     box-sizing border-box
     max-width rem(544)
-    margin rem(16) auto rem(8)
+    margin rem(16) 0 rem(8)
     padding 0 rem(16)
+    position relative
 
     +small-device()
-        margin rem(16) auto 0
+        margin rem(16) 0 0
 
 $wizard-header--dual
     margin-bottom rem(32)
@@ -241,12 +242,16 @@ $wizard-desc--footer
 
 $wizard-header-fixed
     position fixed
-    top rem(14)
-    left 0
+    top rem(8)
+    left rem(16)
     display inline-flex
     align-items center
 
 $wizard-previous
+    position absolute
+    top 50%
+    left 0
+    transform translateY(-50%)
     margin 0
     padding rem(10) rem(16)
     color var(--coolGrey)


### PR DESCRIPTION
We had two problems with the wizard styles in cozy-authentication:

* The badge on the logo was misaligned: 

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/1606068/61056873-6f875a80-a3f4-11e9-8d85-ba1e30bb58fc.png)|![image](https://user-images.githubusercontent.com/1606068/61057126-f3d9dd80-a3f4-11e9-9c05-f40930ad1dfa.png)|

We want to logo on this page to look like the mobile app's logos where the badge is aligned on the right

* The fixed back arrow was misaligned:

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/1606068/61056892-7a41ef80-a3f4-11e9-8402-62eae1cf6e59.png)|![image](https://user-images.githubusercontent.com/1606068/61057188-0c49f800-a3f5-11e9-85a9-cf1a2ea28c2c.png)|

This arrow was just weirdly placed.