### PR TITLE
fix: Transpiled stylesheet contains utility classes

### DIFF
--- a/react/utilities.js
+++ b/react/utilities.js
@@ -2,3 +2,4 @@
 
 // Special file for utilities to be included in the transpiled stylesheet
 import palette from '../stylus/utilities/palette.styl' // 130k
+import utilies from '../stylus/cozy-ui/utils.styl'


### PR DESCRIPTION
This should fix #1119. But some utility classes are likely to be
duplicated (since some of them were already present). More work is
needed to deduplicate them, but this fixes our base promise (transpiled
stylesheet contains everything the components use).