### PR TITLE
fix: Color utilities

### DIFF
--- a/stylus/utilities/bgcolor.styl
+++ b/stylus/utilities/bgcolor.styl
@@ -4,6 +4,6 @@ colors=json('../settings/palette.json', { hash: true })
 
 for color in keys(colors)
     $bg-color-{color}
-        background-color: lookup(color) !important // @stylint ignore
+        background-color: colors[color] !important // @stylint ignore
 
     global('.u-bg-' + color, '$bg-color-' + color)

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -17,7 +17,7 @@ colors=json('../settings/palette.json', { hash: true })
 
 for color in keys(colors)
     $color-{color}
-        color: lookup(color) !important // @stylint ignore
+        color: colors[color] !important // @stylint ignore
 
     global('.u-' + color, '$color-' + color)
 


### PR DESCRIPTION
Most of our utility classes for colors are broken at the moment, as is visible on the [styleguide](https://docs.cozy.io/cozy-ui/styleguide/section-utilities.html) for example. This PR fixes the problem.