### PR TITLE
feat: Make radio and checkbox accessible

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -361,7 +361,10 @@ $checkbox
             background-color var(--paleGrey)
 
     input
-        hide()
+        visually-hide()
+
+        &:focus + span::before
+            box-shadow inset 0 0 0 rem(2) var(--dodgerBlue)
 
         &:checked
             & + span::before

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -74,7 +74,8 @@ hide()
 /*
     visually-hide()
 
-    visually-hide() mixin visually hides an element. The element is still reachable. This mixin doesn't take parameters.
+    visually-hide() mixin visually hides an element. The element is still visible by screen readers.
+    This mixin doesn't take parameters.
 
     Weight: 3
 

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -72,12 +72,33 @@ hide()
     visibility  hidden !important  // @stylint ignore
 
 /*
+    visually-hide()
+
+    visually-hide() mixin visually hides an element. The element is still reachable. This mixin doesn't take parameters.
+
+    Weight: 3
+
+    Styleguide Tools.mixins.hide
+*/
+visually-hide()
+    border 0
+    clip rect(0 0 0 0)
+    clip-path polygon(0 0, 0 0, 0 0)
+    height 1px
+    margin -1px
+    overflow hidden
+    padding 0
+    position absolute
+    width 1px
+    white-space nowrap
+
+/*
     reset()
 
     reset() mixin removes every padding, margin and border of an element.
     This mixin doesn't take parameters.
 
-    Weight: 3
+    Weight: 4
 
     Styleguide Tools.mixins.reset
 */


### PR DESCRIPTION
In Radio and Checkbox components, inputs were hiddden using
`display: none` and `visibility: hidden`, which totally hide the
element. For accessibility reason, we actually want the inputs to be
only visually hidden, but still accessible to screen readers.

Fix #1122

For information, the technique used is from https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/

I also added styles for the focused state.

See https://drazik.github.io/cozy-ui/react/#!/Checkbox and https://drazik.github.io/cozy-ui/react/#!/Radio