### PR TITLE
docs(Text): Rename note to Caption

### DIFF
--- a/react/Text/Readme.md
+++ b/react/Text/Readme.md
@@ -46,10 +46,10 @@ const { Uppercase } = require('./index');
 <Uppercase>This is an uppercase text</Uppercase>
 ```
 
-#### Note text
+#### Caption text
 
 ```
 const { Caption } = require('./index');
 
-<Caption>This a note text</Caption>
+<Caption>This a caption text</Caption>
 ```

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3760,7 +3760,7 @@ exports[`Text should render examples: Text 6`] = `
 
 exports[`Text should render examples: Text 7`] = `
 "<div>
-  <div class=\\"u-caption\\">This a note text</div>
+  <div class=\\"u-caption\\">This a caption text</div>
 </div>"
 `;
 


### PR DESCRIPTION
Currently it's a bit confusing when we search about a `Caption` exemple in the doc.


