### PR TITLE
feat: Customize Field label props

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -158,3 +158,19 @@ const options = [
   />
 </form>
 ```
+
+#### Customized label and input
+
+```
+<form>
+  <Field
+    label="I'm a label"
+    labelProps={{
+      style: { color: 'teal' }
+    }}
+    fieldProps={{
+      style: { borderColor: 'teal' }
+    }}
+  />
+</form>
+```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -79,6 +79,7 @@ const Field = props => {
     className,
     disabled,
     fieldProps,
+    labelProps,
     fullwidth,
     label,
     id,
@@ -168,6 +169,7 @@ const Field = props => {
             onBlur={onBlur}
             readOnly={readOnly}
             size={size}
+            {...fieldProps}
           />
         )
       default:
@@ -179,7 +181,9 @@ const Field = props => {
 
   return (
     <div className={cx(styles['o-field'], className)}>
-      <Label htmlFor={id}>{label}</Label>
+      <Label htmlFor={id} {...labelProps}>
+        {label}
+      </Label>
       {side && (
         <div
           className={cx(styles['o-side'], labelStyles['c-label'], {
@@ -197,6 +201,7 @@ const Field = props => {
 Field.propTypes = {
   ...inputSpecificPropTypes,
   disabled: PropTypes.bool,
+  labelProps: PropTypes.object,
   fieldProps: PropTypes.object,
   fullwidth: PropTypes.bool,
   label: PropTypes.string.isRequired,
@@ -245,6 +250,7 @@ Field.propTypes = {
 
 Field.defaultProps = {
   fieldProps: {},
+  labelProps: {},
   fullwidth: false,
   label: '',
   id: '',

--- a/react/Label/index.jsx
+++ b/react/Label/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
 const Label = props => {
-  const { htmlFor, className, children, block, error } = props
+  const { htmlFor, className, children, block, error, ...otherProps } = props
   return (
     <label
       htmlFor={htmlFor}
@@ -16,6 +16,7 @@ const Label = props => {
         },
         className
       )}
+      {...otherProps}
     >
       {children}
     </label>

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -499,6 +499,14 @@ exports[`Field should render examples: Field 9`] = `
 </div>"
 `;
 
+exports[`Field should render examples: Field 10`] = `
+"<div>
+  <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\" style=\\"color: teal;\\">I'm a label</label><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"\\" style=\\"border-color: teal;\\" value=\\"\\"></div>
+  </form>
+</div>"
+`;
+
 exports[`Hero should render examples: Hero 1`] = `
 "<div>
   <div class=\\"styles__Hero___14z7_\\">


### PR DESCRIPTION
The Field component renders a Label and an Input, but we don't have a lot of control over them. We already had a `fieldProps` prop that allowed to pass props down to the Input, and this PR does the same for the label.

Not super fond of piling on props like this, but the Field also has a built-in logic to toggle a password field between password and plain text that we would have to reimplement otherwise :(