### PR TITLE
feat(Field): Custom secondaryComponent

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -174,3 +174,23 @@ const options = [
   />
 </form>
 ```
+
+#### Password with custom secondaryComponent
+
+```
+<form>
+  <Field
+    label="I'm a label"
+    labelProps={{
+      style: { color: 'teal' }
+    }}
+    fieldProps={{
+      style: { borderColor: 'teal' }
+    }}
+    type="password"
+    secondaryComponent={({visible}) => {
+      return visible ? <div className={'u-bg-dodgerBlue'}>Hide</div> : <div className={'u-bg-silver'}>Show</div>
+    }}
+  />
+</form>
+```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -34,12 +34,14 @@ class InputPassword extends React.Component {
       showLabel,
       showVisibilityButton,
       fullwidth,
+      secondaryComponent,
       ...restProps
     } = this.props
     const { visible } = this.state
+
     return (
       <div className={styles['o-field-input']}>
-        {showVisibilityButton && (
+        {showVisibilityButton && !secondaryComponent && (
           <div
             className={cx(
               labelStyles['c-label'],
@@ -49,6 +51,18 @@ class InputPassword extends React.Component {
             onClick={() => this.toggleVisibility()}
           >
             {visible ? hideLabel : showLabel}
+          </div>
+        )}
+        {showVisibilityButton && secondaryComponent && (
+          <div
+            className={cx(styles['o-field-input-action'], {
+              [styles['o-side-fullwidth']]: fullwidth
+            })}
+            onClick={() => this.toggleVisibility()}
+          >
+            {secondaryComponent({
+              visible
+            })}
           </div>
         )}
         <Input
@@ -94,6 +108,7 @@ const Field = props => {
     onBlur,
     readOnly,
     secondaryLabels,
+    secondaryComponent,
     side,
     size
   } = props
@@ -145,6 +160,7 @@ const Field = props => {
             size={size}
             {...fieldProps}
             {...secondaryLabels}
+            secondaryComponent={secondaryComponent}
           />
         )
       case 'date':
@@ -245,7 +261,8 @@ Field.propTypes = {
   error: PropTypes.bool,
   side: PropTypes.node,
   size: PropTypes.oneOf(['tiny', 'medium', 'large']),
-  secondaryLabels: PropTypes.object
+  secondaryLabels: PropTypes.object,
+  secondaryComponent: PropTypes.func
 }
 
 Field.defaultProps = {

--- a/react/Field/styles.styl
+++ b/react/Field/styles.styl
@@ -6,14 +6,12 @@
 
 .o-field-input
     position relative
+    max-width rem(512)
 
 .o-side
     position absolute
     top 0.5rem
-    left 0
-    width 100%
-    max-width rem(512)
-    text-align right
+    right 0
     cursor pointer
     text-transform unset
 

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -507,6 +507,20 @@ exports[`Field should render examples: Field 10`] = `
 </div>"
 `;
 
+exports[`Field should render examples: Field 11`] = `
+"<div>
+  <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\" style=\\"color: teal;\\">I'm a label</label>
+      <div class=\\"styles__o-field-input___vCqdV\\">
+        <div class=\\"styles__o-field-input-action___2k7a8\\">
+          <div class=\\"u-bg-silver\\">Show</div>
+        </div><input type=\\"password\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"\\" style=\\"border-color: teal;\\" value=\\"\\">
+      </div>
+    </div>
+  </form>
+</div>"
+`;
+
 exports[`Hero should render examples: Hero 1`] = `
 "<div>
   <div class=\\"styles__Hero___14z7_\\">


### PR DESCRIPTION
We can now pass a secondaryComponent prop to InputPassword
in order to manage ourself the component.

Also edited a few css lines, to fix an issue where the
"hide"/"show" was capturing the click on the all width

https://crash--.github.io/cozy-ui/react/#!/Field/21