### PR TITLE
fix: Min/max none

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1737,7 +1737,7 @@ Display an chip that represents complex identity
     Classes to set min-width/height on elements<br>
     [Can be used with breakpoints modifier suffixes (`-t`,`-s`,`-m`)](section-settings.html#kssref-settings-breakpoints)
 
-    .u-miw-none - Cancel min-width
+    .u-miw-auto - Cancel min-width
     .u-miw-1 - Apply min-width 1st step in scale (1rem = 16px)
     .u-miw-2 - Apply min-width 2nd step in scale (2rem = 32px)
     .u-miw-3 - Apply min-width 3rd step in scale (4rem = 64px)
@@ -1748,7 +1748,7 @@ Display an chip that represents complex identity
     .u-miw-8 - Apply min-width 8th step in scale (64rem = 1024px)
     .u-miw-9 - Apply min-width 9th step in scale (96rem = 1536px)
     .u-miw-100 - Apply min-width 100%
-    .u-mih-none - Cancel min-height
+    .u-mih-auto - Cancel min-height
     .u-mih-1 - Apply min-height 1st step in scale (1rem = 16px)
     .u-mih-2 - Apply min-height 2nd step in scale (2rem = 32px)
     .u-mih-3 - Apply min-height 3rd step in scale (4rem = 64px)
@@ -1761,7 +1761,7 @@ Display an chip that represents complex identity
     .u-mih-100 - Apply min-height 100%
 
     Markup:
-    <div class="{{modifier_class}}" style="display: inline-block;background-color:gainsboro; border: 1px solid black;">&nbsp;</div>
+    <div class="{{modifier_class}}" style="display: inline-block;background-color:gainsboro; border: 1px solid black; min-width: 20px;">&nbsp;</div>
 
     Weight: 12
 
@@ -1774,7 +1774,7 @@ Display an chip that represents complex identity
     Classes to set max-width/height on elements<br>
     [Can be used with breakpoints modifier suffixes (`-t`,`-s`,`-m`)](section-settings.html#kssref-settings-breakpoints)
 
-    .u-maw-none - Cancel max-width
+    .u-maw-auto - Cancel max-width
     .u-maw-1 - Apply max-width 1st step in scale (1rem = 16px)
     .u-maw-2 - Apply max-width 2nd step in scale (2rem = 32px)
     .u-maw-3 - Apply max-width 3rd step in scale (4rem = 64px)
@@ -1785,7 +1785,7 @@ Display an chip that represents complex identity
     .u-maw-8 - Apply max-width 8th step in scale (64rem = 1024px)
     .u-maw-9 - Apply max-width 9th step in scale (96rem = 1536px)
     .u-maw-100 - Apply max-width 100%
-    .u-mah-none - Cancel max-height
+    .u-mah-auto - Cancel max-height
     .u-mah-1 - Apply max-height 1st step in scale (1rem = 16px)
     .u-mah-2 - Apply max-height 2nd step in scale (2rem = 32px)
     .u-mah-3 - Apply max-height 3rd step in scale (4rem = 64px)

--- a/stylus/utilities/dimensions.styl
+++ b/stylus/utilities/dimensions.styl
@@ -10,7 +10,8 @@ minmax = {
 }
 
 minmaxscale = {
- 'none': none,
+ 'none': auto, // none is deprecated
+ 'auto': auto,
  '1': rem(16),
  '2': rem(32),
  '3': rem(64),


### PR DESCRIPTION
[`none` is not a valid value for `min-width` and co.](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width). I've replaced `none` with `auto`. The previous `u-miw-none` classes will work now, but are deprecated — please use `u-miw-auto` instead. 