### PR TITLE
fix: Use the correct variable

### DIFF
--- a/react/Toggle/styles.styl
+++ b/react/Toggle/styles.styl
@@ -34,7 +34,7 @@
     transition    all .2s ease-out
 
 .checkbox:checked + .label
-    background emerald
+    background var(--emerald)
 
     &:before
         left rem(18)


### PR DESCRIPTION
Problem: Toggles were grey even if checked.

We used emerald instead of var(--emerald), this bug was hidden previously since
the bar embarked its own UI and the CSS of UI inside the bar had a fallback
to var(--emerald) (IDK why).