### PR TITLE
fix: Use var() to access CSS variables

### DIFF
--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -25,23 +25,23 @@
     align-items center
     padding rem(8)
     border-left rem(4) solid transparent
-    color charcoalGrey
+    color var(--charcoalGrey)
     transition all .2s ease-out
     white-space normal /* otherwise the tick can be wrongly placed in Firefox */
 
     &:hover:not(.select-option--disabled)
-        background-color paleGrey
+        background-color var(--paleGrey)
         cursor pointer
 
         .select-option__actions
           opacity 1
 
 .select-option--focused:not(.select-option--disabled)
-    background-color paleGrey
+    background-color var(--paleGrey)
 
 .select-option--selected
-    background-color paleGrey
-    border-left-color dodgerBlue
+    background-color var(--paleGrey)
+    border-left-color var(--primaryColor)
 
 .select-option--disabled
     color silver

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -5,15 +5,15 @@
 .c-spinner
     display inline-block
     margin 0 rem(8)
-    
-   
+
+
 
     &:before
         content ''
 
     p
         margin-top  rem(15)
-        color       coolGrey
+        color       var(--coolGrey)
         line-height 1.5
 
 // === Modifiers ===

--- a/react/Viewer/controls.styl
+++ b/react/Viewer/controls.styl
@@ -62,7 +62,7 @@
     background linear-gradient(to bottom, rgba(50, 54, 63, .5), rgba(50, 54, 63, .33), rgba(50, 54, 63, 0))
 
     &--mobilebrowser
-        background-color charcoalGrey
+        background-color var(--charcoalGrey)
         opacity 0.9
 
     &--hidden


### PR DESCRIPTION
In #1134, we fixed an issue where we did not use the CSS variable and it caused a visible
bug in the toggle. I tried to automatically detect cases like that with csslint. Fortunately, there were not many cases.

---

## Workflow

```bash
$ yarn transpile
$ npx css-beautify transpile/react/stylesheet.css /tmp/beautified.css # must run csslint on a non-minified CSS
$ csslint /tmp/beautified.css --warnings="known-properties"| python /tmp/reformat.py | grep -v "var"
```

reformat.py (to have each error on oneline to be able to ignore lines with grep, see above)

```
import sys

data = sys.stdin.read()
errors = data.split('\n\n')
for e in errors:
    lines = e.split('\n')
    print "\t".join(lines)
```