### PR TITLE
feat: Add uncontrolled Fields. Can use it in docs

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -13,7 +13,6 @@ Like `Input` component, it can have the following properties:
     label="I'm a label"
     type="textarea"
     placeholder="I'm a textarea"
-    onChange={() => {}}
     size="medium"
   />
 </form>
@@ -192,5 +191,18 @@ const options = [
       return visible ? <div className={'u-bg-dodgerBlue'}>Hide</div> : <div className={'u-bg-silver'}>Show</div>
     }}
   />
+</form>
+```
+
+#### Controlled Field
+
+```
+<form>
+  <Field
+    side="(optional)"
+    fullwidth={true}
+    value={state.value} onChange={ev => setState({value: ev.target.value})}
+  />
+  Value: { state.value }
 </form>
 ```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -109,7 +109,10 @@ const Field = props => {
     side,
     size
   } = props
-
+  const controlledProps = {
+    ...(value ? { value } : {}),
+    ...(onChange ? { onChange } : {})
+  }
   const inputType = type => {
     switch (type) {
       case 'select':
@@ -129,12 +132,11 @@ const Field = props => {
             id={id}
             name={name}
             placeholder={placeholder}
-            value={value}
             error={error}
-            onChange={onChange}
             onKeyUp={onKeyUp}
             onBlur={onBlur}
             readOnly={readOnly}
+            {...controlledProps}
           />
         )
       case 'password':
@@ -148,9 +150,8 @@ const Field = props => {
             name={name}
             type={type}
             placeholder={placeholder}
-            value={value}
             error={error}
-            onChange={onChange}
+            {...controlledProps}
             onKeyUp={onKeyUp}
             onBlur={onBlur}
             readOnly={readOnly}
@@ -175,9 +176,8 @@ const Field = props => {
             name={name}
             type={type}
             placeholder={placeholder}
-            value={value}
             error={error}
-            onChange={onChange}
+            {...controlledProps}
             onKeyUp={onKeyUp}
             onBlur={onBlur}
             readOnly={readOnly}

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -521,6 +521,16 @@ exports[`Field should render examples: Field 11`] = `
 </div>"
 `;
 
+exports[`Field should render examples: Field 12`] = `
+"<div>
+  <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\"></label>
+      <div class=\\"styles__o-side___tXbXL styles__c-label___o4ozG styles__o-side-fullwidth___7WcCI\\">(optional)</div><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR styles__c-input-text--fullwidth___33o_f\\" placeholder=\\"\\" value=\\"\\">
+    </div>Value:
+  </form>
+</div>"
+`;
+
 exports[`Hero should render examples: Hero 1`] = `
 "<div>
   <div class=\\"styles__Hero___14z7_\\">


### PR DESCRIPTION
ATM, `Field` is a controlled component since we set a value and onChange props. Because of that, we can't type something in a Field component without having to deal with setState etc. So it was not usable in our styleguidist. 

This PR should fix this issue. 

https://crash--.github.io/cozy-ui/react/#field
