### PR TITLE
fix: Do not ship postcss.config.js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,9 @@ docs
 coverage
 loaders
 .github/
+
+# Do not ship postcss.config.js in the npm package otherwise
+# parcel will try to use it if it is present.
+# Since parcel users will use the transpiled version of cozy-ui
+# that has already been processed by postcss, it is not necessary.
+postcss.config.js


### PR DESCRIPTION
If we ship `postcss.config.js`, parcel will try to transform CSS files
with the config shipped. This config is meant for transpilation, before
publishing, not for consumption by bundlers down the line.

The problem experienced was that in cozy-keys-lib, when trying to 

```
import 'cozy-ui/transpiled/react/stylesheet.css
```

we had an error "preset advanced cannot be found". This error stemmed from
the fact that the postcss.config.js is configured with `cssnano-preset-advanced`, and `cozy-ui`
does not declare `cssnano-preset-advanced` as a dependency, hence it was not in the node_modules of `cozy-keys-lib`.

By removing postcss.config.js from the npm package, we ensure that bundlers will not
try to load a config that is meant to be before publication, NOT for consumption by bundlers
down the line.

Side note: we did not have the problem in cozy-libs/packages/playground since
cssnano-preset-advanced was in the workspace node_modules because cozy-authentication installed it.