### PR TITLE
feat: Spacing values are a bit more spaced

### DIFF
--- a/react/Stack/Readme.md
+++ b/react/Stack/Readme.md
@@ -17,28 +17,44 @@ const Card = require('../Card').default;
 </Stack>
 ```
 
-You can use `sparse` and `dense` value for "spacing" to have more/less padding.
+You can use `xs`, `s`, `l`, `xl`, and `xxl` values for "spacing" to have less/more padding.
 
 ```
-const Card = require('../Card').default;
+const Card = require('../Card').default
+const spacings = ['xs', 's', 'l', 'xl', 'xxl'];
 
 <div>
-<p>
-Dense:
-</p>
-<Stack spacing="dense">
-  <Card>Homer Simpson</Card>
-  <Card>Marge Simpson</Card>
-</Stack>
 
-<p>
-Sparse:
-</p>
+{ spacings.map(spacing  =>
+  (<>
+    <p>
+    { spacing }:
+    </p>
 
-<Stack spacing="sparse">
-  <Card>Homer Simpson</Card>
-  <Card>Marge Simpson</Card>
-</Stack>
+    <Stack spacing={spacing}>
+      <Card>Homer Simpson</Card>
+      <Card>Marge Simpson</Card>
+    </Stack>
+  </>)
+  )}
 
 </div>
 ```
+
+
+---
+
+
+<Stack spacing='xs'>
+    <Card>
+        <h1 class='u-mb-m'>Joel</h1>
+    </Card>
+    <Card>
+        <h1>Patrick</h1>
+    </Card>
+</Stack>
+
+h1 
+  margin-bottom 1rem
+
+

--- a/react/Stack/index.jsx
+++ b/react/Stack/index.jsx
@@ -3,23 +3,21 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
-const sparseStyle = styles['Stack--sparse']
-const denseStyle = styles['Stack--dense']
-
 const Stack = ({ spacing, ...props }) => {
   return (
     <div
       {...props}
-      className={cx(props.className, styles.Stack, {
-        [sparseStyle]: spacing === 'sparse',
-        [denseStyle]: spacing === 'dense'
-      })}
+      className={cx(
+        props.className,
+        styles.Stack,
+        spacing && styles['Stack--' + spacing]
+      )}
     />
   )
 }
 
 Stack.propTypes = {
-  spacing: PropTypes.oneOf(['sparse', 'dense'])
+  spacing: PropTypes.oneOf(['xs', 's', 'l', 'xl', 'xxl'])
 }
 
 export default Stack

--- a/react/Stack/styles.styl
+++ b/react/Stack/styles.styl
@@ -1,20 +1,9 @@
-@require 'settings/breakpoints.styl'
+@require 'utilities/spaces.styl'
 
-.Stack > * + *
-    margin-top .5rem
-
-.Stack--dense > * + *
-    margin-top .25rem
-
-.Stack--sparse > * + *
-    margin-top .75rem
-
-+small-screen()
-    .Stack > * + *
-        margin-top .25rem
-
-    .Stack--dense > * + *
-        margin-top .15rem
-
-    .Stack--sparse > * + *
-        margin-top .5rem
+for k,v in spacing_values
+  if k == 'm'
+    modifier = ''
+  else
+    modifier = "--" + k
+  .Stack{modifier} > * + *
+    margin-top: v[0]

--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -19,6 +19,18 @@ sizes = {
     '2-half': rem(40),
     '3': rem(48)
 }
+
+// These are the values used by the design team, they should used
+// instead of the `sizes` variable above that is only kept for retro-compatibility
+spacing_values = {
+    xs: .5rem,
+    s: .75rem,
+    m: 1rem, // the standard, no modifier needed
+    l: 1.5rem,
+    xl: 2rem
+    xxl: 3rem
+}
+
 directions = {
     '': all,
     t: top,


### PR DESCRIPTION
Stack spacing values were so close that they were useless. I figured that since it is still very new, we could do a breaking change here.

@joel-costa  I am interested in your input here for vertical spacing.

The styleguide is visible here: https://ptbrowne.github.io/cozy-ui/react/#/Stack

BREAKING CHANGE: sparse/dense spacing values are no longer recognized