### PR TITLE
fix(Infos): Fix the text propTypes

### DIFF
--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -71,7 +71,8 @@ Infos.propTypes = {
   icon: iconPropType,
   /** An important information will be displayed with red colors */
   isImportant: PropTypes.bool,
-  text: PropTypes.string,
+  /** Can be either a Text, or an element (for instance a ReactMardown component) */
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   title: PropTypes.string
 }
 export default Infos


### PR DESCRIPTION
In a few use cases, we pass to infos a ReactMardown component
So it's not a string but an object
