### PR TITLE
feat: Add position direction utilities

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1451,6 +1451,50 @@ Display an chip that represents complex identity
 */
 
 /*
+    Position directions
+
+    Classes to change the directional position of an element<br>
+
+    .u-top-0 - Top 0
+    .u-top-xs - Top XS
+    .u-top-s - Top S
+    .u-top-m - Top M
+    .u-top-l - Top L
+    .u-top-xl - Top XL
+    .u-top-xxl - Top XXL
+    .u-bottom-0 - Bottom 0
+    .u-bottom-xs - Bottom XS
+    .u-bottom-s - Bottom S
+    .u-bottom-m - Bottom M
+    .u-bottom-l - Bottom L
+    .u-bottom-xl - Bottom XL
+    .u-bottom-xxl - Bottom XXL
+    .u-left-0 - Left 0
+    .u-left-xs - Left XS
+    .u-left-s - Left S
+    .u-left-m - Left M
+    .u-left-l - Left L
+    .u-left-xl - Left XL
+    .u-left-xxl - Left XXL
+    .u-right-0 - Right 0
+    .u-right-xs - Right XS
+    .u-right-s - Right S
+    .u-right-m - Right M
+    .u-right-l - Right L
+    .u-right-xl - Right XL
+    .u-right-xxl - Right XXL
+
+    Markup:
+    <div style="position: relative; margin: 1rem; padding: .125rem .25rem; background-color:gainsboro; border: 1px solid black; height: 100px;">
+        <div class="u-pos-absolute u-w-1 u-h-1 {{modifier_class}}" style="background-color:green;"></div>
+    </div>
+
+    Weight: 1
+
+    Styleguide utilities.position-directions
+*/
+
+/*
     Flexbox display
 
     Classes to make Flexbox containers<br>

--- a/stylus/utilities/position.styl
+++ b/stylus/utilities/position.styl
@@ -1,5 +1,6 @@
 @require '../settings/breakpoints'
 @require '../tools/mixins'
+@require './spaces.styl'
 /*------------------------------------*\
   Position utilities
 \*------------------------------------*/
@@ -27,7 +28,27 @@ props = {
     'position-static': 'pos-static',
 }
 
+directions = top bottom left right
+
+cssModulesDirectionsUtils()
+    for direction in directions
+        for kSpace, vSpace in spacing_values
+            :global(.u-{direction}-{kSpace})
+                {direction}: vSpace
+        :global(.u-{direction}-0)
+            {direction}: 0
+
+nativeDirectionsUtils()
+    for direction in directions
+        for kSpace, vSpace in spacing_values
+            .u-{direction}-{kSpace}
+                {direction}: vSpace
+        .u-{direction}-0
+            {direction}: 0
+
 if cssmodules == true
     cssModulesUtils(props, breakpoints)
+    cssModulesDirectionsUtils()
 else
     nativeUtils(props, breakpoints)
+    nativeDirectionsUtils()


### PR DESCRIPTION
This is useful in combination with position utilities. For example if I have:

```html
<div class="u-pos-relative">
  <div class="u-pos-absolute"></div>
</div>
```

And I want to position the children inside its parent, I can now use the new utilities:

```html
<div class="u-pos-relative">
  <div class="u-pos-absolute u-right-0 u-bottom-xs"></div>
</div>
```

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

See https://drazik.github.io/cozy-ui/styleguide/section-utilities.html. I'm not quite happy with the visual examples in the styleguide. If you have ideas to show the result in a better way, please tell me.

For info, the CSS sizes:

cozy-ui.min.css: 122K => 123K
cozy-ui.utils.min.css: 73K => 73K