### PR TITLE
feat: Memoize getCSSVariableValue

### DIFF
--- a/react/utils/color.js
+++ b/react/utils/color.js
@@ -1,5 +1,8 @@
-export const getCssVariableValue = variableName =>
+import memoize from 'lodash/memoize'
+
+export const getCssVariableValue = memoize(variableName =>
   window
     .getComputedStyle(document.body)
     .getPropertyValue(`--${variableName}`)
     .trim()
+)


### PR DESCRIPTION
fix #1153

If by any chance we change CSS variable values, the cache of the lodash memoized function
is accessible through memoizedFn.cache.

> Note: The cache is exposed as the cache property on the memoized function. Its creation may be customized by replacing the _.memoize.Cache constructor with one whose instances implement the Map method interface of clear, delete, get, has, and set.

https://lodash.com/docs/4.17.15#memoize