### PR TITLE
fix: Add example for PageLayout in styleguide

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -45,7 +45,8 @@ module.exports = {
         '../react/Layout/Layout.jsx',
         '../react/Hero/index.jsx',
         '../react/Sidebar/index.jsx',
-        '../react/Circle/index.jsx'
+        '../react/Circle/index.jsx',
+        '../react/Page/index.jsx'
       ]
     },
     {

--- a/react/Page/Readme.md
+++ b/react/Page/Readme.md
@@ -1,11 +1,13 @@
-The Page components enables to make layout that react well to keyboard appearing/disappearing.
+The Page components enables to build a layout that react well to keyboard appearing/disappearing.
 
 In the example below, the Button will appear at the bottom of the screen even if the PageContent
 does not takes all the space (the content grows to fill all the page). When the keyboard is
-shown, the Page real estate shrink and the Button will try to appear above the keyboard if it
+shown, the Page real estate shrinks and the Button will try to appear above the keyboard if it
 has enough space.
 
 ```jsx static
+const { PageLayout, PageContent, PageFooter } = require('./index');
+
 <PageLayout>
   <PageContent>Hello world !</PageContent>
   <PageFooter><Button>Click me !</Button></PageFooter>


### PR DESCRIPTION
The example had not been added to the styleguide.
Since the behavior is only shown on mobile, I only provided
a static example.

EDIT: Add viewable example URL https://ptbrowne.github.io/cozy-ui/react/#/PageLayout