### PR TITLE
fix(colors): Use css var instead of color

### DIFF
--- a/react/AppIcon/styles.styl
+++ b/react/AppIcon/styles.styl
@@ -33,5 +33,5 @@
 }
 
 .c-app-icon-default {
-    color silver
+    color var(--silver)
 }

--- a/react/AppSections/components/SmallAppItem.styl
+++ b/react/AppSections/components/SmallAppItem.styl
@@ -11,7 +11,7 @@
   height var(--item-size)
   align-items center
   justify-content flex-start
-  background white
+  background var(--white)
   box-shadow none
   border-radius 4px
   border solid 1px var(--silver)

--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -44,7 +44,7 @@
     border-left-color var(--primaryColor)
 
 .select-option--disabled
-    color silver
+    color var(--silver)
     cursor not-allowed
 
 .select-option__checkbox

--- a/react/Toggle/styles.styl
+++ b/react/Toggle/styles.styl
@@ -15,7 +15,7 @@
     width         100%
     height        100%
     border-radius rem(16)
-    background    silver
+    background    var(--silver)
     transition    all .2s ease-out
     cursor        pointer
 
@@ -30,7 +30,7 @@
     margin        auto
     border-radius 50%
     content       ''
-    background    white
+    background    var(--white)
     transition    all .2s ease-out
 
 .checkbox:checked + .label

--- a/react/Viewer/controls.styl
+++ b/react/Viewer/controls.styl
@@ -82,11 +82,11 @@
     background-color  transparent
 
     button
-        color white
+        color var(--white)
 
         &:hover
         &:focus
-            color white
+            color var(--white)
 
 .viewer-toolbar-close
     position         absolute
@@ -104,7 +104,7 @@
         height  3rem
 
     button
-        color white
+        color var(--white)
         background-color transparent
         border 0
 

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -10,13 +10,13 @@
     top             0
     bottom          0
     z-index         $overlay-index
-    background      charcoalGrey
+    background      var(--charcoalGrey)
     overflow        hidden
-    color           white
+    color           var(--white)
 
     &--light
-        background  white
-        color       black
+        background  var(--white)
+        color       var(--black)
 
 .viewer-imageviewer
 .viewer-noviewer
@@ -56,7 +56,7 @@
       overflow auto
 
       a
-        color azure
+        color var(--azure)
 
     +medium-screen()
       width 90%
@@ -76,8 +76,8 @@
 .viewer-pdfviewer-toolbar
   position absolute
   bottom 2rem
-  background charcoalGrey
-  color white
+  background var(--charcoalGrey)
+  color var(--white)
   border-radius .5rem
 
 .viewer-imageviewer

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -16,7 +16,7 @@ $alert
     right 0
     bottom rem(48)
     left 0
-    color white
+    color var(--white)
     opacity 1
     transition transform .2s ease-out, opacity .2s ease-out
     cursor default

--- a/stylus/components/badge.styl
+++ b/stylus/components/badge.styl
@@ -13,8 +13,8 @@ $badge
     width size
     height size
     border-radius 50%
-    background-color black
-    color white
+    background-color var(--black)
+    color var(--white)
     z-index 1
     display flex
     flex-direction row
@@ -23,7 +23,7 @@ $badge
     align-content center
     align-items center
     font-size rem(10)
-    border rem(1) solid white
+    border rem(1) solid var(--white)
     cursor inherit
 
 $badge--new

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -170,7 +170,7 @@ $button-alert
     border       0
     height       auto
     padding      rem(8 16)
-    background-color white
+    background-color var(--white)
     font-weight  bold
     font-size rem(14)
     text-decoration none
@@ -190,7 +190,7 @@ $button-alert--error
 
 $button-alert--info
     @extend           $button-alert
-    color             white
+    color             var(--white)
     background-color  var(--coolGrey)
 
     &[disabled]
@@ -199,7 +199,7 @@ $button-alert--info
             background-color var(--coolGrey)
 
     &:visited
-        color white
+        color var(--white)
 
     &:active
     &:hover
@@ -259,7 +259,7 @@ $button-client-mobile
     padding          rem(8 48 8 16)
     font-size        rem(16)
     font-weight      normal
-    color            white
+    color            var(--white)
     text-decoration  none
     text-transform   none
 
@@ -269,7 +269,7 @@ $button-client-mobile
             background-color var(--dodgerBlue)
 
     &:visited
-        color white
+        color var(--white)
 
     &:active
     &:hover
@@ -279,8 +279,8 @@ $button-client-mobile
     figure
         flex                0 0 rem(44)
         border-radius       rem(8)
-        border              rem(5) solid white
-        background-color    white
+        border              rem(5) solid var(--white)
+        background-color    var(--white)
 
         svg
             display block

--- a/stylus/components/circle.styl
+++ b/stylus/components/circle.styl
@@ -9,7 +9,7 @@ $circle
     width rem(40)
     height rem(40)
     background-color var(--dodgerBlue)
-    color white
+    color var(--white)
     font-size rem(18)
 
 $circle--xsmall

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -91,7 +91,7 @@ $form-text
         padding        rem(14) rem(12) rem(12) rem(14)
         box-sizing     border-box
         border-radius  rem(2)
-        background     white
+        background     var(--white)
         border         rem(1) solid var(--silver)
         color          var(--black)
 
@@ -116,7 +116,7 @@ $form-textarea
         padding        rem(14 12 12 14)
         box-sizing     border-box
         border-radius  rem(2)
-        background     white
+        background     var(--white)
         border         rem(1) solid var(--silver)
         color          var(--black)
 
@@ -141,7 +141,7 @@ $form-select
         padding              rem(12 12 14)
         border-radius        rem(4)
         box-sizing           border-box
-        background           white
+        background           var(--white)
         border               rem(1) solid var(--silver)
         color                var(--black)
         appearance           none
@@ -256,7 +256,7 @@ $input-text
     padding rem(13 16)
     box-sizing border-box
     border-radius rem(3)
-    background white
+    background var(--white)
     border rem(1) solid var(--silver)
     font-size rem(16)
     line-height 1.25
@@ -332,7 +332,7 @@ $checkbox
 
         &::before
             transition box-shadow 350ms cubic-bezier(0, .89, .44, 1)
-            background-color white
+            background-color var(--white)
             box-shadow inset 0 0 0 rem(2) var(--silver)
             transform translateY(-50%)
 

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -65,7 +65,7 @@ $modal
     border-radius rem(8)
     max-height 100%
     max-width 100%
-    background-color white
+    background-color var(--white)
     color var(--charcoalGrey)
 
 for size in 'xsmall' 'small' 'medium' 'large' 'xlarge' 'xxlarge'

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -23,7 +23,7 @@ $selectionbar
         align-items       center
         width             100%
         height            rem(52)
-        color             white
+        color             var(--white)
         background-color  var(--slateGrey)
         font-weight       bold
 
@@ -32,11 +32,11 @@ $selectionbar
             width             rem(4)
             height            rem(4)
             border-radius     50%
-            background-color  black
+            background-color  var(--black)
 
         button
             padding 0 rem(16)
-            color   white
+            color   var(--white)
 
         .coz-action-extra
             display none

--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -24,7 +24,7 @@ $wizard
         justify-content flex-start
 
 $wizard--waiting
-    color white
+    color var(--white)
     background-color var(--dodgerBlue)
 
 $wizard--scroll
@@ -79,7 +79,7 @@ $wizard-dual
 
     &:first-child
         justify-content flex-end
-        color white
+        color var(--white)
         background-color var(--dodgerBlue)
 
 $wizard-errors
@@ -180,7 +180,7 @@ $wizard-logo-badge
     right rem(-6)
     width rem(32)
     height rem(32)
-    border .125rem solid white
+    border .125rem solid var(--white)
     background-color var(--dodgerBlue)
     border-radius 50%
 
@@ -572,7 +572,7 @@ $wizard-agreements-icon
         display block
         width 100%
         height 100%
-        fill white
+        fill var(--white)
 
     +medium-screen()
         margin 0 rem(24) 0 0
@@ -611,7 +611,7 @@ $wizard-progress
         right 0
         opacity .24
         border-radius: rem(3)
-        background-color white
+        background-color var(--white)
 
     @media (max-width: 33.9375rem)
         margin rem(8 16 24)
@@ -624,7 +624,7 @@ $wizard-progress-bar
     z-index 1
     width 0
     height 100%
-    background-color white
+    background-color var(--white)
     border-radius rem(3)
     transition width .5s ease-out
 

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1144,27 +1144,27 @@ Display an chip that represents complex identity
 // @stylint off
 .wizard-agreements-item:nth-child(1)
     .wizard-agreements-icon
-        --bgcolor weirdGreen
+        --bgcolor var(--weirdGreen)
 
 .wizard-agreements-item:nth-child(2)
     .wizard-agreements-icon
-        --bgcolor mango
+        --bgcolor var(--mango)
 
 .wizard-agreements-item:nth-child(3)
     .wizard-agreements-icon
-        --bgcolor lightishPurple
+        --bgcolor var(--lightishPurple)
 
 .wizard-agreements-item:nth-child(4)
     .wizard-agreements-icon
-        --bgcolor pomegranate
+        --bgcolor var(--pomegranate)
 
 .wizard-agreements-item:nth-child(5)
     .wizard-agreements-icon
-        --bgcolor azure
+        --bgcolor var(--azure)
 
 .wizard-agreements-item:nth-child(6)
     .wizard-agreements-icon
-        --bgcolor brightSun
+        --bgcolor var(--brightSun)
 // @stylint on
 
 .wizard-updated

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -53,8 +53,8 @@ body
 // COLORS
 html,
 body
-    background-color white
-    color            black
+    background-color var(--white)
+    color            var(--black)
 
 // FORMS
 @require '../components/forms'
@@ -80,7 +80,7 @@ body
             border-radius rem(2)
 
         &::before
-            background-color  white
+            background-color  var(--white)
             box-shadow        inset 0 0 0 rem(2) var(--silver)
 
             &:hover

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -46,7 +46,7 @@ $elastic-content
                 linear-gradient(rgba(214, 216, 218, .25) 0, rgba(214, 216, 218, .25) 25%, rgba(255, 255, 255, 0) 26%, rgba(255, 255, 255, 0) 100%),
                 linear-gradient(rgba(255, 255, 255, 0) 0, rgba(255, 255, 255, 0) 74%, rgba(214, 216, 218, .25) 75%, rgba(214, 216, 218, .25) 100%) 0 100%
     background-repeat no-repeat
-    background-color white
+    background-color var(--white)
     background-size 100% rem(32), 100% rem(32), 100% rem(8), 100% rem(8)
     background-attachment local, local, scroll, scroll
     background-clip padding-box


### PR DESCRIPTION
We style used in a few place an harcorded version of our color. Since cozy-ui 22.3.1, we don't import our `palette.json` file. It results to have undefined color like `charcoalGrey`. To fix this issue, we need to use them as css var 