### PR TITLE
No shrink for Infos

### DIFF
--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -10,12 +10,7 @@ const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
     <div
       className={cx(
         styles['Infos'],
-        'u-flex',
-        'u-flex-column',
         'u-p-1',
-        'u-mih-2',
-        'u-flex-justify-center',
-        'u-ta-left',
         'u-stack-m',
         isImportant ? 'u-bg-chablis' : 'u-bg-paleGrey',
         className

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -3,6 +3,10 @@
 .Infos
     border-radius 4px
     max-width 32rem
+    display flex
+    flex-direction column
+    justify-content center
+    min-height 2rem
 
 .Infos__icon
   padding-top .2rem

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -7,6 +7,8 @@
     flex-direction column
     justify-content center
     min-height 2rem
+    flex-shrink 0
+
 
 .Infos__icon
   padding-top .2rem

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3069,24 +3069,24 @@ exports[`Icon should render examples: Icon 4`] = `
 exports[`Infos should render examples: Infos 1`] = `
 "<div>
   <div class=\\"u-stack-m\\">
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-paleGrey\\">
+    <div class=\\"styles__Infos___2ZZVs u-p-1 u-stack-m u-bg-paleGrey\\">
       <div class=\\"u-flex u-w-100\\">
         <div class=\\"u-text u-ta-left\\">My small persistent information! </div>
       </div>
     </div>
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-paleGrey u-maw-none u-bdrs-0\\">
+    <div class=\\"styles__Infos___2ZZVs u-p-1 u-stack-m u-bg-paleGrey u-maw-none u-bdrs-0\\">
       <div class=\\"u-flex u-w-100\\">
         <div class=\\"u-text u-ta-left\\">In a slightly different style</div>
       </div>
     </div>
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-paleGrey\\">
+    <div class=\\"styles__Infos___2ZZVs u-p-1 u-stack-m u-bg-paleGrey\\">
       <div class=\\"u-flex u-w-100\\"><svg class=\\"styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#info\\"></use>
         </svg>
         <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>
       </div>
     </div>
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-chablis\\">
+    <div class=\\"styles__Infos___2ZZVs u-p-1 u-stack-m u-bg-chablis\\">
       <div class=\\"u-title-h3 u-pomegranate\\">Infos breaking news</div>
       <div class=\\"u-flex u-w-100\\"><svg class=\\"styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#warning\\"></use>


### PR DESCRIPTION
Fix for https://github.com/cozy/cozy-ui/issues/1165, setting `flex-shrink: 0` prevents the Info container to be shrinked.