### PR TITLE
fix: Can not read propTypes of undefined

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -85,7 +85,8 @@ export const translate = () => WrappedComponent => {
     )
   }
   Wrapper.propTypes = {
-    ...WrappedComponent.propTypes,
+    //!TODO Remove this check after fixing https://github.com/cozy/cozy-drive/issues/1848
+    ...(WrappedComponent ? WrappedComponent.propTypes : undefined),
     ...i18nContextTypes
   }
   Wrapper.contextTypes = i18nContextTypes


### PR DESCRIPTION
I didn't take the time to dig on this one, but in Drive, we had a failing test because of that error. I don't know how we can have an `undefined` as `WrappedComponent` but this is the case 

This is a TMP fix, but since this regression was introduced by this commit https://github.com/cozy/cozy-ui/commit/91aa079 I'll dig into it later