### PR TITLE
fix(navitem): SVG is now well displayed on mobile

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -62,14 +62,12 @@ $nav-item-icon
 
     :hover > &
         color var(--charcoalGrey)
-
     +medium-screen()
         display block
-        font-size rem(24)
         margin-right 0
 
         svg
-            margin 0 auto
+            margin 0 auto 3px auto
             width rem(24)
             height rem(24)
 
@@ -113,7 +111,7 @@ $nav-link
         text-align           center
         color                var(--slateGrey)
         font-size            rem(10)
-        line-height          1
+        line-height          rem(12)
         background-position  center top
         background-size      rem(24)
 

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -67,7 +67,7 @@ $nav-item-icon
         margin-right 0
 
         svg
-            margin 0 auto 3px auto
+            margin 0 auto 3px
             width rem(24)
             height rem(24)
 


### PR DESCRIPTION
Since https://github.com/cozy/cozy-ui/pull/1083/files
there is a regression with the bottom nav bar on mobile.
 SVG and text were not correctly displayed.


So this fix is basically a kind of revert for medium_screen() 

<img width="431" alt="Capture d’écran 2019-09-24 à 17 31 14" src="https://user-images.githubusercontent.com/1107936/65526399-579e7d80-def1-11e9-801c-8f7f2e59cbec.png">
<img width="432" alt="Capture d’écran 2019-09-24 à 17 31 29" src="https://user-images.githubusercontent.com/1107936/65526400-579e7d80-def1-11e9-8324-731a21083b86.png">
