### PR TITLE
fix(ActionMenuItem): Handle onClick on Item

### DIFF
--- a/react/ActionMenu/Readme.md
+++ b/react/ActionMenu/Readme.md
@@ -1,4 +1,5 @@
 ### Classic
+
 ```
 const { ActionMenuItem } = require('.')
 const Icon = require('../Icon').default;
@@ -19,6 +20,7 @@ const hideMenu = () => setState({ menuDisplayed: false });
 ```
 
 ### With Header
+
 ```
 const { ActionMenuItem, ActionMenuHeader } = require('.')
 const Icon = require('../Icon').default;
@@ -38,6 +40,29 @@ const hideMenu = () => setState({ menuDisplayed: false });
       <ActionMenuItem left={<Icon icon='file' />}>Item 1</ActionMenuItem>
       <ActionMenuItem left={<Icon icon='right' />}>Item 2</ActionMenuItem>
       <ActionMenuItem left={<Icon icon='file' />}>Item 3</ActionMenuItem>
+  </ActionMenu>}
+</div>
+```
+
+### With Header & onClick
+
+```
+const { ActionMenuItem, ActionMenuHeader } = require('.')
+const Icon = require('../Icon').default;
+const Filename = require('../Filename').default;
+
+const showMenu = () => setState({ menuDisplayed: true })
+const hideMenu = () => setState({ menuDisplayed: false });
+
+<div>
+  <button onClick={showMenu}>Show action menu</button>
+  {state.menuDisplayed &&
+    <ActionMenu
+      onClose={hideMenu}>
+      <ActionMenuHeader>
+        <Filename icon="file" filename="my_awesome_paper" extension=".pdf" />
+      </ActionMenuHeader>
+      <ActionMenuItem onClick={() => alert('click')}left={<Icon icon='file' />}>Item 1</ActionMenuItem>
   </ActionMenu>}
 </div>
 ```

--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -167,9 +167,17 @@ const ActionMenuHeader = ({ children }) => {
   return <div className={styles['c-actionmenu-header']}>{children}</div>
 }
 
-const ActionMenuItem = ({ left, children, right }) => {
+const ActionMenuItem = ({ left, children, right, onClick }) => {
+  const onClickEnhanced = e => {
+    if (onClick) {
+      // we need to stop propagation here so that the menu doesn't close itself
+      e.stopPropagation()
+      onClick()
+    }
+  }
+
   return (
-    <Media className={styles['c-actionmenu-item']}>
+    <Media className={styles['c-actionmenu-item']} onClick={onClickEnhanced}>
       {left && <Img className="u-mh-1">{left}</Img>}
       <Bd className={left ? 'u-mr-1' : 'u-mh-1'}>{children}</Bd>
       {right && <Img className="u-mr-1">{right}</Img>}
@@ -177,5 +185,11 @@ const ActionMenuItem = ({ left, children, right }) => {
   )
 }
 
+ActionMenuItem.propTypes = {
+  left: PropTypes.node,
+  right: PropTypes.node,
+  children: PropTypes.node,
+  onClick: PropTypes.func
+}
 export default ActionMenu
 export { ActionMenuHeader, ActionMenuItem }

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -12,6 +12,12 @@ exports[`ActionMenu should render examples: ActionMenu 2`] = `
 </div>"
 `;
 
+exports[`ActionMenu should render examples: ActionMenu 3`] = `
+"<div>
+  <div><button>Show action menu</button></div>
+</div>"
+`;
+
 exports[`AppTitle should render examples: AppTitle 1`] = `
 "<div>
   <h1 class=\\"u-title-h1 styles__c-apptitle___eqV9l\\">Drive</h1>


### PR DESCRIPTION
Before this commit, if we attached an onClick to an
ActionMenuItem, the onClick was not called since
the propagation of the event was not stopped
resulting in the close of the menu instead of the
call of the onClick props.

With this fix, we stop the propagation if an onClick
is here, and we call it after.

https://crash--.github.io/cozy-ui/react/#actionmenu