### PR TITLE
feat(utilities): Add 1-half to dimensions scale

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1745,8 +1745,11 @@ Display an chip that represents complex identity
     [Can be used with breakpoints modifier suffixes (`-t`,`-s`,`-m`)](section-settings.html#kssref-settings-breakpoints)
 
     .u-w-auto - Cancel width
+    .u-w-half - Apply width half step in scale (0.5rem = 8px)
     .u-w-1 - Apply width 1st step in scale (1rem = 16px)
+    .u-w-1-half - Apply width 1st step + half in scale (1.5rem = 24px)
     .u-w-2 - Apply width 2nd step in scale (2rem = 32px)
+    .u-w-2-half - Apply width 2nd step + half in scale (2.5rem = 40px)
     .u-w-3 - Apply width 3rd step in scale (4rem = 64px)
     .u-w-4 - Apply width 4th step in scale (8rem = 128px)
     .u-w-5 - Apply width 5th step in scale (16rem = 256px)
@@ -1756,8 +1759,11 @@ Display an chip that represents complex identity
     .u-w-9 - Apply width 9th step in scale (96rem = 1536px)
     .u-w-100 - Apply width 100%
     .u-h-auto - Cancel height
+    .u-h-half - Apply height half step in scale (0.5rem = 8px)
     .u-h-1 - Apply height 1st step in scale (1rem = 16px)
+    .u-h-1-half - Apply height 1st step + half in scale (1.5rem = 24px)
     .u-h-2 - Apply height 2nd step in scale (2rem = 32px)
+    .u-h-2-half - Apply height 2nd step + half in scale (2.5rem = 40px)
     .u-h-3 - Apply height 3rd step in scale (4rem = 64px)
     .u-h-4 - Apply height 4th step in scale (8rem = 128px)
     .u-h-5 - Apply height 5th step in scale (16rem = 256px)
@@ -1782,8 +1788,11 @@ Display an chip that represents complex identity
     [Can be used with breakpoints modifier suffixes (`-t`,`-s`,`-m`)](section-settings.html#kssref-settings-breakpoints)
 
     .u-miw-auto - Cancel min-width
+    .u-miw-half - Apply min-width half step in scale (0.5rem = 8px)
     .u-miw-1 - Apply min-width 1st step in scale (1rem = 16px)
+    .u-miw-1-half - Apply min-width 1st step + half step in scale (1.5rem = 24px)
     .u-miw-2 - Apply min-width 2nd step in scale (2rem = 32px)
+    .u-miw-2-half - Apply min-width 2nd step + half step in scale (2.5rem = 40px)
     .u-miw-3 - Apply min-width 3rd step in scale (4rem = 64px)
     .u-miw-4 - Apply min-width 4th step in scale (8rem = 128px)
     .u-miw-5 - Apply min-width 5th step in scale (16rem = 256px)
@@ -1793,8 +1802,11 @@ Display an chip that represents complex identity
     .u-miw-9 - Apply min-width 9th step in scale (96rem = 1536px)
     .u-miw-100 - Apply min-width 100%
     .u-mih-auto - Cancel min-height
+    .u-mih-half - Apply min-height half step in scale (0.5rem = 8px)
     .u-mih-1 - Apply min-height 1st step in scale (1rem = 16px)
+    .u-mih-1-half - Apply min-height 1st step + half step in scale (1.5rem = 24px)
     .u-mih-2 - Apply min-height 2nd step in scale (2rem = 32px)
+    .u-mih-2-half - Apply min-height 2nd step + half step in scale (2.5rem = 40px)
     .u-mih-3 - Apply min-height 3rd step in scale (4rem = 64px)
     .u-mih-4 - Apply min-height 4th step in scale (8rem = 128px)
     .u-mih-5 - Apply min-height 5th step in scale (16rem = 256px)

--- a/stylus/utilities/dimensions.styl
+++ b/stylus/utilities/dimensions.styl
@@ -12,8 +12,11 @@ minmax = {
 minmaxscale = {
  'none': none, // Used for max-width
  'auto': auto, // Used for min-width, see is_valid below
+ 'half': rem(8),
  '1': rem(16),
+ '1-half': rem(24),
  '2': rem(32),
+ '2-half': rem(40),
  '3': rem(64),
  '4': rem(128),
  '5': rem(256),
@@ -31,8 +34,11 @@ dimensions = {
 
 dimensionsscale = {
  'auto': auto,
+ 'half': rem(8),
  '1': rem(16),
+ '1-half': rem(24),
  '2': rem(32),
+ '2-half': rem(40),
  '3': rem(64),
  '4': rem(128),
  '5': rem(256),


### PR DESCRIPTION
For the needs of the password manager's read-only identifier field, we need  an icon with a `1.5rem` width (see https://zpl.io/VD1N3rr). This step was not existing on the dimensions scale, which surprised me since we have it in margin/padding scales. This PR adds it.

I didn't add others « half » steps that are present for margin and padding but not for dimensions (`half` and `2-half`). Do you think we should add it now?

See https://drazik.github.io/cozy-ui/styleguide/section-utilities.html#kssref-utilities-dimensions