### PR TITLE
fix: Set defaultProps to ModalButtons

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -258,6 +258,11 @@ const ModalButtons = ({
   </div>
 )
 
+ModalButtons.defaultProps = {
+  primaryType: 'regular',
+  secondaryType: 'secondary'
+}
+
 class Modal extends Component {
   constructor(props) {
     super(props)


### PR DESCRIPTION
BREAKING CHANGE: ModalButtons now have default props
for primaryType & secondaryType same to Modale


ATM if we use `ModalButtons` manually, we have to set `primaryTheme` and `secondaryTheme`. It should be set by default to the same as `Modal`