### PR TITLE
feat: Menu improvements

### DIFF
--- a/docs/false.js
+++ b/docs/false.js
@@ -1,1 +1,0 @@
-module.exports = false

--- a/docs/isTesting.js
+++ b/docs/isTesting.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+  return (
+    navigator && navigator.userAgent && navigator.userAgent.includes('Argos')
+  )
+}

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -163,7 +163,7 @@ module.exports = {
   usageMode: 'collapse',
   context: {
     utils: path.resolve(__dirname, 'utils'),
-    isTesting: path.resolve(__dirname, 'false'),
+    isTesting: path.resolve(__dirname, 'isTesting'),
     content: path.resolve(__dirname, 'fixtures/content')
   }
 }

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -27,7 +27,12 @@ export const fakeIntentCreate = (action, doctype, options) => {
       })
 
       ReactDOM.render(
-        React.createElement(IntentExample, { onComplete, action, doctype, options }),
+        React.createElement(IntentExample, {
+          onComplete,
+          action,
+          doctype,
+          options
+        }),
         iframe.contentDocument.body
       )
     }
@@ -37,6 +42,6 @@ export const fakeIntentCreate = (action, doctype, options) => {
   return p
 }
 
-export const t = (path) => {
+export const t = path => {
   return get(translations, path)
 }

--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -8,7 +8,7 @@ an item in the `Menu`.
 the item is `disabled`.
 
 ```
-const { MenuItem } = require('.');
+const { default: Menu, MenuItem } = require('.');
 const Button = require('../Button').default;
 const showItem = itemData => alert(JSON.stringify(itemData));
 const showWarning = itemData => alert(itemData + ' is disabled');
@@ -27,7 +27,7 @@ const showWarning = itemData => alert(itemData + ' is disabled');
 Use the `position` attribute to put the menu to the right.
 
 ```
-const { MenuItem } = require('.');
+const { default: Menu, MenuItem } = require('.');
 const { Icon } = require('../Icon');
 
 <Menu position='right' label='Click me !' onSelect={ itemData => alert(JSON.stringify(itemData)) }>
@@ -41,7 +41,7 @@ Use the `component` attribute if you want to use a custom component for the
 opener.
 
 ```
-const { MenuItem } = require('.');
+const { default: Menu, MenuItem } = require('.');
 const { Button } = require('../Button');
 
 <Menu component={<Button label="Greetings with custom component"/>} onSelect={ itemData => alert(JSON.stringify(itemData)) }>

--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -13,7 +13,7 @@ const Button = require('../Button').default;
 const showItem = itemData => alert(JSON.stringify(itemData));
 const showWarning = itemData => alert(itemData + ' is disabled');
 
-<Menu id='menu' label='Click me !' onSelect={ showItem } onSelectDisabled={ showWarning }>
+<Menu initialOpen={isTesting()} id='menu' label='Click me !' onSelect={ showItem } onSelectDisabled={ showWarning }>
   <MenuItem data='hello'>Hello !</MenuItem>
   <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
   <hr />
@@ -30,7 +30,7 @@ Use the `position` attribute to put the menu to the right.
 const { default: Menu, MenuItem } = require('.');
 const { Icon } = require('../Icon');
 
-<Menu position='right' label='Click me !' onSelect={ itemData => alert(JSON.stringify(itemData)) }>
+<Menu initialOpen={isTesting()} position='right' label='Click me !' onSelect={ itemData => alert(JSON.stringify(itemData)) }>
   <MenuItem data='hello'>Hello !</MenuItem>
   <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
   <MenuItem data='hola'>¡Hola!</MenuItem>
@@ -44,7 +44,7 @@ opener.
 const { default: Menu, MenuItem } = require('.');
 const { Button } = require('../Button');
 
-<Menu component={<Button label="Greetings with custom component"/>} onSelect={ itemData => alert(JSON.stringify(itemData)) }>
+<Menu initialOpen={isTesting()} component={<Button label="Greetings with custom component"/>} onSelect={ itemData => alert(JSON.stringify(itemData)) }>
   <MenuItem data='hello'>Hello !</MenuItem>
   <MenuItem disabled data='bonjour'>Bonjour !</MenuItem>
   <MenuItem data='hola'>¡Hola!</MenuItem>

--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -34,7 +34,12 @@ class MenuItem extends Component {
 }
 
 class Menu extends Component {
-  state = { opened: false }
+  constructor(props, context) {
+    super(props, context)
+    this.state = {
+      opened: props.initialOpen
+    }
+  }
 
   toggle = () => (this.state.opened ? this.close() : this.open())
 
@@ -156,7 +161,8 @@ Menu.defaultProps = {
   onSelect: null,
   onSelectDisabled: null,
   itemsStyle: {},
-  popover: false
+  popover: false,
+  initialOpen: false
 }
 
 Menu.propTypes = {
@@ -173,8 +179,10 @@ Menu.propTypes = {
   onSelectDisabled: PropTypes.func,
   /** Global Styles for MenuItems */
   itemsStyle: PropTypes.object,
-  /** if you need fixed menu */
-  popover: PropTypes.bool
+  /** If you need fixed menu */
+  popover: PropTypes.bool,
+  /** Whether the menu should be initially opened */
+  initialOpen: PropTypes.bool
 }
 
 Menu.MenuItem = MenuItem

--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -6,6 +6,8 @@ import MenuButton from './Button'
 import PropTypes from 'prop-types'
 import { Media, Bd, Img } from '../Media'
 import Popover from '../Popover'
+import migrateProps from '../helpers/migrateProps'
+
 class MenuItem extends Component {
   render() {
     const { disabled, className, children, icon, ...props } = this.props
@@ -95,7 +97,7 @@ class Menu extends Component {
 
   render() {
     const {
-      text,
+      label,
       disabled,
       className,
       buttonClassName,
@@ -132,7 +134,7 @@ class Menu extends Component {
           <MenuButton
             disabled={disabled}
             onClick={this.toggle}
-            label={text}
+            text={label}
             buttonClassName={buttonClassName}
           />
         ) : (
@@ -182,11 +184,13 @@ Menu.propTypes = {
   /** If you need fixed menu */
   popover: PropTypes.bool,
   /** Whether the menu should be initially opened */
-  initialOpen: PropTypes.bool
+  initialOpen: PropTypes.bool,
+  /** Text inside the button */
+  label: PropTypes.string
 }
 
 Menu.MenuItem = MenuItem
 Menu.MenuButton = MenuButton
-export default Menu
+export default migrateProps([{ src: 'text', dest: 'label' }])(Menu)
 
 export { MenuItem, MenuButton }

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -45,6 +45,7 @@ $paddingItem = rem(8)
     cursor pointer
     padding   $paddingItem
     line-height 1.15
+    color var(--charcoalGrey)
 
 .c-menu__item-icon
     $marginIcon = rem(12)
@@ -52,6 +53,7 @@ $paddingItem = rem(8)
     margin-right $marginIcon
     // we need to compensate for the already present margin
     margin-left $marginIcon - $paddingItem
+    color var(--slateGrey)
 
     svg
         width 1em

--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -233,7 +233,7 @@ options[0].fixed = true
 options[options.length - 1].fixed = true;
 
 <SelectBoxWithFixedOptions
-  menuIsOpen={isTesting ? true : undefined}
+  menuIsOpen={isTesting() ? true : undefined}
   options={options} />
 ```
 

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3262,19 +3262,48 @@ exports[`ListItemText should render examples: ListItemText 3`] = `
 
 exports[`Menu should render examples: Menu 1`] = `
 "<div>
-  <div class=\\"styles__c-menu___2YTiU styles__c-menu--left___3wamY\\" id=\\"menu\\" label=\\"Click me !\\"><button role=\\"button\\" class=\\"c-btn styles__c-menu__btn___18qF8\\"></button></div>
+  <div class=\\"styles__c-menu___2YTiU styles__c-menu--left___3wamY\\" id=\\"menu\\"><button role=\\"button\\" class=\\"c-btn styles__c-menu__btn___18qF8\\">Click me !</button>
+    <div class=\\"styles__c-menu__inner___2g_mC styles__c-menu__inner--opened___sJHKG\\">
+      <div data=\\"hello\\" class=\\"styles__c-menu__item___1sXjs\\">Hello !</div>
+      <div data=\\"bonjour\\" class=\\"styles__c-menu__item___1sXjs styles__c-menu__item--disabled___OHDks\\">Bonjour !</div>
+      <hr>
+      <div data=\\"hola\\" class=\\"styles__c-menu__item___1sXjs\\">
+        <div class=\\"styles__media___cSJMp styles__media--top___K9w0I\\">
+          <div class=\\"styles__img___3SHpG styles__c-menu__item-icon___kzdkW\\"><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+              <use xlink:href=\\"#paperplane\\"></use>
+            </svg></div>
+          <div class=\\"styles__bd___1Uv-F\\">
+            <div>¡Hola!</div>
+            <div>¿Qué tal?</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>"
 `;
 
 exports[`Menu should render examples: Menu 2`] = `
 "<div>
-  <div class=\\"styles__c-menu___2YTiU styles__c-menu--right___3wxbb\\" label=\\"Click me !\\"><button role=\\"button\\" class=\\"c-btn styles__c-menu__btn___18qF8\\"></button></div>
+  <div class=\\"styles__c-menu___2YTiU styles__c-menu--right___3wxbb\\"><button role=\\"button\\" class=\\"c-btn styles__c-menu__btn___18qF8\\">Click me !</button>
+    <div class=\\"styles__c-menu__inner___2g_mC styles__c-menu__inner--opened___sJHKG\\">
+      <div data=\\"hello\\" class=\\"styles__c-menu__item___1sXjs\\">Hello !</div>
+      <div data=\\"bonjour\\" class=\\"styles__c-menu__item___1sXjs styles__c-menu__item--disabled___OHDks\\">Bonjour !</div>
+      <div data=\\"hola\\" class=\\"styles__c-menu__item___1sXjs\\">¡Hola!</div>
+    </div>
+  </div>
 </div>"
 `;
 
 exports[`Menu should render examples: Menu 3`] = `
 "<div>
-  <div class=\\"styles__c-menu___2YTiU styles__c-menu--left___3wamY\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>Greetings with custom component</span></span></button></div>
+  <div class=\\"styles__c-menu___2YTiU styles__c-menu--left___3wamY\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>Greetings with custom component</span></span></button>
+    <div class=\\"styles__c-menu__inner___2g_mC styles__c-menu__inner--opened___sJHKG\\">
+      <div data=\\"hello\\" class=\\"styles__c-menu__item___1sXjs\\">Hello !</div>
+      <div data=\\"bonjour\\" class=\\"styles__c-menu__item___1sXjs styles__c-menu__item--disabled___OHDks\\">Bonjour !</div>
+      <div data=\\"hola\\" class=\\"styles__c-menu__item___1sXjs\\">¡Hola!</div>
+    </div>
+  </div>
 </div>"
 `;
 

--- a/react/helpers/migrateProps.jsx
+++ b/react/helpers/migrateProps.jsx
@@ -77,7 +77,7 @@ const migrate = (oldProps, options) => {
  * ```
  *
  * @param  {Array} migrateOptions - Prop migrations that will be done on the old props
- * @return {[type]}         [description]
+ * @return {HOC}
  */
 export default migrateOptions => Wrapped => oldProps => {
   const newProps = migrate(oldProps, migrateOptions, Wrapped)

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -86,6 +86,10 @@ const prepareFS = async (styleguideDir, screenshotDir) => {
 const prepareBrowser = async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
+  // Put Argos in user agent
+  await page.setUserAgent(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36; Argos'
+  )
   await page.setDefaultNavigationTimeout(0)
   console.log('Browser opened and set up')
   return { browser, page }

--- a/stylus/components/menu.styl
+++ b/stylus/components/menu.styl
@@ -2,24 +2,6 @@
 @require '../tools/mixins'
 
 $menu
-    // These styles are needed for the menu to work and come directly from bosonic's source
-    // TODO: find a better way for bosonic to share its styling
-    // @stylint off
-    // because styling doesn't support custom elements
-    b-menu-button
-        position relative
-
-    b-menu-button > b-listbox
-        display none
-        position absolute
-
-    b-menu-button[open] > b-listbox
-        display block
-
-    b-item
-        display block
-    // @stylint on
-
     .coz-menu
         @extend $popover
         right 0

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -14,13 +14,6 @@ $popover
     border-radius     rem(4)
     box-shadow        rem(0 1 3 0) rgba(50, 54, 63, .19), rem(0 6 18 0) rgba(50, 54, 63, .19)
     background-color  var(--white)
-    // @stylint off
-    // because Stylint doesn't support custom elements
-    b-item:hover
-    b-item:focus
-        background-color var(--paleGrey)
-        outline          none
-    // @stylint on
 
     hr
         margin      rem(5) 0

--- a/test/testFromStyleguidist.js
+++ b/test/testFromStyleguidist.js
@@ -166,7 +166,7 @@ const testFromStyleguidist = (name, markdown, require) => {
       Text,
       Textarea,
       Toggle,
-      true
+      () => true
     )
 
   const options = {


### PR DESCRIPTION
- Fix the colors (fix #1170), charcoalGrey for text, slateGrey for icon
- Menu used in examples was the one from material-ui, styleguidist got confused when
  auto-providing the `Menu` variable inside the examples. Requiring explicitly fixes
  it (fix #1169).
- Have the menu automatically opened for Argos (provided the isArgos() util that can
  be used in examples for this kind of behavior. Based on user-agent)

Preview here : https://ptbrowne.github.io/cozy-ui/react/#/Menu