### PR TITLE
Composite row

### DIFF
--- a/docs/components/Variants.jsx
+++ b/docs/components/Variants.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+/**
+ * Useful for components for which there are variants, this component
+ * takes an object representing a variant (a mapping from string to boolean
+ * representing features of the component that are activated in the variant),
+ * shows checkboxes showing which feature is activated and through the onChange
+ * prop, enables the update of the variant.
+ *
+ * @param  {Object.<string, boolean>} options.variant - Which features are activated in the variant
+ * @param  {Function} options.onChange - Called with the updated variant when a checkbox is clicked
+ */
+const VariantInfo = ({ variant, onChange }) => {
+  const setElement = (element, newValue) => {
+    const newVariant = { ...variant, [element]: newValue }
+    onChange(newVariant)
+  }
+  return (
+    <div className="u-m-1">
+      {Object.entries(variant).map(([element, value], i) => (
+        <React.Fragment key={i}>
+          {element}:{' '}
+          <input
+            onClick={() => setElement(element, !value)}
+            className="u-mr-1"
+            type="checkbox"
+            checked={value}
+          />
+        </React.Fragment>
+      ))}
+    </div>
+  )
+}
+
+VariantInfo.propTypes = {
+  /** Called with the updated variant when a checkbox is clicked */
+  onChange: PropTypes.func.isRequired,
+  /** @type {Object.<string, boolean>} Which features are activated in the variant */
+  variant: PropTypes.object.isRequired
+}
+
+const Variants = ({ initialVariants, children }) => {
+  const [variants, setVariants] = useState(initialVariants)
+
+  const onChangeVariant = (updatedVariant, i) => {
+    setVariants([
+      ...variants.slice(0, i),
+      updatedVariant,
+      ...variants.slice(i + 1)
+    ])
+  }
+
+  return (
+    <>
+      {variants.map((variant, i) => (
+        <React.Fragment key={i}>
+          <VariantInfo
+            variant={variant}
+            onChange={variant => onChangeVariant(variant, i)}
+          />
+          {children(variant)}
+        </React.Fragment>
+      ))}
+    </>
+  )
+}
+
+export default Variants

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -15,6 +15,7 @@ module.exports = {
         '../react/Button/index.jsx',
         '../react/ButtonAction/index.jsx',
         '../react/Card/index.jsx',
+        '../react/CompositeRow/index.jsx',
         '../react/InlineCard/index.jsx',
         '../react/Chip/index.jsx',
         '../react/Icon/index.jsx',

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -3,6 +3,9 @@ const webpack = require('webpack')
 
 module.exports = {
   resolve: {
+    alias: {
+      docs: __dirname
+    },
     extensions: ['.jsx', '.js', '.json', '.styl']
   },
   module: {

--- a/react/CompositeRow/Readme.md
+++ b/react/CompositeRow/Readme.md
@@ -1,0 +1,96 @@
+```js
+import { Media, Bd, Img } from '../Media'
+import UIChip from '../Chip'
+import { Bold, Caption } from '../Text'
+import Icon from '../Icon'
+import Circle from '../Circle'
+
+import Variants from 'docs/components/Variants'
+
+const fnacLogoURL = 'https://upload.wikimedia.org/wikipedia/commons/2/2e/Fnac_Logo.svg';
+
+const Chip = React.memo(({ children, ...props }) => (
+  <UIChip
+    variant="outlined"
+    className='u-mr-0 u-mb-0'
+    size='small'
+    children={children} {...props}
+  />
+))
+
+const ChipImage = React.memo(({ src }) => (
+  <img className='u-mr-half' src={src} height='50%' />
+))
+
+const compositeStyle = {
+  boxShadow: '0 0 10px rgba(0, 0, 0, 0.15)',
+  boxSizing: 'border-box', 
+}
+
+
+const CompositeImage = () => (
+  <Circle backgroundColor='var(--melon)'>
+    <Icon icon='wallet' />
+  </Circle>
+)
+
+const Amount = () => (
+  <Bold tag='span'>12,15€</Bold>
+)
+
+const onDotsClick = () => { alert('clicked dots !')}
+const Dots = () => (
+  <Icon className="u-c-pointer" color="var(--coolGrey)" icon="dots" onClick={onDotsClick}/>
+)
+
+const Chips = () => (
+  <Bd className='u-row-xs'>
+    <Chip>
+      <ChipImage src={fnacLogoURL} /> Fnac
+    </Chip>
+    <Chip>
+      <ChipImage src={fnacLogoURL} /> Fnac
+    </Chip>
+  </Bd>
+)
+
+const Actions = ({ extraInformation }) => (
+  <Media>
+    <Bd className='u-row-xs'>
+      <Chip>
+        <ChipImage src={fnacLogoURL} /> Fnac
+      </Chip>
+      <Chip>
+        <ChipImage src={fnacLogoURL} /> Fnac
+      </Chip>
+    </Bd>
+    { extraInformation ? <Shrink><Caption>Extra information to the right of the card</Caption></Shrink> : null }
+  </Media>
+)
+
+const Shrink = Img
+
+const initialVariants = [
+  { chips: true, secondaryText: true, dots: true, icon: true, extraInformation: true },
+  { chips: false, secondaryText: true, icon: true, dots: true },
+  { dense: true, chips: false, secondaryText: false, dots: false, icon: true },
+  { chips: false, secondaryText: false, dots: false, icon: false },
+  { dense: true, chips: false, secondaryText: false, dots: false, icon: false }
+];
+
+<Variants initialVariants={initialVariants}>{
+  variant => (
+    <CompositeRow
+      primaryText='Primary text'
+      secondaryText={variant.secondaryText ? 'Secondary Text' : null}
+      image={variant.icon ? <CompositeImage /> : null}
+      right={<>
+        <Shrink><Amount /></Shrink>
+        { variant.dots ? <Shrink><Dots /></Shrink> : null }
+      </>}
+      actions={variant.chips ? <Actions extraInformation={variant.extraInformation} /> : null}
+      dense={variant.dense}
+      style={compositeStyle}
+    />
+  )
+}</Variants>

--- a/react/CompositeRow/index.jsx
+++ b/react/CompositeRow/index.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import { Media, Bd, Img } from '../Media'
+import { Text, Caption } from '../Text'
+
+const denseStyle = { height: '48px' }
+
+/**
+ * A ready-made row layout for presenting rich information.
+ */
+const CompositeRow = ({
+  style,
+  className,
+  primaryText,
+  secondaryText,
+  image,
+  right,
+  actions,
+  dense
+}) => {
+  return (
+    <Media
+      className={cx('u-mb-2 ', className, dense ? 'u-ph-1' : 'u-p-1')}
+      style={dense ? Object.assign({}, denseStyle, style) : style}
+    >
+      <div className="u-media u-media-grow u-row-m">
+        {image ? <Img className="u-flex-self-start">{image}</Img> : null}
+        <div className="u-media-grow u-stack-xs">
+          <div className="u-media u-row-m">
+            <Bd>
+              <Text>{primaryText}</Text>
+              {secondaryText ? <Caption>{secondaryText}</Caption> : null}
+            </Bd>
+            {right}
+          </div>
+          {actions}
+        </div>
+      </div>
+    </Media>
+  )
+}
+
+CompositeRow.propTypes = {
+  /** Custom CSS */
+  style: PropTypes.object,
+  /** Custom class */
+  className: PropTypes.string,
+  /** First line */
+  primaryText: PropTypes.element,
+  /** Second line */
+  secondaryText: PropTypes.element,
+  /** Image to the left of the row */
+  image: PropTypes.element,
+  /**
+   * Actions are shown below primary and secondary texts. Pass fragment for multiple elements.
+   * Good to use with Chips.
+   */
+  actions: PropTypes.element,
+  /* Element(s) to the show to the right of the CompositeRow */
+  right: PropTypes.element,
+  /** Row height will be fixed to 48px */
+  dense: PropTypes.bool
+}
+
+export default CompositeRow


### PR DESCRIPTION


Add to styleguide different variants of composite row layouts that Joel has on Sketch/Zeplin.

Visible on https://ptbrowne.github.io/cozy-ui/react/#/CompositeRow


- [x] Montant doit être aligné au milieu avec le Primary/Secondary text
- [x] Icône ne doit pas dépasser du cadre même quand la card est petite
- [x] Sans secondary text, le Primary text doit être aligné au milieu avec l'icône

~~I find the implementation a bit verbose, I will try to use utility classes instead of Bd/Img/Media to have less nesting.~~ With the help of utility classes, nesting is reduced, see https://github.com/cozy/cozy-ui/pull/1190/commits/4d76fc38209eb98d6b308431563e29de53d4949c

I also want to gather feedback on the following API: 

Proposition of names for the component (with my preference next to it):

- ComplexRow -
- RichRow +
- InfoRow -
- CompositeRow ++
- ListItem ++ (coherence with MaterialUI)

Proposition of props:

<p align='center'><img width="532" alt="image" src="https://user-images.githubusercontent.com/465582/66806029-c6865980-ef26-11e9-82a2-500892b74d5e.png"></p>




- I hesitate on "chips" since we maybe would want to have another kind of components there, do you have any thoughts on this @joel-costa  ? Alternatives

  - `chips` - 
  - `belowLeft` +
  - `extra` -
  - `belowRight` +

I think `belowLeft` and `belowRight` are actually better since they are more generic and at the same time, they are more descriptive.

Utility classes introduced:

- u-media, u-media-grow, u-media-fixed (Bd -> u-media-grow, Img -> u-media-fixed)

This is more flexible than Bd, Img since you can compose classes without introducing more divs

```patch
 <Media>
-  <Bd>
-    <Media>
-    </Media>
-  </Bd>
+  <div class='u-media-grow u-media'>
+  </div>
 </Media>
```

- u-row + variants (like u-stack but horizontal) cc @Crash-- ;)

Related work:

- MaterialUI ListItem : https://material-ui.com/components/lists/