### PR TITLE
fix(InputGroup): Now accept a classname

### DIFF
--- a/react/InputGroup/Readme.md
+++ b/react/InputGroup/Readme.md
@@ -87,3 +87,17 @@ const Input = require('../Input').default;
   </div>
 </form>
 ```
+
+### InputGroup with a prepended text and a custom classname (border-radius)
+
+```
+const { Bold } = require('../Text');
+const Input = require('../Input').default;
+<form>
+  <div>
+    <InputGroup prepend={<Bold className="u-pl-1">text</Bold>} className="u-bdrs-3">
+      <Input placeholder="Placeholder" />
+    </InputGroup>
+  </div>
+</form>
+```

--- a/react/InputGroup/index.jsx
+++ b/react/InputGroup/index.jsx
@@ -22,15 +22,26 @@ class InputGroup extends Component {
   }
 
   render() {
-    const { children, prepend, append, error, fullwidth } = this.props
+    const {
+      children,
+      prepend,
+      append,
+      error,
+      fullwidth,
+      className
+    } = this.props
     const { focused } = this.state
     return (
       <div
-        className={cx(styles['c-inputgroup'], {
-          [styles['c-inputgroup--error']]: error,
-          [styles['c-inputgroup--fullwidth']]: fullwidth,
-          [styles['c-inputgroup--focus']]: focused
-        })}
+        className={cx(
+          styles['c-inputgroup'],
+          {
+            [styles['c-inputgroup--error']]: error,
+            [styles['c-inputgroup--fullwidth']]: fullwidth,
+            [styles['c-inputgroup--focus']]: focused
+          },
+          className
+        )}
       >
         {prepend && (
           <div className={styles['c-inputgroup-side']}>{prepend}</div>
@@ -46,7 +57,8 @@ InputGroup.propTypes = {
   prepend: PropTypes.object,
   append: PropTypes.object,
   error: PropTypes.bool,
-  fullwidth: PropTypes.bool
+  fullwidth: PropTypes.bool,
+  className: PropTypes.string
 }
 
 InputGroup.defaultProps = {

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3256,6 +3256,21 @@ exports[`InputGroup should render examples: InputGroup 6`] = `
 </div>"
 `;
 
+exports[`InputGroup should render examples: InputGroup 7`] = `
+"<div>
+  <form>
+    <div>
+      <div class=\\"styles__c-inputgroup___12OVJ u-bdrs-3\\">
+        <div class=\\"styles__c-inputgroup-side___60v0v\\">
+          <div class=\\"u-title-h4 u-pl-1\\">text</div>
+        </div>
+        <div class=\\"styles__c-inputgroup-main___1LP4B\\"><input type=\\"text\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"Placeholder\\" value=\\"\\"></div>
+      </div>
+    </div>
+  </form>
+</div>"
+`;
+
 exports[`Label should render examples: Label 1`] = `
 "<div>
   <form>


### PR DESCRIPTION
Currently there is no way to pass a classname to our `InputGroup` component. 

I needed it to customize the border radius of this component 

https://crash--.github.io/cozy-ui/react/#inputgroup