### PR TITLE
chore(styleguide): Fix icon in BarButton examples

### DIFF
--- a/react/BarButton/Readme.md
+++ b/react/BarButton/Readme.md
@@ -15,7 +15,7 @@ This component is used to display a back Button into the Cozy Bar.
 ## `disabled`
 
 ```jsx
-<BarButton icon="back" disabled />
+<BarButton icon="previous" disabled />
 ```
 
 ## `href`

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -99,7 +99,7 @@ exports[`Badge should render examples: Badge 1`] = `
 exports[`BarButton should render examples: BarButton 1`] = `
 "<div>
   <div class=\\"styles__c-bar-btn___1Jc6J\\"><svg class=\\"u-silver styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
-      <use xlink:href=\\"#back\\"></use>
+      <use xlink:href=\\"#previous\\"></use>
     </svg></div>
 </div>"
 `;


### PR DESCRIPTION
We used an outdated icon in a BarButton example. This just fixes it.

https://drazik.github.io/cozy-ui/react/