### PR TITLE
fix(Alerter): Add the safe-area-bottom

### DIFF
--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -14,7 +14,7 @@ $alert
     position fixed
     z-index $alert-index-mobile
     right 0
-    bottom rem(48)
+    bottom calc(3rem + env(safe-area-inset-bottom))
     left 0
     color var(--white)
     opacity 1


### PR DESCRIPTION
Currently, our Alerter doesn't deal with safe-bottom-area on mobile. 

The result is pretty easy guessable. If the text is only on one line, we don't see it. 
