### PR TITLE
feat: Expose react-styleguidist screenshot binary

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,5 @@ loaders
 # Since parcel users will use the transpiled version of cozy-ui
 # that has already been processed by postcss, it is not necessary.
 postcss.config.js
+
+screenshots

--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@ build
 .travis.yml
 renovate.json
 yarn.lock
-/scripts
+
 .changelog
 examples
 docs
@@ -22,4 +22,4 @@ loaders
 # that has already been processed by postcss, it is not necessary.
 postcss.config.js
 
-screenshots
+screenshots/

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,26 @@ yarn build:doc:react
 yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
 ```
 
+## UI regression testing
+
+Components in `cozy-ui` are showcased with [React Styleguidist][]. To prevent UI regressions,
+for each PR, each component is screenshotted and compared to the master version to find any
+regression (thanks [Argos][] !).
+
+If your app uses [React Styleguidist][], `cozy-ui` provides `rsg-screenshots`, a CLI tool to take
+screenshots of your components (uses Puppeteer under the hood).
+
+```bash
+$ yarn add cozy-ui
+$ # The rsg-screenshots binary is now installed
+$ yarn build:doc:react # Build our styleguide, the output directory is docs/react
+$ rsg-screenshots --screenshot-dir screenshots/ --styleguide-dir docs/react
+# Each component in the styleguide will be screenshotted and saved inside the
+# screenshots/ directory
+```
+
+See our [travis configuration](./travis.yml) for more information.
+
 ## License
 
 Cozy UI is developed by Cozy Cloud and distributed under the AGPL-3.0 license.
@@ -107,3 +127,5 @@ You can reach the Cozy Community by:
 * Mentioning us on [Twitter](https://twitter.com/cozycloud)
 
 [stylus]: http://stylus-lang.com/
+[React Styleguidist]: https://react-styleguidist.js.org/
+[Argos]: https://github.com/argos-ci/argos

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-development",
   "description": "Cozy apps UI SDK",
   "main": "./index.js",
+  "bin": {
+    "rsg-screenshots": "./scripts/screenshots.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/cozy/cozy-ui.git"
@@ -42,7 +45,7 @@
     "semantic-release": "semantic-release",
     "sprite": "scripts/make-icon-sprite.sh",
     "jest": "yarn test:jest",
-    "screenshots": "node scripts/screenshots.js",
+    "screenshots": "node scripts/screenshots.js --screenshot-dir ./screenshots --styleguide-dir ./build/react",
     "test": "yarn test:jest",
     "test:jest": "jest --verbose",
     "transpile": "env BABEL_ENV=transpilation babel react/ --out-dir transpiled/react --verbose",
@@ -133,6 +136,7 @@
     "react-select": "2.2.0"
   },
   "peerDependencies": {
+    "puppeteer": "1.20.0",
     "@material-ui/core": "3.9.3",
     "cozy-client": "*",
     "cozy-device-helper": "1.7.5",


### PR DESCRIPTION
This is helpful for other applications that want to take
screenshots of their styleguide. Banks has a styleguide for
example.