### PR TITLE
chore(styleguide): Make examples copy-pasteable

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -154,6 +154,7 @@ module.exports = {
   webpackConfig: webpackMerge(require('./webpack.config.js'), {
     resolve: {
       alias: {
+        'cozy-ui/transpiled/react': path.resolve(__dirname, '../react/'),
         'cozy-ui': path.join(__dirname, '..')
       }
     }

--- a/react/Accordion/Readme.md
+++ b/react/Accordion/Readme.md
@@ -1,7 +1,7 @@
 ### Default (unsynchronized)
 
 ```
-import Accordion, { AccordionItem } from './index';
+import Accordion, { AccordionItem } from 'cozy-ui/transpiled/react/Accordion';
 
 <div>
   <Accordion>

--- a/react/ActionMenu/Readme.md
+++ b/react/ActionMenu/Readme.md
@@ -1,8 +1,8 @@
 ### Classic
 
 ```
-import ActionMenu, { ActionMenuItem } from './index';
-import Icon from '../Icon';
+import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 
 const showMenu = () => setState({ menuDisplayed: true })
 const hideMenu = () => setState({ menuDisplayed: false });

--- a/react/Alerter/Readme.md
+++ b/react/Alerter/Readme.md
@@ -2,7 +2,7 @@ Display notications!
 Include the `<Alert />` component somewhere in your app, but only once. After that, you can use the static methods `Alert.info`, `Alert.success` and `Alert.error` to trigger a notification.
 
 ```
-import Alerter from './index';
+import Alerter from 'cozy-ui/transpiled/react/Alerter';
 // we have to put the Alert only once in the app
 <div>
   <button onClick={() => Alert.info("This is an info alert!")}>Show alert info</button>
@@ -17,7 +17,7 @@ import Alerter from './index';
 The `Alert` methods support an optionnal second parameter, which can be used to add a button to the notification, with the `buttonText` and `buttonAction` keys:
 
 ```
-import Alerter from './index';
+import Alerter from 'cozy-ui/transpiled/react/Alerter';
 const triggerAlert = () => {
   Alerter.info("Accept our terms and conditions and subscribe to our newsletter", {
     buttonText: "ok",
@@ -50,7 +50,7 @@ const triggerAlertSuccess = () => {
 A dismiss function is provided to the `buttonAction` as argument which allow you to dismiss the alert before the duration ends from anywhere in your `buttonAction` code:
 
 ```
-import Alerter from './index';
+import Alerter from 'cozy-ui/transpiled/react/Alerter';
 
 const triggerAlertWithDismiss = () => {
   Alerter.info("This is an alert with a dismiss button. Dismiss me ->", {

--- a/react/AppIcon/Readme.md
+++ b/react/AppIcon/Readme.md
@@ -33,7 +33,7 @@ Is it also possible to provide a custom asynchronous `fetchIcon` which takes an 
 ```
 
 ```jsx
-import AppIcon from './index';
+import AppIcon from 'cozy-ui/transpiled/react/AppIcon';
 const fetchIcon1 = () => 'https://placeholder.pics/svg/100/7DC4FF/Test%20Icon'
 const fetchIcon2 = () => 'https://placeholder.pics/svg/100/FF0202/Test%20Icon'
 
@@ -61,7 +61,7 @@ If the `fetchIcon` is missing, the `<AppIcon />` component needs the `domain` pr
 You can provide an `<Icon />` `icon` props to fallback when the AppIcon fetched is broken or the `fetchIcon` function errored.
 
 ```jsx
-import AppIcon from './index';
+import AppIcon from 'cozy-ui/transpiled/react/AppIcon';
 const fetchIcon = () => 'https://placeholder.pics/svg/100/7DC4FF/Test%20Icon'
 const fetchIconBroken = () => 'blahblahblah'
 

--- a/react/AppLinker/Readme.md
+++ b/react/AppLinker/Readme.md
@@ -15,7 +15,7 @@ As it uses the render props pattern, it is flexible and can be used to build com
 anchor.
 
 ```
-import AppLinker from './index';
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker';
 <AppLinker slug='banks' href='http://dalailama-banks.mycozy.cloud'>{
   ({ onClick, href, name }) => (
     <a href={href} onClick={onClick}>

--- a/react/AppSections/Readme.md
+++ b/react/AppSections/Readme.md
@@ -1,6 +1,6 @@
 ```
 import mockApps from './_mockApps';
-import Sections from './Sections';
+import Sections from 'cozy-ui/transpiled/react/AppSections';
 import { I18n } from '../I18n';
 const locale = {};
 const handleAppClick = app => {

--- a/react/AppTitle/Readme.md
+++ b/react/AppTitle/Readme.md
@@ -3,7 +3,7 @@ Displays the App title in the Cozy Bar
 ### Default
 
 ```
-import AppTitle from './index';
+import AppTitle from 'cozy-ui/transpiled/react/AppTitle';
 <AppTitle>Drive</AppTitle>
 ```
 

--- a/react/Avatar/Readme.md
+++ b/react/Avatar/Readme.md
@@ -3,7 +3,7 @@ Show an avatar with initials
 ### Default
 
 ```
-import Avatar from './index';
+import Avatar from 'cozy-ui/transpiled/react/Avatar';
 <Avatar />
 ```
 
@@ -11,20 +11,20 @@ import Avatar from './index';
 #### with name
 
 ```
-import Avatar from './index';
+import Avatar from 'cozy-ui/transpiled/react/Avatar';
 <Avatar text="CD" />
 ```
 
 ### with image instead of initials
 
 ```
-import Avatar from './index';
+import Avatar from 'cozy-ui/transpiled/react/Avatar';
 <Avatar image="https://cozy.io/fr/images/cozy-logo_white.png" />
 ```
 
 ### Available sizes: xsmall, small, medium (default), large, xlarge
 ```
-import Avatar from './index';
+import Avatar from 'cozy-ui/transpiled/react/Avatar';
 <div>
   <div className="u-flex">
     <Avatar size="xsmall" />

--- a/react/Badge/Readme.md
+++ b/react/Badge/Readme.md
@@ -7,8 +7,8 @@ This component spreads all other props to its root element.
 Default type is `normal`
 
 ```
-import Badge from './index'
-import ButtonAction from '../ButtonAction';
+import Badge from 'cozy-ui/transpiled/react/Badge'
+import ButtonAction from 'cozy-ui/transpiled/react/ButtonAction';
 
 <div>
   <p>

--- a/react/BarButton/Readme.md
+++ b/react/BarButton/Readme.md
@@ -15,7 +15,7 @@ return (
 ## `disabled`
 
 ```jsx
-import BarButton from './index.jsx';
+import BarButton from 'cozy-ui/transpiled/react/BarButton';
 
 <BarButton icon="previous" disabled />
 ```
@@ -23,7 +23,7 @@ import BarButton from './index.jsx';
 ## `href`
 
 ```jsx
-import BarButton from './index.jsx';
+import BarButton from 'cozy-ui/transpiled/react/BarButton';
 
 <BarButton icon="upload" href="http://cozy.io" />
 ```
@@ -31,7 +31,7 @@ import BarButton from './index.jsx';
 ## `icon`
 
 ```jsx
-import BarButton from './index.jsx';
+import BarButton from 'cozy-ui/transpiled/react/BarButton';
 
 <BarButton icon="cube" />
 ```
@@ -39,7 +39,7 @@ import BarButton from './index.jsx';
 ## `onClick`
 
 ```jsx
-import BarButton from './index.jsx';
+import BarButton from 'cozy-ui/transpiled/react/BarButton';
 
 <BarButton icon="gear" onClick={() => alert('BarButton has been clicked')} />
 ```

--- a/react/Button/Readme.md
+++ b/react/Button/Readme.md
@@ -13,7 +13,7 @@ when `<ButtonLink>` has:
 #### Themes
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 const props = [{}, { disabled: true}, { busy: true }];
 const themes = ['regular', 'ghost', 'danger', 'highlight', 'secondary', 'danger-outline', 'alpha', 'text'];
 
@@ -31,7 +31,7 @@ const themes = ['regular', 'ghost', 'danger', 'highlight', 'secondary', 'danger-
 #### Sizes
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <div>
   <p><Button size='tiny' label='Tiny' /></p>
@@ -48,7 +48,7 @@ import Button from './index';
 - `full` to enable full width
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <div>
   <p><Button label='Normal'/></p>
@@ -64,7 +64,7 @@ import Button from './index';
 - `center` to center the label (default)
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <div>
   <p><Button extension="full" label='Default (center)'/></p>
@@ -77,8 +77,8 @@ import Button from './index';
 #### Extra right content
 
 ```
-import Button from './index';
-const Chip = require('../Chip').default;
+import Button from 'cozy-ui/transpiled/react/Button';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 
 <div>
   <p><Button extension="full" size="large" label='Label' extraRight={<Chip size="small" theme="primary" className="u-m-0">1/2</Chip>} /></p>
@@ -88,19 +88,19 @@ const Chip = require('../Chip').default;
 #### Add a action on click
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 <Button theme='danger-outline' onClick={ () => alert('yay !') } label='Show alert' />
 ```
 
 #### When loading, put a spinner
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 <Button busy label='Loading'/>
 ```
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 initialState = { busy:false };
 <Button onClick={() => {setState(state => ({busy: !state.busy}))}} busy={state.busy} label='Toggle busy'/>
 ```
@@ -108,7 +108,7 @@ initialState = { busy:false };
 #### Disable a button
 
 ```
-import Button, { ButtonLink } from './index';
+import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button';
 <div>
   <Button disabled label='Loading' />
   <ButtonLink disabled href='http://cozy.io' label='Go to Cozy website' />
@@ -121,7 +121,7 @@ The color of the icon is taken care of by the button style, there's no need to s
 If you want a button with only an icon as content, you must set the `iconOnly` prop.
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 <div>
   <Button theme="danger" icon='trash' label='delete' />
   <Button theme="secondary" icon='dots' iconOnly label="See more" extension='narrow' />
@@ -131,8 +131,8 @@ import Button from './index';
 You can also pass an Icon directly if you need more flexibility.
 
 ```
-import Button from './index';
-import Icon from '../Icon';
+import Button from 'cozy-ui/transpiled/react/Button';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <div>
   <Button theme="danger" icon={ <Icon icon='trash' color='yellow' /> } label='delete' />
 </div>
@@ -141,7 +141,7 @@ import Icon from '../Icon';
 #### Create a round button with an icon
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 <div>
   <Button icon='plus' label='Add' iconOnly round />
   <Button theme="secondary" icon='cross' label='Delete' iconOnly round />
@@ -153,7 +153,7 @@ import Button from './index';
 Subtle buttons are buttons without background and borders, wich look "inverted" compared to the basic Buttons.
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 <div>
   <p>
     <Button subtle size='tiny' label='Tiny text' onClick={() => alert('Clicked on Tiny text')} />
@@ -187,7 +187,7 @@ import Button from './index';
 #### Using Links
 
 ```
-import { ButtonLink } from './index';
+import { ButtonLink } from 'cozy-ui/transpiled/react/Button';
 <div>
   <p>
     <ButtonLink size="tiny" href="https://cozy.io" target="_blank" label='Link to Cozy.io'/>
@@ -215,7 +215,7 @@ You can pass `tag={NavLink}` and `NavLink` will be used. Any props that you
 pass to the `Button` will be passed down to the component.
 
 ```
-import Button from './index';
+import Button from 'cozy-ui/transpiled/react/Button';
 const NavLink = props => (
   <span onClick={() => alert(`Navigating to ${props.to}`)} {...props}>{
     props.children

--- a/react/ButtonAction/Readme.md
+++ b/react/ButtonAction/Readme.md
@@ -4,7 +4,7 @@ The Action Button has different types whether it's `normal`, just `new` or not c
 Default type is `normal`
 
 ```
-import ButtonAction from './index';
+import ButtonAction from 'cozy-ui/transpiled/react/ButtonAction';
 <div>
   <p>
     <ButtonAction label='Normal' rightIcon='openwith' />
@@ -24,7 +24,7 @@ import ButtonAction from './index';
 #### Long labels are troncated by default
 
 ```
-import ButtonAction from './index';
+import ButtonAction from 'cozy-ui/transpiled/react/ButtonAction';
 <div>
   <p><ButtonAction label='Very long long long label' type='normal' rightIcon='hourglass' /></p>
 </div>
@@ -33,7 +33,7 @@ import ButtonAction from './index';
 #### Compact version (on mobile mostly)
 
 ```
-import ButtonAction from './index';
+import ButtonAction from 'cozy-ui/transpiled/react/ButtonAction';
 <div>
   <p><ButtonAction compact label='Normal' rightIcon='openwith' /></p>
   <p><ButtonAction compact disabled label='Disabled' rightIcon='hourglass' /></p>

--- a/react/Card/Readme.md
+++ b/react/Card/Readme.md
@@ -1,9 +1,9 @@
 A card is a small block used to separate some content from the rest of the UI.
 
 ```
-import Card from './index';
-import { Text, SubTitle } from '../Text';
-import Button from '../Button';
+import Card from 'cozy-ui/transpiled/react/Card';
+import { Text, SubTitle } from 'cozy-ui/transpiled/react/Text';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <Card>
   <SubTitle className="u-mb-1">This is a card</SubTitle>
@@ -19,8 +19,8 @@ import Button from '../Button';
 Renders the Card with increased margins.
 
 ```
-import Card from './index';
-import { Text, SubTitle } from '../Text';
+import Card from 'cozy-ui/transpiled/react/Card';
+import { Text, SubTitle } from 'cozy-ui/transpiled/react/Text';
 
 <Card inset>
   <Text>This is some card content. Content can be small or huge. Also, it has margins.</Text>
@@ -32,8 +32,8 @@ import { Text, SubTitle } from '../Text';
 Uses the provided tag to render the root element of the Card
 
 ```
-import Card from './index';
-import { Text, SubTitle } from '../Text';
+import Card from 'cozy-ui/transpiled/react/Card';
+import { Text, SubTitle } from 'cozy-ui/transpiled/react/Text';
 
 <Card tag="a" href="https://cozy.io" target="_blank">
   <SubTitle>Visit cozy.io</SubTitle>

--- a/react/Checkbox/Readme.md
+++ b/react/Checkbox/Readme.md
@@ -1,7 +1,7 @@
 ### Standard Checkbox
 
 ```
-import Checkbox from './index';
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox';
 <form>
   <div><Checkbox label="This is a checkbox" /></div>
 </form>
@@ -10,27 +10,27 @@ import Checkbox from './index';
 ### Checkbox when there's an error
 
 ```
-import Checkbox from './index';
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox';
 <div><Checkbox label="This is a checkbox with an error" error /></div>
 ```
 
 ### Checkbox when disabled
 
 ```
-import Checkbox from './index';
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox';
 <div><Checkbox label="This is a disabled checkbox" disabled /></div>
 ```
 
 ### Checkbox mixed checked
 
 ```
-import Checkbox from './index';
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox';
 <div><Checkbox label="This is a mixed checkbox" mixed /></div>
 ```
 
 ### Checkbox with complex children
 
 ```
-import Checkbox from './index';
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox';
 <div><Checkbox>This is a <strong>complex</strong> text</Checkbox></div>
 ```

--- a/react/Chip/Readme.md
+++ b/react/Chip/Readme.md
@@ -1,9 +1,9 @@
 Chips represent complex entities in small blocks, such as a contact.
 
 ```
-import Chip from './index';
-import Icon from '../Icon';
-import Avatar from '../Avatar';
+import Chip from 'cozy-ui/transpiled/react/Chip';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Avatar from 'cozy-ui/transpiled/react/Avatar';
 const ContactChip = ({ contact }) => (
   <Chip style={{ paddingLeft: '0.25rem' }}>
     <Avatar textId={ contact.name } text={contact.initials} size='small' style={{ marginRight: '0.5rem' }}/> {contact.name}
@@ -26,8 +26,8 @@ const ContactChip = ({ contact }) => (
 ### Round chip
 
 ```
-import Chip from './index';
-import Icon from '../Icon';
+import Chip from 'cozy-ui/transpiled/react/Chip';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <Chip.Round>
   <Icon icon='right'/>
 </Chip.Round>
@@ -36,7 +36,7 @@ import Icon from '../Icon';
 ### Chip separator
 
 ```
-import Chip from './index';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 <Chip>
   Something
   <Chip.Separator />
@@ -47,8 +47,8 @@ import Chip from './index';
 ### Chip buttons
 
 ```
-import Chip from './index';
-import Icon from '../Icon';
+import Chip from 'cozy-ui/transpiled/react/Chip';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <div>
   <Chip.Button><Icon icon='right' /></Chip.Button>
   <Chip.Button disabled><Icon icon='left' /></Chip.Button>
@@ -58,7 +58,7 @@ import Icon from '../Icon';
 ### Specify underlying tag/component
 
 ```
-import Chip from './index';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 <div>
   <Chip component="button" onClick={() => alert('You clicked')}>This is a button</Chip>
   <Chip component="button" disabled>This is a disabled button</Chip>
@@ -69,7 +69,7 @@ import Chip from './index';
 ### Sizes
 
 ```
-import Chip from './index';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 <div>
   <Chip size="tiny">This is a tiny Chip</Chip>
   <Chip size="small">This is a small Chip</Chip>
@@ -80,7 +80,7 @@ import Chip from './index';
 ### Variants
 
 ```
-import Chip from './index';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 <div>
   <Chip variant="normal">This is a normal Chip (default)</Chip>
   <Chip variant="outlined">This is an outlined Chip</Chip>
@@ -91,7 +91,7 @@ import Chip from './index';
 ### Themes
 
 ```
-import Chip from './index';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 <div>
   <div>
     <Chip theme="normal">This is a normal Chip (default)</Chip>
@@ -114,7 +114,7 @@ import Chip from './index';
 ### Mix sizes, variants and themes
 
 ```
-import Chip from './index';
+import Chip from 'cozy-ui/transpiled/react/Chip';
 <div>
   <div>
     <Chip theme="normal" size="small">This is a normal Chip</Chip>
@@ -137,8 +137,8 @@ import Chip from './index';
 ### Complete example
 
 ```
-import Chip from './index';
-import Icon from '../Icon';
+import Chip from 'cozy-ui/transpiled/react/Chip';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <Chip
   size="small"
   variant="outlined"

--- a/react/CipherIcon/Readme.md
+++ b/react/CipherIcon/Readme.md
@@ -1,8 +1,8 @@
 This is an icon representing a cipher for a given konnector
 
 ```
-import CipherIcon from './index';
-import { Text, SubTitle } from '../Text';
+import CipherIcon from 'cozy-ui/transpiled/react/CipherIcon';
+import { Text, SubTitle } from 'cozy-ui/transpiled/react/Text';
 
 <div>
   <div>

--- a/react/Circle/Readme.md
+++ b/react/Circle/Readme.md
@@ -3,7 +3,7 @@ Displays a simple circle with some text inside of it.
 ### Default
 
 ```
-import Circle from './index';
+import Circle from 'cozy-ui/transpiled/react/Circle';
 <div>
   <Circle>
     yo
@@ -13,7 +13,7 @@ import Circle from './index';
 
 ### Available sizes: xsmall, small, medium (default), large, xlarge
 ```
-import Circle from './index';
+import Circle from 'cozy-ui/transpiled/react/Circle';
 <div>
   <div>
     <Circle size="xsmall">Yo</Circle>

--- a/react/ContextHeader/Readme.md
+++ b/react/ContextHeader/Readme.md
@@ -3,7 +3,7 @@ A little inset with text and optional icon that can be used to provide some cont
 ### Default
 
 ```
-import ContextHeader from './index';
+import ContextHeader from 'cozy-ui/transpiled/react/ContextHeader';
 <div>
   <ContextHeader title="Pick a book" text="What will you read today?" />
 </div>
@@ -12,7 +12,7 @@ import ContextHeader from './index';
 ### With an icon
 
 ```
-import ContextHeader from './index';
+import ContextHeader from 'cozy-ui/transpiled/react/ContextHeader';
 <div>
   <ContextHeader title="Pick a book" text="What will you read today?" icon="album" />
 </div>
@@ -21,7 +21,7 @@ import ContextHeader from './index';
 ### With a closing action
 
 ```
-import ContextHeader from './index';
+import ContextHeader from 'cozy-ui/transpiled/react/ContextHeader';
 <div>
   <ContextHeader title="Pick a book" text="What will you read today?" icon="album" onClose={() => alert('Nothing then.')} />
 </div>

--- a/react/Counter/Readme.md
+++ b/react/Counter/Readme.md
@@ -3,7 +3,7 @@ A simple way to show how many *things* there are.
 ### Default
 
 ```
-import Counter from './index';
+import Counter from 'cozy-ui/transpiled/react/Counter';
 <div >
   <Counter count={42} />
 </div>
@@ -14,7 +14,7 @@ import Counter from './index';
 Above a certain number, an approximation is displayed. The default treshold is 99.
 
 ```
-import Counter from './index';
+import Counter from 'cozy-ui/transpiled/react/Counter';
 <div >
   <Counter count={14} max={5} />
 </div>

--- a/react/Empty/Readme.md
+++ b/react/Empty/Readme.md
@@ -3,7 +3,7 @@ Empty (or error) view in a listing container
 ### Default
 
 ```
-import Empty from './index';
+import Empty from 'cozy-ui/transpiled/react/Empty';
 const styles = {
   empty: {
     position: 'relative',
@@ -21,8 +21,8 @@ const styles = {
 ### With some additional content
 
 ```
-import Empty from './index';
-import Button from '../Button';
+import Empty from 'cozy-ui/transpiled/react/Empty';
+import Button from 'cozy-ui/transpiled/react/Button';
 const styles = {
   empty: {
     position: 'relative',

--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -7,7 +7,7 @@ Like `Input` component, it can have the following properties:
 ##### Example
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     id="idField"
@@ -27,8 +27,8 @@ It gives access to the underlying `<input />` element, for example to give focus
 ##### Example
 
 ```
-import Field from './index';
-import Button from '../Button';
+import Field from 'cozy-ui/transpiled/react/Field';
+import Button from 'cozy-ui/transpiled/react/Button';
 class FieldWithFocus extends React.Component {
   constructor() {
     super()
@@ -60,7 +60,7 @@ Name of the form field, injected into `Input`, `TextArea` or `SelectBox` compone
 ##### Exemple
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     label="I got a name"
@@ -72,7 +72,7 @@ import Field from './index';
 #### Field when there's an error
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     id="idFieldError"
@@ -87,7 +87,7 @@ import Field from './index';
 #### Field with SelectBox
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 const options = [
 {
   label: 'Choice 1',
@@ -117,7 +117,7 @@ const options = [
 #### Password field with show/hide button
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     id="idFieldPassword"
@@ -134,7 +134,7 @@ import Field from './index';
 #### Password field without show/hide button
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     id="idFieldPassword"
@@ -147,7 +147,7 @@ import Field from './index';
 #### Side element
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     label="I'm a label"
@@ -159,7 +159,7 @@ import Field from './index';
 #### Side element with fullwidth element
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     label="I'm a label"
@@ -172,7 +172,7 @@ import Field from './index';
 #### Customized label and input
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     label="I'm a label"
@@ -189,7 +189,7 @@ import Field from './index';
 #### Password with custom secondaryComponent
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     label="I'm a label"
@@ -210,7 +210,7 @@ import Field from './index';
 #### Controlled Field
 
 ```
-import Field from './index';
+import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
     side="(optional)"

--- a/react/Figure/Figure.md
+++ b/react/Figure/Figure.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Figure } from './index';
+import { Figure } from 'cozy-ui/transpiled/react/Figure';
 <div>
   <Figure
     total={1000}

--- a/react/Figure/FigureBlock.md
+++ b/react/Figure/FigureBlock.md
@@ -1,7 +1,7 @@
 Pour montrer une KPI importante.
 
 ```jsx
-import { FigureBlock } from './index';
+import { FigureBlock } from 'cozy-ui/transpiled/react/Figure';
 <div>
   <FigureBlock
     label='Balance totale'

--- a/react/FileInput/Readme.md
+++ b/react/FileInput/Readme.md
@@ -3,7 +3,7 @@ This component is used to display a customizable input file. It's just a wrapper
 ### Default
 
 ```jsx
-import FileInput from './index';
+import FileInput from 'cozy-ui/transpiled/react/FileInput';
 <FileInput className="file-selector" onChange={console.log}>
   <span role="button">Click me to choose file</span>
 </FileInput>
@@ -12,8 +12,8 @@ import FileInput from './index';
 You render what you want:
 
 ```jsx
-import FileInput from './index';
-import Icon from '../Icon';
+import FileInput from 'cozy-ui/transpiled/react/FileInput';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <FileInput onChange={console.log}>
   <Icon icon="file" role="button" />
 </FileInput>
@@ -22,7 +22,7 @@ import Icon from '../Icon';
 ### Multiple files
 
 ```jsx
-import FileInput from './index';
+import FileInput from 'cozy-ui/transpiled/react/FileInput';
 <FileInput multiple onChange={console.log}>
   <span role="button">Click me to choose files</span>
 </FileInput>
@@ -31,7 +31,7 @@ import FileInput from './index';
 ### Only accept images
 
 ```jsx
-import FileInput from './index';
+import FileInput from 'cozy-ui/transpiled/react/FileInput';
 <FileInput accept="image/*" multiple onChange={console.log}>
   <span>Click me to choose an image</span>
 </FileInput>
@@ -42,6 +42,6 @@ import FileInput from './index';
 If you want a classic input file, just set `hidden` prop to `false`:
 
 ```jsx
-import FileInput from './index';
+import FileInput from 'cozy-ui/transpiled/react/FileInput';
 <FileInput hidden={false} onChange={console.log} />
 ```

--- a/react/Filename/Readme.md
+++ b/react/Filename/Readme.md
@@ -1,7 +1,7 @@
 #### Filename with extension (ellipsis by default)
 
 ```
-import Filename from './index';
+import Filename from 'cozy-ui/transpiled/react/Filename';
 <div>
   <Filename filename="Lacinia condimentum potenti id est tortor dictumst lectus tincidunt hac ultricies, curae mattis nisi neque sodales sagittis dui nulla aliquam turpis eros, finibus ac iaculis dictum et orci elit posuere ex" extension=".pdf" />
 </div>
@@ -10,7 +10,7 @@ import Filename from './index';
 #### Filename with extension and icon
 
 ```
-import Filename from './index';
+import Filename from 'cozy-ui/transpiled/react/Filename';
 <div>
   <Filename icon="file" filename="my_awesome_paper" extension=".pdf" />
 </div>

--- a/react/Hero/Readme.md
+++ b/react/Hero/Readme.md
@@ -10,8 +10,8 @@ import Hero, {
   Paragraph,
   CTA,
   Icon
-} from './index';
-import Button from '../Button';
+} from 'cozy-ui/transpiled/react/Hero';
+import Button from 'cozy-ui/transpiled/react/Button';
 import { t } from '../../docs/utils';
 
 const RED = '#f52d2d'

--- a/react/Icon/Readme.md
+++ b/react/Icon/Readme.md
@@ -9,8 +9,8 @@ your applicaiton.
 ### Available illustrations icons (colors fixed)
 
 ```
-import Icon from './index';
-import Sprite from './Sprite';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite';
 const availableIcons = ['cozy', 'cloud-broken', 'cozy-logo', 'device-laptop', 'device-phone', 'device-tablet', 'file-type-audio', 'file-type-bin', 'file-type-code', 'file-type-files', 'file-type-folder', 'file-type-image', 'file-type-pdf', 'file-type-sheet', 'file-type-slide', 'file-type-text', 'file-type-video', 'file-type-zip', 'google', 'top-select', 'bottom-select', 'check-white', 'dash-white', 'keychain'];
 
 <div style={{ fontSize: '2rem', display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
@@ -27,8 +27,8 @@ const availableIcons = ['cozy', 'cloud-broken', 'cozy-logo', 'device-laptop', 'd
 ### Available UI icons
 
 ```
-import Icon from './index';
-import Sprite from './Sprite';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite';
 const colors = ['#297EF2', '#08b442', '#B449E7', '#F52D2D', '#FF962F']
 let i = 0
 const availableIcons = ['album', 'album-add', 'album-remove', 'file', 'file-add', 'file-none', 'file-outline', 'folder', 'folder-add', 'wallet', 'wallet-add', 'credit-card', 'credit-card-add', 'top', 'right', 'bottom', 'left', 'up', 'down', 'next', 'previous', 'dropdown', 'dropup', 'dropdown-close', 'dropdown-open', 'rise', 'answer', 'restore', 'rotate-left', 'rotate-right', 'download', 'upload', 'moveto', 'logout', 'exchange', 'movement-in', 'movement-out', 'certified', 'check-circle', 'check', 'info-outlined', 'info', 'flag', 'flag-outlined', 'cloud', 'cloud-happy', 'to-the-cloud', 'grid', 'list', 'group-list', 'groups', 'cube', 'connector', 'share', 'share-circle', 'offline', 'online', 'email', 'email-notification', 'people', 'team', 'from-user', 'cross', 'cross-small', 'plus', 'plus-small', 'attention', 'warn', 'warning', 'devices', 'laptop', 'phone', 'phone-download', 'eye', 'eye-closed', 'link', 'unlink', 'lock', 'unlock', 'pie-chart', 'stats', 'apple', 'browser-brave', 'browser-chrome', 'browser-duckduckgo', 'browser-edge', 'browser-firefox', 'browser-ie', 'browser-opera', 'browser-safari', 'archive', 'attachment', 'bank', 'bell', 'burger', 'calendar', 'camera', 'stack', 'check-list', 'circle-filled', 'clock', 'collect', 'comment', 'company', 'compass', 'contract', 'contrast', 'crop', 'dash', 'dashboard', 'data-control', 'dots', 'eu', 'euro', 'filter', 'fingerprint', 'flash-auto', 'flashlight', 'forbidden', 'gear', 'globe', 'heart', 'help', 'history', 'home', 'hourglass', 'image', 'key', 'lightbulb', 'location', 'magic-trick', 'magnet', 'magnifier', 'merge', 'multi-files', 'music', 'new', 'openwith', 'palette', 'paperplane', 'pen', 'rename', 'percent-circle', 'personal-data', 'pin', 'printer', 'repare', 'select-all', 'setting', 'sound', 'spinner', 'star', 'sync', 'target', 'telephone', 'trash', 'trophy', 'videos', 'car', 'file-duotone', 'qualify'];
@@ -49,7 +49,7 @@ const availableIcons = ['album', 'album-add', 'album-remove', 'file', 'file-add'
 Use `spin` and `rotate` if you want you to turn your icons upside down 🙃.
 
 ```
-import Icon from './index';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <div>
   <Icon icon='spinner' color='#0bda51' spin/>{'\u00A0'}
   <Icon icon='right' color='#c30017' rotate={45}/>
@@ -74,7 +74,7 @@ import myIcon from "my-icon.svg";
 Icon forwards unknown props to the underlying `<svg />` element.
 
 ```
-import Icon from './index';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <div>
   <Icon icon='warning' onClick={() => alert('Be careful !')} width={32} height={32} color='purple' /><span>← Click it</span>
 </div>

--- a/react/IconStack/Readme.md
+++ b/react/IconStack/Readme.md
@@ -4,8 +4,8 @@ A component to put something in the background and center an
 other component on the foreground
 
 ```
-const IconStack = require('./index').default;
-const Icon = require('../Icon').default;
+import IconStack from 'cozy-ui/transpiled/react/IconStack';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 <IconStack
   background={<Icon icon="file-duotone" color="blue"  size={32} />}
   foreground={<Icon icon="bank" color="red" height={16} width={16} />}

--- a/react/Infos/Readme.md
+++ b/react/Infos/Readme.md
@@ -1,8 +1,8 @@
 ### Infos display info
 
 ```
-import Infos from './index';
-import Button from '../Button';
+import Infos from 'cozy-ui/transpiled/react/Infos';
+import Button from 'cozy-ui/transpiled/react/Button';
 <div className='u-stack-m'>
     <Infos text="My small persistent information! " />
     <Infos text="In a slightly different style" className='u-maw-none u-bdrs-0'/>

--- a/react/InlineCard/Readme.md
+++ b/react/InlineCard/Readme.md
@@ -1,7 +1,7 @@
 A inline card is a small inline block used to separate some content from the rest of the UI.
 
 ```
-import InlineCard from './index';
+import InlineCard from 'cozy-ui/transpiled/react/InlineCard';
 <InlineCard>
   I am an inline card
 </InlineCard>

--- a/react/Input/Readme.md
+++ b/react/Input/Readme.md
@@ -1,7 +1,7 @@
 ### Input's available types (text, password, email, url)
 
 ```
-import Input from './index';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <p><Input placeholder="This is a input[type=text]" /></p>
   <p><Input type="password" placeholder="This is a input[type=password]" /></p>
@@ -14,7 +14,7 @@ import Input from './index';
 ### Disabled Input
 
 ```
-import Input from './index';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <Input disabled value="I'm disabled" />
 </form>
@@ -23,7 +23,7 @@ import Input from './index';
 ### Input when there's an error
 
 ```
-import Input from './index';
+import Input from 'cozy-ui/transpiled/react/Input';
 <Input error placeholder="This is a input[type=text] with error" />
 ```
 
@@ -32,7 +32,7 @@ import Input from './index';
 By default, the size is `large`.
 
 ```
-import Input from './index';
+import Input from 'cozy-ui/transpiled/react/Input';
 <div>
   <p>
     <Input placeholder="I have a tiny size" size="tiny" />
@@ -46,7 +46,7 @@ import Input from './index';
 ### Full width inputs
 
 ```
-import Input from './index';
+import Input from 'cozy-ui/transpiled/react/Input';
 <Input placeholder="I'm full width" fullwidth />
 ```
 
@@ -55,8 +55,8 @@ import Input from './index';
 If you need to programmatically access the underlying `<input />` for example to give focus or move the caret, you can use the `inputRef` prop, that is passed to the `ref` property of the `<input />`.
 
 ```
-import Input from './index';
-import Button from '../Button';
+import Input from 'cozy-ui/transpiled/react/Input';
+import Button from 'cozy-ui/transpiled/react/Button';
 class InputComponent extends React.Component {
   constructor() {
     super()
@@ -83,7 +83,7 @@ class InputComponent extends React.Component {
 `Input` forwards unknown props to the underlying `<input />` element.
 
 ```
-import Input from './index';
+import Input from 'cozy-ui/transpiled/react/Input';
 <div>
   <Input placeholder='Type to see changes' value={state.value} onChange={ev => setState({value: ev.target.value})} />&nbsp;&nbsp;
   Value: { state.value }

--- a/react/InputGroup/Readme.md
+++ b/react/InputGroup/Readme.md
@@ -1,9 +1,9 @@
 ### InputGroup with an appended text
 
 ```
-import InputGroup from './index';
-import { Bold } from '../Text';
-import Input from '../Input';
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup';
+import { Bold } from 'cozy-ui/transpiled/react/Text';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <InputGroup append={<InputGroup.Unit>€</InputGroup.Unit>}>
@@ -16,9 +16,9 @@ import Input from '../Input';
 ### InputGroup with a prepended text
 
 ```
-import InputGroup from './index';
-import { Bold } from '../Text';
-import Input from '../Input';
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup';
+import { Bold } from 'cozy-ui/transpiled/react/Text';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <InputGroup prepend={<Bold className="u-pl-1">text</Bold>}>
@@ -33,8 +33,8 @@ import Input from '../Input';
 You will need to set a width to the side component, with a utility class for example.
 
 ```
-import InputGroup from './index';
-import Input from '../Input';
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <InputGroup append={<Input placeholder="@domain.tld" className="u-w-4"/>}>
@@ -49,9 +49,9 @@ import Input from '../Input';
 You will need to set a width to the side component, with a utility class for example.
 
 ```
-import InputGroup from './index';
-import Input from '../Input';
-import SelectBox from '../SelectBox';
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup';
+import Input from 'cozy-ui/transpiled/react/Input';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'cozy.io', label: '.cozy.io' },
   { value: 'cozycloud.cc', label: '.cozycloud.cc' }
@@ -68,9 +68,9 @@ const options = [
 ### Full width InputGroup with an appended text
 
 ```
-import InputGroup from './index';
-import { Bold } from '../Text';
-import Input from '../Input';
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup';
+import { Bold } from 'cozy-ui/transpiled/react/Text';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <InputGroup fullwidth append={<Bold className="u-pr-1">text</Bold>}>
@@ -83,9 +83,9 @@ import Input from '../Input';
 ### Errored InputGroup with an appended text
 
 ```
-import InputGroup from './index';
-import { Bold } from '../Text';
-import Input from '../Input';
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup';
+import { Bold } from 'cozy-ui/transpiled/react/Text';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <InputGroup error append={<Bold className="u-pr-1">text</Bold>}>
@@ -98,8 +98,8 @@ import Input from '../Input';
 ### InputGroup with a prepended text and a custom classname (border-radius)
 
 ```
-const { Bold } = require('../Text');
-const Input = require('../Input').default;
+import { Bold } from 'cozy-ui/transpiled/react/Text';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <InputGroup prepend={<Bold className="u-pl-1">text</Bold>} className="u-bdrs-3">

--- a/react/IntentIframe/Readme.md
+++ b/react/IntentIframe/Readme.md
@@ -4,7 +4,7 @@ See [the documentation]() for more information about intents.
 Example:
 
 ```
-import IntentIframe from './index';
+import IntentIframe from 'cozy-ui/transpiled/react/IntentIframe';
 import utils from '../../docs/utils';
   <IntentIframe
     action="PICK"

--- a/react/IntentModal/IntentModal.md
+++ b/react/IntentModal/IntentModal.md
@@ -1,7 +1,7 @@
 The IntentOpener component is useful to start an new intent modal from a click on a button. But sometimes you want/have to handle the modal opening state on the application side so you need to just render an Intent inside a modal. The IntentModal component is clearly for that use case. This is also the same modal code used by the IntentOpener component.
 
 ```
-import IntentModal from './index';
+import IntentModal from 'cozy-ui/transpiled/react/IntentModal';
 initialState = { modalOpened: false};
 
 <div>

--- a/react/IntentOpener/IntentOpener.md
+++ b/react/IntentOpener/IntentOpener.md
@@ -1,5 +1,5 @@
 ```
-import IntentOpener from './index';
+import IntentOpener from 'cozy-ui/transpiled/react/IntentOpener';
 <IntentOpener
   onComplete={res => alert('intent has completed ! ' + JSON.stringify(res))}
   onDismiss={() => alert('intent has been dismissed !')}

--- a/react/Label/Readme.md
+++ b/react/Label/Readme.md
@@ -1,8 +1,8 @@
 #### Label element for forms
 
 ```
-import Label from './index';
-import Input from '../Input';
+import Label from 'cozy-ui/transpiled/react/Label';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <Label htmlFor="idInput">This is a label</Label>
@@ -14,8 +14,8 @@ import Input from '../Input';
 #### Inline Label (Labels are displayed `block` by default)
 
 ```
-import Label from './index';
-import Input from '../Input';
+import Label from 'cozy-ui/transpiled/react/Label';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <Label htmlFor="idInput2" block={false}>This is an inline label</Label>
@@ -27,8 +27,8 @@ import Input from '../Input';
 #### Label when there's an error
 
 ```
-import Label from './index';
-import Input from '../Input';
+import Label from 'cozy-ui/transpiled/react/Label';
+import Input from 'cozy-ui/transpiled/react/Input';
 <form>
   <div>
     <Label htmlFor="idInput2" error>This is an error label</Label>

--- a/react/Labs/ExperimentalModal/Readme.md
+++ b/react/Labs/ExperimentalModal/Readme.md
@@ -8,7 +8,7 @@ and add a border-top.
 Not tested on "long content".
 
 ```
-import ExperimentalModal from './index';
+import ExperimentalModal from 'cozy-ui/transpiled/react/Labs/ExperimentalModal';
 
 initialState = { modalOpened: isTesting()};
 const hideModal = () => setState({ modalOpened: false });

--- a/react/Labs/GridItem/Readme.md
+++ b/react/Labs/GridItem/Readme.md
@@ -4,10 +4,10 @@ GridItem is currently experimental since its behavior is
 not well defined yet.
 
 ```
-import MuiCozyTheme from '../../MuiCozyTheme';
-import Grid from '../../MuiCozyTheme/Grid';
-import GridItem from './index';
-import Card from '../../Card';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid';
+import GridItem from 'cozy-ui/transpiled/react/Labs/GridItem';
+import Card from 'cozy-ui/transpiled/react/Card';
 
 <MuiCozyTheme>
     <Grid container spacing={24}>

--- a/react/Layout/Layout.md
+++ b/react/Layout/Layout.md
@@ -4,9 +4,9 @@ The Layout component brings a strong context for apps with any screen resolution
 * `<Content />` is the main content or your app.
 
 ```jsx
-import { Layout, Main, Content } from './index';
-import Sidebar from '../Sidebar';
-import Nav, { NavItem, NavIcon, NavText, genNavLink } from '../Nav';
+import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout';
+import Sidebar from 'cozy-ui/transpiled/react/Sidebar';
+import Nav, { NavItem, NavIcon, NavText, genNavLink } from 'cozy-ui/transpiled/react/Nav';
 
 const NavLink = genNavLink(({ children, className }) =>
   <a className={className}>{ children }</a>)
@@ -52,7 +52,7 @@ const styles = {
 `monoColumn` option (without sidebar)
 
 ```jsx
-import { Layout, Main, Content } from './index';
+import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout';
 
 <Layout monoColumn>
     <Main>

--- a/react/ListItemText/Readme.md
+++ b/react/ListItemText/Readme.md
@@ -1,23 +1,23 @@
 #### List item main text
 
 ```
-import ListItemText from './index';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
 <ListItemText primaryText="I'm a list item text"/>
 ```
 
 #### List item main text with an annotation text
 
 ```
-import ListItemText from './index';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
 <ListItemText primaryText="I'm a primary text" secondaryText="I'm a secondary text"/>
 ```
 
 #### Custom List item
 
 ```
-import ListItemText from './index';
-import { Text, Caption } from '../Text';
-import MidEllipsis from '../MidEllipsis';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
+import { Text, Caption } from 'cozy-ui/transpiled/react/Text';
+import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
 
 <ListItemText>
   <Text>I'm a primary text</Text>

--- a/react/Media/Readme.md
+++ b/react/Media/Readme.md
@@ -12,7 +12,7 @@ Flexbox : https://philipwalton.github.io/solved-by-flexbox/demos/media-object/
 `align=middle` (default)
 
 ```jsx
-import { Media, Img, Bd } from './index';
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media';
 const imgStyle = { marginRight: '1rem' };
 
 <Media>
@@ -28,7 +28,7 @@ const imgStyle = { marginRight: '1rem' };
 `align=top`
 
 ```jsx
-import { Media, Img, Bd } from './index';
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media';
 const imgStyle = { marginRight: '1rem' };
 
 <Media align='top'>
@@ -44,7 +44,7 @@ const imgStyle = { marginRight: '1rem' };
 `align=bottom`
 
 ```jsx
-import { Media, Img, Bd } from './index';
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media';
 const imgStyle = { marginRight: '1rem' };
 
 <Media align='bottom'>

--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -8,9 +8,9 @@ an item in the `Menu`.
 the item is `disabled`.
 
 ```
-import Menu, { MenuItem } from './index';
-import Button from '../Button';
-import Icon from '../Icon';
+import Menu, { MenuItem } from 'cozy-ui/transpiled/react/Menu';
+import Button from 'cozy-ui/transpiled/react/Button';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 const showItem = itemData => alert(JSON.stringify(itemData));
 const showWarning = itemData => alert(itemData + ' is disabled');
 
@@ -28,8 +28,8 @@ const showWarning = itemData => alert(itemData + ' is disabled');
 Use the `position` attribute to put the menu to the right.
 
 ```
-import Menu, { MenuItem } from './index';
-import Icon from '../Icon';
+import Menu, { MenuItem } from 'cozy-ui/transpiled/react/Menu';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 
 <Menu initialOpen={isTesting()} position='right' label='Click me !' onSelect={ itemData => alert(JSON.stringify(itemData)) }>
   <MenuItem data='hello'>Hello !</MenuItem>
@@ -42,8 +42,8 @@ Use the `component` attribute if you want to use a custom component for the
 opener.
 
 ```
-import Menu, { MenuItem } from './index';
-import Button from '../Button';
+import Menu, { MenuItem } from 'cozy-ui/transpiled/react/Menu';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <Menu initialOpen={isTesting()} component={<Button label="Greetings with custom component"/>} onSelect={ itemData => alert(JSON.stringify(itemData)) }>
   <MenuItem data='hello'>Hello !</MenuItem>

--- a/react/MidEllipsis/Readme.md
+++ b/react/MidEllipsis/Readme.md
@@ -1,6 +1,6 @@
 #### Ellipsis in the middle
 
 ```
-import MidEllipsis from './index';
+import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
 <MidEllipsis text={content.ada.short} />
 ```

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -1,7 +1,7 @@
 ### Simple
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 initialState = { modalOpened: false};
 
 <div>
@@ -15,7 +15,7 @@ initialState = { modalOpened: false};
 ### Simple with no title
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 initialState = { modalOpened: false};
 
 <div>
@@ -32,7 +32,7 @@ Several sizes avalaible: `xsmall, small`, `medium`, `large`, `xlarge`, `xxlarge`
 `small` being the default one.
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 initialState = { modalOpened: false};
 const sizes = [
   'xsmall',
@@ -56,7 +56,7 @@ const sizes = [
 Besides the default spacing inside a Modal, you can choose another type from this two available: `small` and `large`
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 initialState = { modalOpened: false};
 const spacings = [
   'small',
@@ -76,7 +76,7 @@ const spacings = [
 If you want the modal to fill all the available space, without margin, on mobile screen.
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 initialState = { modalOpened: false};
 
 <div>
@@ -92,7 +92,7 @@ initialState = { modalOpened: false};
 With `closable` set to `false`, the user will not be able to close the modal, even by clicking outside the modal. You must manage the modal's closing by yourself.
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 <div>
   <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
     Toggle modal
@@ -110,7 +110,7 @@ import Modal from './index';
 If you have a long content, the modal's content will scroll. For the scrollbars to be displayed correctly, you must specify `overflowHidden=true`.
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 <div>
   <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
     Toggle modal
@@ -128,7 +128,7 @@ import Modal from './index';
 You can specify primary and secondary actions. Use `primaryType` and `secondaryType` to choose the types of the buttons
 
 ```
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 const showModal = () => setState({ modalOpened: true })
 const hideModal = () => setState({ modalOpened: false });
 
@@ -154,7 +154,7 @@ const hideModal = () => setState({ modalOpened: false });
 For more complex modals, you can use individual components.
 
 ```
-import Modal, { ModalDescription, ModalHeader, ModalFooter } from './index';
+import Modal, { ModalDescription, ModalHeader, ModalFooter } from 'cozy-ui/transpiled/react/Modal';
 const headerStyle = {
   background: 'linear-gradient(to right, #005c97, #363795)',
   color: 'white',
@@ -184,7 +184,7 @@ const headerStyle = {
 If you need a part of your modal content fixed (not scrollable) and the other part scrollable, you need to compose you own complex modal.
 
 ```
-import Modal, { ModalContent, ModalHeader, ModalFooter } from './index';
+import Modal, { ModalContent, ModalHeader, ModalFooter } from 'cozy-ui/transpiled/react/Modal';
 
 <div>
   <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
@@ -213,7 +213,7 @@ If you need a modal with a branded header when you have a brand related content.
 #### with a background color
 
 ```
-import Modal, { ModalDescription, ModalBrandedHeader } from './index';
+import Modal, { ModalDescription, ModalBrandedHeader } from 'cozy-ui/transpiled/react/Modal';
 
 <div>
   <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
@@ -235,7 +235,7 @@ import Modal, { ModalDescription, ModalBrandedHeader } from './index';
 #### with a background gradient
 
 ```
-import Modal, { ModalDescription, ModalBrandedHeader } from './index';
+import Modal, { ModalDescription, ModalBrandedHeader } from 'cozy-ui/transpiled/react/Modal';
 
 <div>
   <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
@@ -257,7 +257,7 @@ import Modal, { ModalDescription, ModalBrandedHeader } from './index';
 #### Animated Content Header
 
 ```
-import Modal, { ModalContent, AnimatedContentHeader } from './index';
+import Modal, { ModalContent, AnimatedContentHeader } from 'cozy-ui/transpiled/react/Modal';
 
 // heigth 128px
 const animatedHeader = <img src="https://cozy.io/fr/images/cozy-logo-name-horizontal-blue.svg" />;
@@ -312,7 +312,7 @@ class ModalCounterWithAnimatedHeader extends React.Component {
 When your modal contains a multi-step process, you may want to add a back button that takes care of going one step back in the inner process, but not close the modal. In that case, you can use the `ModalBackButton` component.
 
 ```
-const { ModalContent, ModalBackButton } = Modal;
+import Modal, { ModalContent, ModalBackButton } from 'cozy-ui/transpiled/react/Modal';
 const toggle = () => setState({ modalOpened: !state.modalOpened });
 const goToStep1 = () => setState({ step: 1 });
 const goToStep2 = () => setState({ step: 2 });
@@ -349,8 +349,8 @@ initialState = {
 ### Panes
 
 ```
-import Modal, { ModalDescription, ModalBrandedHeader } from './index';
-import Panel from '../Panel';
+import Modal, { ModalDescription, ModalBrandedHeader } from 'cozy-ui/transpiled/react/Modal';
+import Panel from 'cozy-ui/transpiled/react/Panel';
 const toggle = () => setState({ modalOpened: !state.modalOpened });
 
 <div>
@@ -385,7 +385,7 @@ const toggle = () => setState({ modalOpened: !state.modalOpened });
 You can use the `into` prop to wrap the `Modal` in a `Portal`. This `prop` will be set to `"body"` in future versions so try to put it now to check if your Modal does not break when rendered in a Portal.
 
 ```jsx
-import Modal from './index';
+import Modal from 'cozy-ui/transpiled/react/Modal';
 initialState = { modalOpened: false};
 
 <div>

--- a/react/MuiCozyTheme/Buttons/Readme.md
+++ b/react/MuiCozyTheme/Buttons/Readme.md
@@ -1,6 +1,6 @@
 ```
-import MuiCozyTheme from '..';
-import Button from '.';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons';
 
 const ButtonsVariant = ({variant}) => {
   return (

--- a/react/MuiCozyTheme/ExpansionPanel/Readme.md
+++ b/react/MuiCozyTheme/ExpansionPanel/Readme.md
@@ -1,7 +1,7 @@
 ## Default
 
 ```
-import MuiCozyTheme from '..';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
@@ -39,12 +39,12 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 These are material-ui components, so you can customize it like any other:
 
 ```
-import MuiCozyTheme from '../index';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import { withStyles } from '@material-ui/core/styles';
-import Icon from '../../Icon';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 
 const StyledSummary = withStyles(() => ({
   expand: {}, // required to use `&$expanded` selector

--- a/react/MuiCozyTheme/Grid/Readme.md
+++ b/react/MuiCozyTheme/Grid/Readme.md
@@ -5,9 +5,9 @@ Displays a Grid of items
 ### Default usage
 
 ```
-import MuiCozyTheme from '..';
-import Grid from '.';
-import Card from '../../Card';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid';
+import Card from 'cozy-ui/transpiled/react/Card';
 
 <MuiCozyTheme>
     <Grid container spacing={24}>

--- a/react/MuiCozyTheme/List/Readme.md
+++ b/react/MuiCozyTheme/List/Readme.md
@@ -6,16 +6,16 @@ Displays a List of items, with several metadata
 
 ### Default usage
 ```
-import MuiCozyTheme from '..';
-import List from '.';
-import ListItem from '../ListItem';
-import ListItemIcon from '../ListItemIcon';
-import ListItemText from '../../ListItemText';
-import ListItemSecondaryAction from '../ListItemSecondaryAction';
-import Icon from '../../Icon';
-import Menu from '../Menus';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List';
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem';
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Menu from 'cozy-ui/transpiled/react/MuiCozyTheme/Menus';
 import MenuItem from '@material-ui/core/MenuItem'
-import Button from '../../Button';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <MuiCozyTheme>
   <List>
@@ -62,13 +62,13 @@ import Button from '../../Button';
 ### dense
 Reduce the space around a list item
 ```
-import MuiCozyTheme from '..';
-import List from '.';
-import ListItem from '../ListItem';
-import ListItemIcon from '../ListItemIcon';
-import ListItemText from '../../ListItemText';
-import ListItemSecondaryAction from '../ListItemSecondaryAction';
-import Icon from '../../Icon';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List';
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem';
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 
 <MuiCozyTheme>
   <List dense={true}>
@@ -95,12 +95,12 @@ import Icon from '../../Icon';
 ### List item selected
 Highlight a selected item from the list
 ```
-import MuiCozyTheme from '..';
-import List from '.';
-import ListItem from '../ListItem';
-import ListItemIcon from '../ListItemIcon';
-import ListItemText from '../../ListItemText';
-import Icon from '../../Icon';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List';
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem';
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 
 <MuiCozyTheme>
   <List>
@@ -125,13 +125,14 @@ import Icon from '../../Icon';
 ### List with sub header
 Adds a sub header as a list divider
 ```
-import MuiCozyTheme from '..';
-import List from '.';
-import ListItem from '../ListItem';
-import ListItemIcon from '../ListItemIcon';
-import ListItemText from '../../ListItemText';
-import ListSubheader from '../ListSubheader';
-import Icon from '../../Icon';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List';
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem';
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
+import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+
 
 <MuiCozyTheme>
   <List>

--- a/react/MuiCozyTheme/Menus/Readme.md
+++ b/react/MuiCozyTheme/Menus/Readme.md
@@ -1,8 +1,8 @@
 ```
-import MuiCozyTheme from '..';
-import Menu from '.';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import Menu from 'cozy-ui/transpiled/react/MuiCozyTheme/Menus';
 import MenuItem from '@material-ui/core/MenuItem';
-import Button from '../../Button';
+import Button from 'cozy-ui/transpiled/react/Button';
 
 <MuiCozyTheme>
   <Menu

--- a/react/MuiCozyTheme/RaisedList/README.md
+++ b/react/MuiCozyTheme/RaisedList/README.md
@@ -1,8 +1,8 @@
 ```
-import MuiCozyTheme from '..';
-import RaisedList from '.';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import RaisedList from 'cozy-ui/transpiled/react/MuiCozyTheme/RaisedList';
 import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '../../ListItemText';
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
 
 <MuiCozyTheme>
   <RaisedList>

--- a/react/MuiCozyTheme/Readme.md
+++ b/react/MuiCozyTheme/Readme.md
@@ -1,5 +1,5 @@
 ```jsx static
-import MuiCozyTheme from 'cozy-ui/react/MuiCozyTheme'
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Button from '@material-ui/core/Button'
 
 const DisplayButtonWithCozyTheme = () => (

--- a/react/Overlay/Readme.md
+++ b/react/Overlay/Readme.md
@@ -1,5 +1,5 @@
 ```
-import Overlay from './index';
+import Overlay from 'cozy-ui/transpiled/react/Overlay';
 initialState={ overlayShown: false}
 const showOverlay = () => setState({overlayShown: true})
 const hideOverlay = () => setState({overlayShown: false});
@@ -17,7 +17,7 @@ It can react to the escape key.
 
 
 ```
-import Overlay from './index';
+import Overlay from 'cozy-ui/transpiled/react/Overlay';
 initialState={ overlayShown: false}
 const showOverlay = () => setState({overlayShown: true})
 const hideOverlay = () => setState({overlayShown: false});

--- a/react/Page/Readme.md
+++ b/react/Page/Readme.md
@@ -6,7 +6,7 @@ shown, the Page real estate shrinks and the Button will try to appear above the 
 has enough space.
 
 ```jsx static
-const { PageLayout, PageContent, PageFooter } = require('./index');
+import { PageLayout, PageContent, PageFooter } from 'cozy-ui/transpiled/react/Page';
 
 <PageLayout>
   <PageContent>Hello world !</PageContent>

--- a/react/PercentageLine/Readme.md
+++ b/react/PercentageLine/Readme.md
@@ -1,5 +1,5 @@
 ```
-import PercentageLine from './index';
+import PercentageLine from 'cozy-ui/transpiled/react/PercentageLine';
 initialState = { percentage: 0.5 * 100 };
 
 <>

--- a/react/Popup/Readme.md
+++ b/react/Popup/Readme.md
@@ -3,7 +3,7 @@ A simple Popup which provides handlers for a few events.
 ### Simple use case
 
 ```
-import Popup from './index';
+import Popup from 'cozy-ui/transpiled/react/Popup';
 <div>
   <button onClick={() => setState({ showPopup: true })}>
     Show popup

--- a/react/PopupOpener/Readme.md
+++ b/react/PopupOpener/Readme.md
@@ -1,7 +1,7 @@
 #### An popup opener
 
 ```
-import PopupOpener from './index';
+import PopupOpener from 'cozy-ui/transpiled/react/PopupOpener';
 <PopupOpener url="https://cozy.io" title="Cozy Site" height={500} width={500}>
   <button>Toggle Popup</button>
 </PopupOpener>

--- a/react/PushClientBanner/Readme.md
+++ b/react/PushClientBanner/Readme.md
@@ -4,7 +4,7 @@ Banner to advertise for Cozy desktop client.
 ### Basic usage
 
 ```
-import BannerClient from './index';
+import BannerClient from 'cozy-ui/transpiled/react/PushClientBanner';
 <BannerClient
   text="Get Cozy Drive for Desktop and synchronise your files safely to make them accessible at all times."
   hrefMobile="https://cozy.io"
@@ -18,7 +18,7 @@ import BannerClient from './index';
 #### action
 You can add a function to `onClick` prop on top of the hyperlink
 ```
-import BannerClient from './index';
+import BannerClient from 'cozy-ui/transpiled/react/PushClientBanner';
 <BannerClient
   text="Get Cozy Drive for Desktop and synchronise your files safely to make them accessible at all times."
   hrefMobile="https://cozy.io"

--- a/react/PushClientButton/Readme.md
+++ b/react/PushClientButton/Readme.md
@@ -4,7 +4,7 @@ Call To Action for downloading Cozy desktop client.
 ### Basic usage
 
 ```
-import ButtonClient from './index';
+import ButtonClient from 'cozy-ui/transpiled/react/PushClientButton';
 <ButtonClient label="Download our desktop client" href="https://cozy.io" />
 ```
 
@@ -12,7 +12,7 @@ import ButtonClient from './index';
 #### action
 You can add a function to `onClick` prop on top of the hyperlink
 ```
-import ButtonClient from './index';
+import ButtonClient from 'cozy-ui/transpiled/react/PushClientButton';
 <ButtonClient
   label="Download our desktop client"
   href="https://cozy.io"
@@ -23,7 +23,7 @@ import ButtonClient from './index';
 #### className
 You can add custom classNames
 ```
-import ButtonClient from './index';
+import ButtonClient from 'cozy-ui/transpiled/react/PushClientButton';
 <ButtonClient
   label="Download our desktop client"
   href="https://cozy.io"

--- a/react/Radio/Readme.md
+++ b/react/Radio/Readme.md
@@ -1,7 +1,7 @@
 ### Radio
 
 ```
-import Radio from './index';
+import Radio from 'cozy-ui/transpiled/react/Radio';
 <form>
   <div>
     <Radio name="radioForm" value="radioValue1" label="This is a radio button" />
@@ -14,13 +14,13 @@ import Radio from './index';
 ### Radio when there's an error
 
 ```
-import Radio from './index';
+import Radio from 'cozy-ui/transpiled/react/Radio';
 <div><Radio name="radioForm" value="radioValue1" label="This is a radio button" error /></div>
 ```
 
 ### Radio when disabled
 
 ```
-import Radio from './index';
+import Radio from 'cozy-ui/transpiled/react/Radio';
 <div><Radio name="radioForm"value="radioValue1" label="This is a disabled radio button" disabled /></div>
 ```

--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -5,7 +5,7 @@ A select box for more advanced use cases, based on [`react-select` v2](https://r
 You can use this exactly like you would use `react-select`. See the [official documentation](https://react-select.com) for more examples.
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
@@ -24,7 +24,7 @@ const options = [
 For example if you want to force the menu to be open:
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' }
 ];
@@ -42,7 +42,7 @@ option list is shown.
 This example should not cause an overflow on the SelectBoxWrapper component.
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'banana', label: 'Banana' },
   { value: 'chocolate', label: 'Chocolate' },
@@ -85,7 +85,7 @@ class SelectBoxWrapper extends React.Component {
 Disable the SelectBox
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
@@ -101,7 +101,7 @@ const options = [
 Set the select to spread to 100% of the available width (default: `false`).
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
 { value: 'chocolate', label: 'Chocolate' },
 { value: 'strawberry', label: 'Strawberry', isDisabled: true },
@@ -117,7 +117,7 @@ const options = [
 This property gives access to the underlying `<input />` element contained into a `ReactSelect` component, for example to give focus or move the caret.
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
@@ -138,7 +138,7 @@ let inputElement;
 Set the text size between `tiny`, `medium` and `large` (default: `large`).
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const tinyOptions = [
   { value: '1', label: 'I am a tiny SelectBox' },
   { value: '2', label: 'I am not a medium SelectBox' },
@@ -169,7 +169,7 @@ const largeOptions = [
 You can use the `reactSelectControl` HOC to turn an existing, custom component into the control button for the `Select`:
 
 ```
-import SelectBox, { reactSelectControl } from './index';
+import SelectBox, { reactSelectControl } from 'cozy-ui/transpiled/react/SelectBox';
 const MyControl = <button>toggle options</button>;
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
@@ -190,7 +190,7 @@ const options = [
 There is a `CheckboxOption` component that can be used as an `Option`, and renders like this:
 
 ```
-import SelectBox, { CheckboxOption } from './index';
+import SelectBox, { CheckboxOption } from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry' },
@@ -211,7 +211,7 @@ const options = [
 You can display additional actions inside an Option with the ActionsOption component.
 
 ```
-import SelectBox, { ActionsOption } from './index';
+import SelectBox, { ActionsOption } from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
@@ -232,7 +232,7 @@ const CustomOption = (props) => (<ActionsOption {...props} actions={[
 ### Fixed options
 
 ```
-import { SelectBoxWithFixedOptions } from './index';
+import { SelectBoxWithFixedOptions } from 'cozy-ui/transpiled/react/SelectBox';
 const options = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('').map(x => ({ value:x, label: x }));
 
 options[0].fixed = true
@@ -251,7 +251,7 @@ from `react-select` for you to further customize the components.
 Here a custom class is applied to the `ValueContainer`.
 
 ```
-import SelectBox, { components } from './index';
+import SelectBox, { components } from 'cozy-ui/transpiled/react/SelectBox';
 
 const ValueContainer = props => {
   return (
@@ -272,7 +272,7 @@ const ValueContainer = props => {
 Add a prefix className:
 
 ```
-import SelectBox from './index';
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' }
 ];

--- a/react/Sidebar/Readme.md
+++ b/react/Sidebar/Readme.md
@@ -6,7 +6,7 @@ used as follows.
 
 ```jsx static
 import { NavLink as RRNavLink } from 'react-router'
-import { genNavLink } from 'cozy-ui/react/Nav'
+import { genNavLink } from 'cozy-ui/transpiled/react/Nav'
 
 const NavLink = genNavLink(RRNavLink)
 ```
@@ -14,8 +14,8 @@ const NavLink = genNavLink(RRNavLink)
 In action :
 
 ```
-import Sidebar from './index';
-import Nav, { NavItem, NavIcon, NavText, genNavLink } from '../Nav';
+import Sidebar from 'cozy-ui/transpiled/react/Sidebar';
+import Nav, { NavItem, NavIcon, NavText, genNavLink } from 'cozy-ui/transpiled/react/Nav';
 
 const NavLink = genNavLink(({ children, className }) =>
   <a className={className}>{ children }</a>);

--- a/react/Spinner/Readme.md
+++ b/react/Spinner/Readme.md
@@ -3,14 +3,14 @@ Show a spinner when loading something.
 ### Default
 
 ```
-import Spinner from './index';
+import Spinner from 'cozy-ui/transpiled/react/Spinner';
 <Spinner />
 ```
 
 ### Color
 
 ```
-import Spinner from './index';
+import Spinner from 'cozy-ui/transpiled/react/Spinner';
 <div>
   blue (default): <Spinner /> or <Spinner color='blue' />
   grey: <Spinner color='grey' />
@@ -22,7 +22,7 @@ import Spinner from './index';
 ### Placement
 
 ```
-import Spinner from './index';
+import Spinner from 'cozy-ui/transpiled/react/Spinner';
 <div>
   <Spinner noMargin={ true }/>
 </div>
@@ -31,7 +31,7 @@ import Spinner from './index';
 ### Sizes
 
 ```
-import Spinner from './index';
+import Spinner from 'cozy-ui/transpiled/react/Spinner';
 <div>
   tiny: <Spinner size='tiny' /><br/>
   small: <Spinner size='small' /><br/>
@@ -51,8 +51,8 @@ When you use `loadingType`, `<Spinner />` needs to be in an `<I18n />` wrapper a
 ```
 
 ```
-import Spinner from './index';
-import I18n from '../I18n';
+import Spinner from 'cozy-ui/transpiled/react/Spinner';
+import I18n from 'cozy-ui/transpiled/react/I18n';
 
 <div>
   <I18n lang='en' dictRequire={() => {}}>

--- a/react/Stack/Readme.md
+++ b/react/Stack/Readme.md
@@ -6,8 +6,8 @@ See [this article](https://every-layout.dev/layouts/stack/) for more information
 The padding is responsive, it is smaller on mobile/tablet.
 
 ```
-import Stack from './index';
-import Card from '../Card';
+import Stack from 'cozy-ui/transpiled/react/Stack';
+import Card from 'cozy-ui/transpiled/react/Card';
 
 <Stack>
   <Card>Homer Simpson</Card>
@@ -21,8 +21,8 @@ import Card from '../Card';
 You can use `xs`, `s`, `l`, `xl`, and `xxl` values for "spacing" to have less/more padding.
 
 ```
-import Stack from './index';
-import Card from '../Card';
+import Stack from 'cozy-ui/transpiled/react/Stack';
+import Card from 'cozy-ui/transpiled/react/Card';
 const spacings = ['xs', 's', 'l', 'xl', 'xxl'];
 
 <div>

--- a/react/Tabs/Readme.md
+++ b/react/Tabs/Readme.md
@@ -1,6 +1,6 @@
 
 ```
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from './index';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from 'cozy-ui/transpiled/react/Tabs';
 
 const general = `
   Grace Murray Hopper, née le 9 décembre 1906 à New York et morte le 1er janvier 1992 dans le comté d'Arlington, est une informaticienne américaine et Rear admiral (lower half) de la marine américaine. Elle est la conceptrice du premier compilateur en 1951 (A-0 System) et du langage COBOL en 1959.

--- a/react/Text/Readme.md
+++ b/react/Text/Readme.md
@@ -1,7 +1,7 @@
 #### Standard text
 
 ```
-import Text from './index';
+import Text from 'cozy-ui/transpiled/react/Text';
 
 <Text>This a standard text</Text>
 ```
@@ -9,7 +9,7 @@ import Text from './index';
 #### Main title
 
 ```
-import { MainTitle } from './index';
+import { MainTitle } from 'cozy-ui/transpiled/react/Text';
 
 <MainTitle>This a main title text</MainTitle>
 ```
@@ -17,7 +17,7 @@ import { MainTitle } from './index';
 #### Title
 
 ```
-import { Title } from './index';
+import { Title } from 'cozy-ui/transpiled/react/Text';
 
 <Title>This a title text</Title>
 ```
@@ -25,7 +25,7 @@ import { Title } from './index';
 #### SubTitle
 
 ```
-import { SubTitle } from './index';
+import { SubTitle } from 'cozy-ui/transpiled/react/Text';
 
 <SubTitle>This a subtitle text</SubTitle>
 ```
@@ -33,7 +33,7 @@ import { SubTitle } from './index';
 #### Bold text
 
 ```
-import { Bold } from './index';
+import { Bold } from 'cozy-ui/transpiled/react/Text';
 
 <Bold>This a bold text</Bold>
 ```
@@ -41,7 +41,7 @@ import { Bold } from './index';
 #### Uppercase test
 
 ```
-import { Uppercase } from './index';
+import { Uppercase } from 'cozy-ui/transpiled/react/Text';
 
 <Uppercase>This is an uppercase text</Uppercase>
 ```
@@ -49,7 +49,7 @@ import { Uppercase } from './index';
 #### Caption text
 
 ```
-import { Caption } from './index';
+import { Caption } from 'cozy-ui/transpiled/react/Text';
 
 <Caption>This a caption text</Caption>
 ```

--- a/react/Textarea/Readme.md
+++ b/react/Textarea/Readme.md
@@ -1,28 +1,28 @@
 #### Textarea for long text
 
 ```
-import Textarea from './index';
+import Textarea from 'cozy-ui/transpiled/react/Textarea';
 <Textarea placeholder="Once upon a time…"></Textarea>
 ```
 
 #### Textarea when there's an error
 
 ```
-import Textarea from './index';
+import Textarea from 'cozy-ui/transpiled/react/Textarea';
 <Textarea error placeholder="Once upon a time, there was an error…"></Textarea>
 ```
 
 #### Disabled Textarea
 
 ```
-import Textarea from './index';
+import Textarea from 'cozy-ui/transpiled/react/Textarea';
 <Textarea disabled defaultValue="Don't edit me." />
 ```
 
 #### Alternative textarea sizes
 
 ```
-import Textarea from './index';
+import Textarea from 'cozy-ui/transpiled/react/Textarea';
 <div>
   <p>
     <Textarea placeholder="I'm have a tiny size" size="tiny"></Textarea>
@@ -36,7 +36,7 @@ import Textarea from './index';
 #### Full width textarea
 
 ```
-import Textarea from './index';
+import Textarea from 'cozy-ui/transpiled/react/Textarea';
 <div>
   <p>
     <Textarea placeholder="I'm full width" fullwidth></Textarea>
@@ -49,7 +49,7 @@ import Textarea from './index';
 `Textarea` forwards unknown props to the underlying `<textarea />` element.
 
 ```
-import Textarea from './index';
+import Textarea from 'cozy-ui/transpiled/react/Textarea';
 <div>
   <Textarea name='my-field' />
 </div>

--- a/react/Toggle/Readme.md
+++ b/react/Toggle/Readme.md
@@ -1,7 +1,7 @@
 ### Simplest usage
 
 ```js
-import Toggle from './index';
+import Toggle from 'cozy-ui/transpiled/react/Toggle';
 <Toggle id="simple-toggle" />
 ```
 
@@ -10,27 +10,27 @@ import Toggle from './index';
 - Toggle is **on** by default:
 
 ```js
-import Toggle from './index';
+import Toggle from 'cozy-ui/transpiled/react/Toggle';
 <Toggle id="toggle" checked />
 ```
 
 - Toggle is **off** by default:
 
 ```js
-import Toggle from './index';
+import Toggle from 'cozy-ui/transpiled/react/Toggle';
 <Toggle id="toggle" checked={false} />
 ```
 
 #### Disabled
 ```js
-import Toggle from './index';
+import Toggle from 'cozy-ui/transpiled/react/Toggle';
 <Toggle id="toggle" disabled={false} />
 ```
 
 ### More complex example
 
 ```jsx
-import Toggle from './index';
+import Toggle from 'cozy-ui/transpiled/react/Toggle';
 <div>
   <label
     htmlFor='0'

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -3,10 +3,10 @@ The `Viewer` component can be used to display the content of various file types.
 Once rendered, the `Viewer` will take up all the available space in it's container (using `position: absolute`). It can be paired with the `Overlay` component to take up the whole screen.
 
 ```
-import Viewer from './index';
+import Viewer from 'cozy-ui/transpiled/react/Viewer';
 // The DemoProvider inserts a fake cozy-client in the React context.
 import DemoProvider from './docs/DemoProvider';
-import Overlay from '../Overlay';
+import Overlay from 'cozy-ui/transpiled/react/Overlay';
 
 // We provide a collection of (fake) io.cozy.files to be rendered
 const files = [

--- a/react/Well/Readme.md
+++ b/react/Well/Readme.md
@@ -3,14 +3,14 @@
 ### Example:
 
 ```js static
-import Card from '../Card';
+import Card from 'cozy-ui/transpiled/react/Card';
 <Card inset className="u-bg-paleGrey">
   Your content
 </Card>
 ```
 
 ```
-import Well from './index';
+import Well from 'cozy-ui/transpiled/react/Well';
 <Well>
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 </Well>


### PR DESCRIPTION
Use an alias in the config so when we import things from `'cozy-ui/transpiled/react'` in the styleguide examples, it actually uses source files. This way, the examples can be copy-pasted without having to resolve import path afterwards in the app code.

See https://drazik.github.io/cozy-ui/react