### PR TITLE
feat: Update ghost button style

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -10,7 +10,7 @@ regularTheme = {
     primaryColor: var(--dodgerBlue), secondaryColor: var(--dodgerBlue), activeColor: var(--scienceBlue), contrastColor: var(--white)
 }
 ghostTheme = {
-    primaryColor: var(--hawkesBlue), secondaryColor: var(--primaryColor), activeColor: var(--hawkesBlue), contrastColor: var(--primaryColor)
+    primaryColor: var(--zircon), secondaryColor: var(--frenchPass), activeColor: var(--frenchPass), contrastColor: var(--dodgerBlue)
 }
 highlightTheme = {
     primaryColor: var(--emerald), secondaryColor: var(--emerald), activeColor: var(--malachite), contrastColor: var(--white)
@@ -112,11 +112,6 @@ $button--regular  // Deprecated
 $button--ghost
     themedBtn(ghostTheme)
     border-style dashed
-
-    &:active
-    &:hover
-    &:focus
-        border-color: var(--primaryColor)
 
 $button--highlight
     themedBtn(highlightTheme)


### PR DESCRIPTION
A small update to our ghost button style, including missing hover styles, curtesy of @joel-costa 

Before: 

<img width="401" alt="Capture d'écran 2019-10-22 10 26 14" src="https://user-images.githubusercontent.com/2261445/67269553-38c2e500-f4b7-11e9-8946-a8ccf125a050.png">

After:

<img width="407" alt="Capture d'écran 2019-10-22 10 26 21" src="https://user-images.githubusercontent.com/2261445/67269559-3bbdd580-f4b7-11e9-8aaf-ccd94d575e75.png">
