### PR TITLE
fix(Tabs): Overflow scroll only when needed

### DIFF
--- a/react/Tabs/Readme.md
+++ b/react/Tabs/Readme.md
@@ -45,5 +45,30 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non, soluta. Voluptas 
     </TabPanels>
   </Tabs>
 
+  <div style={{ width: 300, marginTop: 32 }}>
+    <Tabs initialActiveTab='general'>
+      <TabList inverted>
+        <Tab name='general'>General</Tab>
+        <Tab name='details'>Details</Tab>
+        <Tab name='similar'>Similar</Tab>
+        <Tab name='others'>Others</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel name='general'>
+          { general }
+        </TabPanel>
+        <TabPanel name='details'>
+          { description }
+        </TabPanel>
+        <TabPanel name='similar'>
+          Similar tab
+        </TabPanel>
+        <TabPanel name='others'>
+          Others tab
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  </div>
+
 </>
 ```

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3914,6 +3914,21 @@ exports[`Tabs should render examples: Tabs 1`] = `
       </div>
     </div>
   </div>
+  <div style=\\"width: 300px; margin-top: 32px;\\">
+    <div class=\\"styles__coz-tabs___24QL5\\">
+      <div class=\\"styles__coz-tab-list___3qac8 styles__coz-tab-list--inverted___3VjXc\\">
+        <div class=\\"styles__coz-tab___2mOye styles__coz-tab--active___1wmwM\\">General</div>
+        <div class=\\"styles__coz-tab___2mOye\\">Details</div>
+        <div class=\\"styles__coz-tab___2mOye\\">Similar</div>
+        <div class=\\"styles__coz-tab___2mOye\\">Others</div>
+      </div>
+      <div class=\\"\\">
+        <div class=\\"styles__coz-tab-panel___35538\\">
+          Grace Murray Hopper, née le 9 décembre 1906 à New York et morte le 1er janvier 1992 dans le comté d'Arlington, est une informaticienne américaine et Rear admiral (lower half) de la marine américaine. Elle est la conceptrice du premier compilateur en 1951 (A-0 System) et du langage COBOL en 1959.
+        </div>
+      </div>
+    </div>
+  </div>
 </div>"
 `;
 

--- a/stylus/components/tabs.styl
+++ b/stylus/components/tabs.styl
@@ -5,7 +5,8 @@ $tabs-base
     .coz-tab-list
         border-bottom  rem(1) solid var(--silver)
         background var(--tabsBackgroundColor)
-        overflow-x scroll
+        overflow-x auto
+        display flex
 
     .coz-tab-list--inverted
         --tabsActiveTextColor var(--primaryContrastTextColor)
@@ -14,7 +15,7 @@ $tabs-base
         --tabsBackgroundColor var(--primaryColor)
 
     .coz-tab
-        display        inline-block
+        flex 0 0
         padding        rem(10 16)
         text-transform uppercase
         font-size      rem(12)


### PR DESCRIPTION
Using `overflow-x: scroll` causes a scroll gutter to be always rendered
on some platforms, even if scroll is not needed because nothing
overflows. Using `overflow-x: auto` prevents this, but we also need to
use `display: flex` on the parent instead of `display: inline-block` on
children, otherwise they wrap.

See https://drazik.github.io/cozy-ui/react/#!/Tab/0