### PR TITLE
feat: Allows `ref` forwarding in Textarea

### DIFF
--- a/react/Textarea/Readme.md
+++ b/react/Textarea/Readme.md
@@ -54,3 +54,5 @@ import Textarea from 'cozy-ui/transpiled/react/Textarea';
   <Textarea name='my-field' />
 </div>
 ```
+
+It will also forwards the [`ref`](https://reactjs.org/docs/refs-and-the-dom.html) property received by the `<Textarea />` to the underlying `<textarea />`. The calling component will then have access to a reference to the `<textarea />` DOM node.

--- a/react/Textarea/index.jsx
+++ b/react/Textarea/index.jsx
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
-const Textarea = props => {
+const Textarea = React.forwardRef((props, ref) => {
   const {
     className,
     disabled,
@@ -16,6 +16,7 @@ const Textarea = props => {
   } = props
   return (
     <textarea
+      ref={ref}
       aria-disabled={disabled}
       disabled={disabled}
       placeholder={placeholder}
@@ -33,7 +34,7 @@ const Textarea = props => {
       {children}
     </textarea>
   )
-}
+})
 
 Textarea.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
```
<Textarea ref={domRef} />
```
