### PR TITLE
fix(Menu): Warning initialOpen

### DIFF
--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -109,6 +109,7 @@ class Menu extends Component {
       /* eslint-disable no-unused-vars */
       onSelect,
       onSelectDisabled,
+      initialOpen,
       /* eslint-enable no-unused-vars */
       ...restProps
     } = this.props


### PR DESCRIPTION
> React does not recognize the `initialOpen` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `initialopen` instead. If you accidentally passed it from a parent component, remove it from the DOM element.


Since we don't want to pass this props to the DOM, we add it to the destructured list.. 