### PR TITLE
feat(CompositeRow): Don't set margins

### DIFF
--- a/react/CompositeRow/index.jsx
+++ b/react/CompositeRow/index.jsx
@@ -21,7 +21,7 @@ const CompositeRow = ({
 }) => {
   return (
     <Media
-      className={cx('u-mb-2 ', className, dense ? 'u-ph-1' : 'u-p-1')}
+      className={cx(className, dense ? 'u-ph-1' : 'u-p-1')}
       style={dense ? Object.assign({}, denseStyle, style) : style}
     >
       <div className="u-media u-media-grow u-row-m">


### PR DESCRIPTION
Since CompositeRows have a margin-bottom, we have to add style to them if we want to render multiple ones as a list. I think CompositeRow should not take care of its margins. The context in which we render them should take care of that (using a Stack, for example).

See https://drazik.github.io/cozy-ui/react/#!/CompositeRow

BREAKING CHANGE: CompositeRow no longer have bottom margin. You can add
the `u-mb-2` class name to you CompositeRows if you want to keep the
previous style