### PR TITLE
feat: Add display name to withBreakpoints components

### DIFF
--- a/react/helpers/withBreakpoints.jsx
+++ b/react/helpers/withBreakpoints.jsx
@@ -50,7 +50,7 @@ const getBreakpointsStatus = breakpoints => {
  *
  *
  */
-const withBreakpoints = (bp = breakpoints) => Wrapped =>
+const withBreakpoints = (bp = breakpoints) => Wrapped => {
   class Aware extends Component {
     constructor(props) {
       super(props)
@@ -80,6 +80,10 @@ const withBreakpoints = (bp = breakpoints) => Wrapped =>
       return <Wrapped {...props} breakpoints={breakpoints} />
     }
   }
+
+  Aware.displayName = `withBreakpoints(${Wrapped.displayName || Wrapped.name})`
+  return Aware
+}
 
 /**
  * HOC that tries a predicate on props + state and


### PR DESCRIPTION
withBreakpoints did not add a display name to the wrapped component, it
does now by keeping the display name of the wrapped component and wrapping
it with "withBreakpoints()" (can you wrap your head around this sentence ?).