### PR TITLE
feat(PercentageLine): Make it customizable

### DIFF
--- a/react/PercentageLine/PercentageLine.styl
+++ b/react/PercentageLine/PercentageLine.styl
@@ -1,4 +1,7 @@
 .PercentageLine
+    height 5px
+
+.PercentageLine__inner
+    height 100%
     transition transform 0.3s ease
     transform-origin 0 0
-    height 5px

--- a/react/PercentageLine/Readme.md
+++ b/react/PercentageLine/Readme.md
@@ -1,9 +1,14 @@
 ```
 import PercentageLine from 'cozy-ui/transpiled/react/PercentageLine';
+import styles from './customization-example.styl';
 initialState = { percentage: 0.5 * 100 };
 
 <>
     <button onClick={() => setState({ percentage: Math.random() * 100})}>Random percentage</button>
-    {(state.percentage).toFixed(2)}% <PercentageLine  color='var(--primaryColor)' value={state.percentage}/>
+    {(state.percentage).toFixed(2)}%
+    <h2>Original</h2>
+    <PercentageLine  color='var(--primaryColor)' value={state.percentage}/>
+    <h2>Customized with a class name</h2>
+    <PercentageLine color="var(--primaryColor)" value={state.percentage} className={styles.CustomizedPercentageLine} />
 </>
 ```

--- a/react/PercentageLine/customization-example.styl
+++ b/react/PercentageLine/customization-example.styl
@@ -1,0 +1,2 @@
+.CustomizedPercentageLine
+    background-color var(--coolGrey)

--- a/react/PercentageLine/index.jsx
+++ b/react/PercentageLine/index.jsx
@@ -4,14 +4,16 @@ import styles from './PercentageLine.styl'
 import PropTypes from 'prop-types'
 
 const PercentageLine = ({ value, color, className, style }) => (
-  <div
-    className={cx(className, styles.PercentageLine)}
-    style={{
-      transform: `scaleX(${value / 100})`,
-      backgroundColor: color,
-      ...style
-    }}
-  />
+  <div className={cx(className, styles.PercentageLine)}>
+    <div
+      className={styles.PercentageLine__inner}
+      style={{
+        transform: `scaleX(${value / 100})`,
+        backgroundColor: color,
+        ...style
+      }}
+    />
+  </div>
 )
 
 PercentageLine.propTypes = {


### PR DESCRIPTION
In the context of consumer credit details page in banks, we need to show
a percentage line that is slightly different from the one we have in UI.
All customizations (like adding a background-color, a track border) were
not possible with the current implementation. With these changes, we can
customize it more.

See https://drazik.github.io/cozy-ui/react/#!/PercentageLine (it has no visual effect on the styleguide example though).

See https://app.zeplin.io/project/584a6f4e838090371f59518f/screen/5dc074f342347622db75a1a4 to know what we want to achieve by customizing the PercentageLine