### PR TITLE
fix: Border box for input group

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -472,6 +472,7 @@ $field-inline
 $inputgroup
     display inline-flex
     flex-direction row
+    box-sizing border-box
     align-items stretch
     width 100%
     max-width rem(512)


### PR DESCRIPTION
This is important since it sets its width to 100% and has
a border. If box-sizing is not set, the border can be
drawn outside the parent which can be a problem if the
parent has overflow: hidden