### PR TITLE
fix(PercentageBar): Force line to take full height

### DIFF
--- a/react/PercentageBar/styles.styl
+++ b/react/PercentageBar/styles.styl
@@ -6,6 +6,6 @@ radius = 4px
     height 1.5rem
     border-radius radius
 
-.PercentageBar__line
-    height 100%
-    border-radius radius
+    .PercentageBar__line
+        height 100%
+        border-radius radius


### PR DESCRIPTION
It seems after transpilation the PercentageBar CSS is before the PercentageLine one (maybe for an alphabetic order ?). Since `.PercentageBar__line` and `.PercentageLine` selectors have the same specificity, then the later "wins", and the line in `PercentageBar` dont take the full height.