### PR TITLE
feat: Added IconGrid component

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -125,7 +125,8 @@ module.exports = {
       name: 'Labs',
       components: () => [
         '../react/Labs/GridItem',
-        '../react/Labs/ExperimentalModal'
+        '../react/Labs/ExperimentalModal',
+        '../react/Labs/IconGrid'
       ]
     }
   ],

--- a/react/Labs/IconGrid/Readme.md
+++ b/react/Labs/IconGrid/Readme.md
@@ -1,0 +1,14 @@
+### IconGrid
+
+A component to display a grid of 4 icons. This component is not considered stable and may be replaced by a more generic grid component in the future.
+
+```
+import IconGrid from 'cozy-ui/transpiled/react/Labs/IconGrid';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+<IconGrid>
+  <Icon icon="file" />
+  <Icon icon="cloud" />
+  <Icon icon="cloud-happy" />
+  <Icon icon="online" />
+</IconGrid>
+```

--- a/react/Labs/IconGrid/index.jsx
+++ b/react/Labs/IconGrid/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import styles from './styles.styl'
+
+const IconGrid = ({ children }) => (
+  <div className={styles['iconGrid']}>{children}</div>
+)
+
+export default IconGrid

--- a/react/Labs/IconGrid/styles.styl
+++ b/react/Labs/IconGrid/styles.styl
@@ -1,0 +1,5 @@
+.iconGrid
+    display grid
+    grid-template-columns repeat(2, 16px)
+    grid-template-rows repeat(2, 16px)
+    grid-gap rem(1)


### PR DESCRIPTION
This PR adds the IconGrid component, seen below:

<img width="100" alt="Capture d'écran 2019-11-07 18 00 23" src="https://user-images.githubusercontent.com/2261445/68410109-7c407300-0188-11ea-9348-cad500560eee.png">

It's in the Labs section because in an upcoming task, we will introduce a Grid component in cozy-ui, and my hope is that this Grid component is flexible enough to replace the IconGrid. In the meantime we have this component that displays a 2x2 grid of icons. Update documentation is [here](https://yannick-lohse.fr/cozy-ui/react/#!/IconGrid).



