### PR TITLE
Handle flat and nested subdomains

### DIFF
--- a/react/AppLinker/native.spec.js
+++ b/react/AppLinker/native.spec.js
@@ -1,60 +1,74 @@
-import { generateUniversalLink } from './native'
+import { generateUniversalLink, generateWebLink } from './native'
 
 describe('native functions', () => {
-  it('should generate the universalink', () => {
-    const universalLink = generateUniversalLink({
-      slug: 'drive',
-      nativePath: '/files/1',
-      fallbackUrl: 'https://drive.cozy.tools/files/1'
-    })
-    const endLink =
-      'https://links.mycozy.cloud/drive/files/1?fallback=https%3A%2F%2Fdrive.cozy.tools%2Ffiles%2F1'
+  describe('generating a web link', () => {
+    it('should generate a web link', () => {
+      const webLink = generateWebLink({
+        cozyUrl: 'https://test.cozy.tools:8080',
+        nativePath: '/files/1',
+        slug: 'drive'
+      })
 
-    expect(universalLink).toEqual(endLink)
+      expect(webLink).toEqual('https://test-drive.cozy.tools:8080/#/files/1')
+    })
   })
 
-  it('should generate the universalink with several search params', () => {
-    const universalLink = generateUniversalLink({
-      slug: 'drive',
-      nativePath: '/files/1?viewer=test',
-      fallbackUrl: 'https://drive.cozy.tools/files/1?viewer=test'
-    })
-    const endLink =
-      'https://links.mycozy.cloud/drive/files/1?viewer=test&fallback=https%3A%2F%2Fdrive.cozy.tools%2Ffiles%2F1%3Fviewer%3Dtest'
-    expect(universalLink).toEqual(endLink)
-  })
+  describe('universal link', () => {
+    it('should generate the universalink', () => {
+      const universalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '/files/1',
+        fallbackUrl: 'https://drive.cozy.tools/files/1'
+      })
+      const endLink =
+        'https://links.mycozy.cloud/drive/files/1?fallback=https%3A%2F%2Fdrive.cozy.tools%2Ffiles%2F1'
 
-  it('should generate the universalink for the home of an app', () => {
-    const universalLink = generateUniversalLink({
-      slug: 'drive',
-      nativePath: '/',
-      fallbackUrl: 'https://drive.cozy.tools/'
+      expect(universalLink).toEqual(endLink)
     })
-    const endLink =
-      'https://links.mycozy.cloud/drive/?fallback=https%3A%2F%2Fdrive.cozy.tools%2F'
-    expect(universalLink).toEqual(endLink)
-  })
 
-  it('should generate the universalink for the home of an app even if no path', () => {
-    const universalLink = generateUniversalLink({
-      slug: 'drive',
-      nativePath: '',
-      fallbackUrl: 'https://drive.cozy.tools/'
+    it('should generate the universalink with several search params', () => {
+      const universalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '/files/1?viewer=test',
+        fallbackUrl: 'https://drive.cozy.tools/files/1?viewer=test'
+      })
+      const endLink =
+        'https://links.mycozy.cloud/drive/files/1?viewer=test&fallback=https%3A%2F%2Fdrive.cozy.tools%2Ffiles%2F1%3Fviewer%3Dtest'
+      expect(universalLink).toEqual(endLink)
     })
-    const endLink =
-      'https://links.mycozy.cloud/drive/?fallback=https%3A%2F%2Fdrive.cozy.tools%2F'
 
-    expect(universalLink).toEqual(endLink)
-  })
-
-  it('should automatically generate fallbackUrl if provided with cozyUrl', () => {
-    const universalLink = generateUniversalLink({
-      slug: 'drive',
-      nativePath: '/files',
-      cozyUrl: 'https://name.cozy.tools/'
+    it('should generate the universalink for the home of an app', () => {
+      const universalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '/',
+        fallbackUrl: 'https://drive.cozy.tools/'
+      })
+      const endLink =
+        'https://links.mycozy.cloud/drive/?fallback=https%3A%2F%2Fdrive.cozy.tools%2F'
+      expect(universalLink).toEqual(endLink)
     })
-    const endLink =
-      'https://links.mycozy.cloud/drive/files?fallback=https%3A%2F%2Fname-drive.cozy.tools%2F%23%2Ffiles'
-    expect(universalLink).toEqual(endLink)
+
+    it('should generate the universalink for the home of an app even if no path', () => {
+      const universalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '',
+        fallbackUrl: 'https://drive.cozy.tools/'
+      })
+      const endLink =
+        'https://links.mycozy.cloud/drive/?fallback=https%3A%2F%2Fdrive.cozy.tools%2F'
+
+      expect(universalLink).toEqual(endLink)
+    })
+
+    it('should automatically generate fallbackUrl if provided with cozyUrl', () => {
+      const universalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '/files',
+        cozyUrl: 'https://name.cozy.tools/'
+      })
+      const endLink =
+        'https://links.mycozy.cloud/drive/files?fallback=https%3A%2F%2Fname-drive.cozy.tools%2F%23%2Ffiles'
+      expect(universalLink).toEqual(endLink)
+    })
   })
 })

--- a/react/AppLinker/native.spec.js
+++ b/react/AppLinker/native.spec.js
@@ -11,6 +11,24 @@ describe('native functions', () => {
 
       expect(webLink).toEqual('https://test-drive.cozy.tools:8080/#/files/1')
     })
+
+    it('should handle both types of subdomains', () => {
+      const flatLink = generateWebLink({
+        cozyUrl: 'https://test.cozy.tools:8080',
+        nativePath: '/files/1',
+        slug: 'drive',
+        subDomainType: 'flat'
+      })
+      expect(flatLink).toEqual('https://test-drive.cozy.tools:8080/#/files/1')
+
+      const nestedLink = generateWebLink({
+        cozyUrl: 'https://cozy.tools:8080',
+        nativePath: '/files/1',
+        slug: 'drive',
+        subDomainType: 'nested'
+      })
+      expect(nestedLink).toEqual('https://drive.cozy.tools:8080/#/files/1')
+    })
   })
 
   describe('universal link', () => {
@@ -69,6 +87,29 @@ describe('native functions', () => {
       const endLink =
         'https://links.mycozy.cloud/drive/files?fallback=https%3A%2F%2Fname-drive.cozy.tools%2F%23%2Ffiles'
       expect(universalLink).toEqual(endLink)
+    })
+
+    it('should handle both types of subdomains', () => {
+      const flatUniversalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '/files',
+        cozyUrl: 'https://name.cozy.tools/',
+        subDomainType: 'flat'
+      })
+      expect(flatUniversalLink).toEqual(
+        'https://links.mycozy.cloud/drive/files?fallback=https%3A%2F%2Fname-drive.cozy.tools%2F%23%2Ffiles'
+      )
+
+      const nestedUniversalLink = generateUniversalLink({
+        slug: 'drive',
+        nativePath: '/files',
+        cozyUrl: 'https://name.cozy.tools/',
+        subDomainType: 'nested'
+      })
+
+      expect(nestedUniversalLink).toEqual(
+        'https://links.mycozy.cloud/drive/files?fallback=https%3A%2F%2Fdrive.name.cozy.tools%2F%23%2Ffiles'
+      )
     })
   })
 })


### PR DESCRIPTION
So far when using AppLinker, we only supported the flat subdomains configuration. We can now support both, by using this PR and https://github.com/cozy/cozy-stack/pull/2172

