### PR TITLE
fix: Flex basis for tab names

### DIFF
--- a/react/Tabs/Readme.md
+++ b/react/Tabs/Readme.md
@@ -1,6 +1,6 @@
-
 ```
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from 'cozy-ui/transpiled/react/Tabs';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 
 const general = `
   Grace Murray Hopper, née le 9 décembre 1906 à New York et morte le 1er janvier 1992 dans le comté d'Arlington, est une informaticienne américaine et Rear admiral (lower half) de la marine américaine. Elle est la conceptrice du premier compilateur en 1951 (A-0 System) et du langage COBOL en 1959.
@@ -33,7 +33,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non, soluta. Voluptas 
   <Tabs initialActiveTab='general'>
     <TabList inverted>
       <Tab name='general'>General</Tab>
-      <Tab name='details'>Details</Tab>
+      <Tab name='details'>Details <Icon icon="magnifier" size={13} className="u-ml-half" /></Tab>
     </TabList>
     <TabPanels>
       <TabPanel name='general'>

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3961,7 +3961,9 @@ exports[`Tabs should render examples: Tabs 1`] = `
   <div class=\\"styles__coz-tabs___24QL5\\">
     <div class=\\"styles__coz-tab-list___3qac8 styles__coz-tab-list--inverted___3VjXc\\">
       <div class=\\"styles__coz-tab___2mOye styles__coz-tab--active___1wmwM\\">General</div>
-      <div class=\\"styles__coz-tab___2mOye\\">Details</div>
+      <div class=\\"styles__coz-tab___2mOye\\">Details <svg class=\\"u-ml-half styles__icon___23x3R\\" width=\\"13\\" height=\\"13\\">
+          <use xlink:href=\\"#magnifier\\"></use>
+        </svg></div>
     </div>
     <div class=\\"\\">
       <div class=\\"styles__coz-tab-panel___35538\\">

--- a/stylus/components/tabs.styl
+++ b/stylus/components/tabs.styl
@@ -15,7 +15,7 @@ $tabs-base
         --tabsBackgroundColor var(--primaryColor)
 
     .coz-tab
-        flex 0 0
+        flex 0 0 auto
         padding        rem(10 16)
         text-transform uppercase
         font-size      rem(12)


### PR DESCRIPTION
I'm still not sure *why*, but when specifying `flex 0 0`, the elements flex-basis is set to 0% instead of the default `auto`. This caused a problem when adding icons to tab names for example:

<img width="243" alt="Capture d'écran 2019-11-12 14 10 45" src="https://user-images.githubusercontent.com/2261445/68674720-ba59e000-0556-11ea-9ed3-92b278522cc8.png">

Specifying `flex 0 0 auto` solves the issue.