### PR TITLE
fix: Cannot use var referencing another var

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -21,7 +21,7 @@ export const theme = createMuiTheme({
       contrastText: getCssVariableValue('primaryContrastTextColor')
     },
     error: {
-      main: getCssVariableValue('errorColor')
+      main: getCssVariableValue('pomegranate')
     },
     secondary: {
       light: getCssVariableValue('monza'),

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -155,6 +155,4 @@
     --primaryColorLighter #4B93F7
     --primaryColorLightest #9FC4FB
     --primaryContrastTextColor var(--white)
-
-    --errorColor var(--pomegranate)
 // @stylint on


### PR DESCRIPTION
We have to use pomegranate right now instead of an indirection
since we cannot pass to mui a css variable.