### PR TITLE
fix: Fix grid gap value

### DIFF
--- a/react/Labs/IconGrid/styles.styl
+++ b/react/Labs/IconGrid/styles.styl
@@ -2,4 +2,4 @@
     display grid
     grid-template-columns repeat(2, 16px)
     grid-template-rows repeat(2, 16px)
-    grid-gap rem(1)
+    grid-gap 1px


### PR DESCRIPTION
Stylus compiles `grid-gap rem(1)` to… `grid-gap rem(1)`, which the browser obviously doesn't understand.