### PR TITLE
feat(ExpModal): Don't display Footer if no footer

### DIFF
--- a/react/Labs/ExperimentalModal/index.jsx
+++ b/react/Labs/ExperimentalModal/index.jsx
@@ -52,20 +52,22 @@ class ExperimentalModal extends Component {
         >
           {description}
         </ModalContent>
-        <ModalFooter
-          className={classNames({
-            [styles['modal-footer']]: isMobile
-          })}
-        >
-          <ModalButtons
-            primaryText={primaryText}
-            primaryAction={primaryAction}
-            primaryType={'regular'}
-            secondaryText={secondaryText}
-            secondaryAction={secondaryAction}
-            secondaryType={'secondary'}
-          />
-        </ModalFooter>
+        {primaryText && primaryAction && (
+          <ModalFooter
+            className={classNames({
+              [styles['modal-footer']]: isMobile
+            })}
+          >
+            <ModalButtons
+              primaryText={primaryText}
+              primaryAction={primaryAction}
+              primaryType={'regular'}
+              secondaryText={secondaryText}
+              secondaryAction={secondaryAction}
+              secondaryType={'secondary'}
+            />
+          </ModalFooter>
+        )}
       </Modal>
     )
   }


### PR DESCRIPTION
Currently we display the Footer (there is no button, but we have a border / box-shadow)  even if we don't have any action. With this commit, we only display the footer if we have at least a primaryAction 