### PR TITLE
feat: New variation for experimental modal

### DIFF
--- a/react/Labs/ExperimentalModal/Readme.md
+++ b/react/Labs/ExperimentalModal/Readme.md
@@ -1,11 +1,8 @@
 ### ExperimentalModal
 
-This modal brings a new UI only on Mobile for now. It changes the
-size of the Header and its margins and add border-bottom.
-It also changes our ModalFooter to something fixed in the bottom
-and add a border-top.
+There are 2 variations of this modal that can be used.
 
-Not tested on "long content".
+The first one has a fixed header and footer that are separated from the body of the modal by a border.
 
 ```
 import ExperimentalModal from 'cozy-ui/transpiled/react/Labs/ExperimentalModal';
@@ -26,6 +23,28 @@ const hideModal = () => setState({ modalOpened: false });
     primaryAction={hideModal}
     secondaryText='Touch me'
     secondaryAction={hideModal}
+    />
+    }
+</div>
+```
+
+In the second variation, the modal has no dedicated header or footer, everything is part of the main body content. But it is possible to fix some content at the bottom of the footer in case the main content is too short (only on mobile).
+
+```
+import ExperimentalModal from 'cozy-ui/transpiled/react/Labs/ExperimentalModal';
+import Button from 'cozy-ui/transpiled/react/Button';
+
+initialState = { modalOpened: isTesting()};
+const hideModal = () => setState({ modalOpened: false });
+
+<div>
+  <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  {state.modalOpened && <ExperimentalModal
+    dismissAction={hideModal}
+    description={content.ada.short}
+    descriptionFooter={<Button label="submit" />}
     />
     }
 </div>

--- a/react/Labs/ExperimentalModal/index.jsx
+++ b/react/Labs/ExperimentalModal/index.jsx
@@ -21,17 +21,18 @@ class ExperimentalModal extends Component {
       secondaryText,
       secondaryAction,
       description,
+      descriptionFooter,
       breakpoints: { isMobile }
     } = this.props
     return (
       <Modal
         mobileFullscreen
-        closable={isMobile ? false : true}
+        closable={isMobile && title ? false : true}
         size="large"
         title={isMobile ? '' : title}
         dismissAction={dismissAction}
       >
-        {isMobile && (
+        {isMobile && title && (
           <ModalHeader className={classNames(styles['modal-header'])}>
             <h2>{title}</h2>
 
@@ -47,10 +48,16 @@ class ExperimentalModal extends Component {
         )}
         <ModalContent
           className={classNames({
-            ['u-flex-grow-1 u-ph-1']: isMobile
+            ['u-flex-grow-1 u-ph-1']: isMobile,
+            ['u-flex u-flex-column']: descriptionFooter
           })}
         >
-          {description}
+          {descriptionFooter ? (
+            <div className="u-flex-grow-1">{description}</div>
+          ) : (
+            <>{description}</>
+          )}
+          {descriptionFooter}
         </ModalContent>
         {primaryText && primaryAction && (
           <ModalFooter


### PR DESCRIPTION
As the titles says, this is an alternative layout for the new modals. [Have a look at the documentation and let me know what you think.](https://yannick-lohse.fr/cozy-ui/react/#!/ExperimentalModal)

Eventually I think it would be good to rename `description` and `descriptionFooter` to maybe `content` and `contentFooter`, when I see `description` I tend to think of a simple string but it can be a lot more here.