### PR TITLE
Custom class name for BarButton + migrateProps displayName

### DIFF
--- a/react/BarButton/index.jsx
+++ b/react/BarButton/index.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import styles from './styles.styl'
 
@@ -26,10 +27,10 @@ MaybeLink.propTypes = {
 
 export class BarButton extends PureComponent {
   render() {
-    const { disabled, icon, href, onClick } = this.props
+    const { disabled, icon, href, onClick, className } = this.props
     return (
       <MaybeLink
-        className={styles['c-bar-btn']}
+        className={cx(styles['c-bar-btn'], className)}
         href={!disabled ? href : undefined}
         onClick={!disabled ? onClick : undefined}
       >
@@ -55,7 +56,11 @@ BarButton.propTypes = {
   /**
    * Click event handler on the component.
    */
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  /**
+   * Custom extra class name
+   */
+  className: PropTypes.string
 }
 
 export default BarButton

--- a/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
+++ b/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IntentModal component renders as expected 1`] = `
-<Unknown
+<Modal
   className="styles__intentModal___1aYIb"
   closable={true}
   closeBtnClassName="styles__intentModal__cross___1Hfuz"
@@ -26,5 +26,5 @@ exports[`IntentModal component renders as expected 1`] = `
     onTerminate={[MockFunction onCompleteMock]}
     type="io.cozy.whatever"
   />
-</Unknown>
+</Modal>
 `;

--- a/react/helpers/migrateProps.jsx
+++ b/react/helpers/migrateProps.jsx
@@ -79,7 +79,11 @@ const migrate = (oldProps, options) => {
  * @param  {Array} migrateOptions - Prop migrations that will be done on the old props
  * @return {HOC}
  */
-export default migrateOptions => Wrapped => oldProps => {
-  const newProps = migrate(oldProps, migrateOptions, Wrapped)
-  return <Wrapped {...newProps} />
+export default migrateOptions => Component => {
+  const Wrapped = oldProps => {
+    const newProps = migrate(oldProps, migrateOptions, Component)
+    return <Component {...newProps} />
+  }
+  Wrapped.displayName = Component.displayName || Component.name
+  return Wrapped
 }


### PR DESCRIPTION
Two unrelated changes grouped under 1 PR for convenience 😇

- Allow BarButton to receive a custom class name.
- migrateProps puts the same displayName on the wrapped component as the component it wraps