### PR TITLE
fix: Use a regular button for the modal cross

### DIFF
--- a/react/Modal/ModalCross.jsx
+++ b/react/Modal/ModalCross.jsx
@@ -1,19 +1,15 @@
 import React from 'react'
 import styles from './styles.styl'
 import cx from 'classnames'
-import { Button } from '../Button'
 import Icon from '../Icon'
 import palette from '../palette'
 
 const ModalCross = ({ onClick, color, className }) => (
-  <Button
-    theme="close"
+  <button
     className={cx(styles['c-modal-close'], className)}
     onClick={onClick}
-    extension="narrow"
     type="button"
-    label="Close"
-    iconOnly
+    aria-label="close"
   >
     <Icon
       icon="cross"
@@ -21,7 +17,7 @@ const ModalCross = ({ onClick, color, className }) => (
       height="24"
       color={color || palette['coolGrey']}
     />
-  </Button>
+  </button>
 )
 
 export default ModalCross

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -241,13 +241,14 @@ $modal-section
 cross-size=rem(40)
 
 $modal-close
+    box-sizing border-box
     position absolute
     top rem(24)
     right rem(24)
     margin 0
-    padding 0
-    background-size rem(28)
+    padding rem(8)
     background-color transparent
+    border 0
     cursor pointer
     display block
     width cross-size


### PR DESCRIPTION
We've had an issue for a while with the crosses in the modals of the styleguidist, more details can be found on [this thread](https://github.com/cozy/cozy-ui/issues/335#issuecomment-487582163) but basically it was a conflict of css classes.

With this fix, the cross doesn't use the `Button` component anymore, which means they don't try to override each others styles anymore.

My online preview repo is currently used by #1244 so I'll update this PR once the other one is merged.