### PR TITLE
fix: HMR for CSS works in styleguidist

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,22 @@
 const path = require('path')
+const { isUsingDevStyleguidist } = require('./docs/build-utils')
 
 const plugins = [
-  [
-    'css-modules-transform',
-    {
-      extensions: ['.styl'],
-      preprocessCss: './preprocess',
-      extractCss: './transpiled/react/stylesheet.css',
-      generateScopedName: '[name]__[local]___[hash:base64:5]'
-    }
-  ],
+  // While developing on the styleguidist, we do not want babel to touch the CSS
+  // otherwise CSS hot reload does not work
+  isUsingDevStyleguidist()
+    ? null
+    : [
+        'css-modules-transform',
+        {
+          extensions: ['.styl'],
+          preprocessCss: './preprocess',
+          extractCss: './transpiled/react/stylesheet.css',
+          generateScopedName: '[name]__[local]___[hash:base64:5]'
+        }
+      ],
   ['inline-json-import', {}]
-]
+].filter(Boolean)
 
 module.exports = {
   presets: [

--- a/docs/build-utils.js
+++ b/docs/build-utils.js
@@ -1,0 +1,8 @@
+const isUsingDevStyleguidist = () => {
+  const buildEnv = process.env.BUILD_ENV
+  return buildEnv === 'watch-styleguidist'
+}
+
+module.exports = {
+  isUsingDevStyleguidist
+}

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -1,5 +1,6 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const webpack = require('webpack')
+const { isUsingDevStyleguidist } = require('./build-utils')
 
 module.exports = {
   resolve: {
@@ -18,7 +19,11 @@ module.exports = {
       {
         test: /\.styl$/,
         loader: [
-          MiniCssExtractPlugin.loader,
+          // While developing on the styleguidist, we do not want the CSS
+          // to be extract otherwise CSS hot reload does not work
+          isUsingDevStyleguidist()
+            ? 'style-loader'
+            : MiniCssExtractPlugin.loader,
           {
             loader: 'css-loader',
             options: {
@@ -41,11 +46,11 @@ module.exports = {
     ]
   },
   plugins: [
-    new MiniCssExtractPlugin('[name].css'),
+    isUsingDevStyleguidist() ? null : new MiniCssExtractPlugin('[name].css'),
     new webpack.DefinePlugin({
       'process.env': {
         USE_REACT: 'true'
       }
     })
-  ]
+  ].filter(Boolean)
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "travis-deploy-once": "travis-deploy-once",
     "watch:css": "yarn build:css --watch",
     "prewatch:doc:react": "yarn sprite",
-    "watch:doc:react": "styleguidist server --config docs/styleguide.config.js",
+    "watch:doc:react": "env BUILD_ENV=watch-styleguidist styleguidist server --config docs/styleguide.config.js",
     "watch:doc:kss": "nodemon --ext styl,md --watch stylus --exec 'yarn build:doc:kss && http-server build/styleguide -p 4242'"
   },
   "sideEffects": [


### PR DESCRIPTION
When launching the styleguidist in watch mode, we add an environment
variable that babel and webpack use to disable extraction of CSS.


![ezgif-1-f82a2877b6e3](https://user-images.githubusercontent.com/465582/69352370-1cb09000-0c7d-11ea-8845-0d8f4444bd6f.gif)
