### PR TITLE
ModalStack

### DIFF
--- a/react/ViewStack/ModalStack.jsx
+++ b/react/ViewStack/ModalStack.jsx
@@ -3,6 +3,18 @@ import Modal from '../Modal'
 import { ViewStackContext } from './context'
 import { useStack } from './hooks'
 
+/**
+ * Wraps children so that they can push views that will appear as modals.
+ *
+ * - Children receive stack{Pop,Push} methods through `useViewStack`.
+ * - When stackPush(<View />) is called, a modal containing <View/> is displayed
+ * - When stackPop() is called, the modal disappears
+ * - Several modals can be stacked in this manner
+ * - The <Modal /> element wrapping <View /> can receive props via the 2nd
+ * argument of stackPush : `stackPush(<SmallView />, { size: 'xsmall' })`
+ *
+ * Can be used as a replacement of a <ViewStack /> on mobile
+ */
 const ModalStack = ({ children }) => {
   const [stChildren, , stackPush, stackPop] = useStack(
     React.Children.toArray(children)

--- a/react/ViewStack/ModalStack.jsx
+++ b/react/ViewStack/ModalStack.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import Modal from '../Modal'
+import { ViewStackContext } from './context'
+import { useStack } from './hooks'
+
+const ModalStack = ({ children }) => {
+  const [stChildren, , stackPush, stackPop] = useStack(
+    React.Children.toArray(children)
+  )
+
+  const contextValue = { stackPush, stackPop }
+
+  return (
+    <ViewStackContext.Provider value={contextValue}>
+      {stChildren[0]}
+      {stChildren.slice(1).map((child, i) => {
+        const hasProps = child.length > 1
+        const props = hasProps ? child[1] : null
+        child = hasProps ? child[0] : child
+        return (
+          <Modal mobileFullscreen key={i} dismissAction={stackPop} {...props}>
+            {child}
+          </Modal>
+        )
+      })}
+    </ViewStackContext.Provider>
+  )
+}
+
+export default ModalStack

--- a/react/ViewStack/index.js
+++ b/react/ViewStack/index.js
@@ -1,2 +1,3 @@
 export { default } from './ViewStack'
+export { default as ModalStack } from './ModalStack'
 export { useViewStack, ViewStackContext } from './context'


### PR DESCRIPTION
Using the same mechanism as the ViewStack (that should be renamed SlideStack
now ?) we can have a stack of views that uses Modals.

This could be useful for example to change the style of stacking based on
whether we are on desktop or mobile.

See how the switch from a sliding stack to a modalling (?) stack : https://github.com/cozy/cozy-banks/pull/1680/commits/3eedbf390f8adb5f4ddba2ad255c9e4e392e7f27