### PR TITLE
fix: Remove outline for focused buttons in DateMonthPicker

### DIFF
--- a/react/DateMonthPicker/styles.styl
+++ b/react/DateMonthPicker/styles.styl
@@ -28,6 +28,9 @@ $button
   &:active, &:hover:active
     @extend $buttonActive
 
+  &:focus
+      outline 0
+
 $select
   justify-content center
   display flex


### PR DESCRIPTION
There was still a little blue outline after clicking the buttons for prev/next
year in the DateMonthPicker.