### PR TITLE
Feat/tracker

### DIFF
--- a/react/helpers/tracker.jsx
+++ b/react/helpers/tracker.jsx
@@ -148,3 +148,24 @@ export const resetTracker = () => {
     trackerInstance = null
   }
 }
+/**
+ *
+ * @param {array} event Event to track ['Drive', 'action', 'label']
+ * @param {object} trackerForTest Mocked Tracker for test purpose
+ */
+export const trackEvent = (event, trackerForTest) => {
+  const tracker = trackerForTest || getTracker()
+  if (tracker) {
+    let trackEventArray = []
+    if (event && event[0]) {
+      //Like that, we can do trackEvent(['Drive', 'option1']) without thinking of adding this `trackEvent` attr
+      if (event[0] !== 'trackEvent') {
+        trackEventArray = event.unshift('trackEvent')
+      }
+
+      trackEventArray = event
+    }
+
+    tracker.push(trackEventArray)
+  }
+}

--- a/react/helpers/tracker.spec.js
+++ b/react/helpers/tracker.spec.js
@@ -1,0 +1,29 @@
+import * as trackerFile from './tracker'
+
+jest.mock('./tracker', () => ({
+  ...require.requireActual('./tracker'),
+  getTracker: jest.fn()
+}))
+describe('tracker / piwik action', () => {
+  beforeEach(() => {
+    trackerFile.getTracker.mockImplementation(() => ({ push: jest.fn() }))
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it('should track event', () => {
+    const tracker = trackerFile.getTracker()
+    trackerFile.trackEvent(['trackEvent', 'toto'], tracker)
+    expect(tracker.push).toHaveBeenCalledWith(['trackEvent', 'toto'])
+  })
+  it('should add or not the trackEvent item in the array', () => {
+    const tracker = trackerFile.getTracker()
+    trackerFile.trackEvent(['toto'], tracker)
+    expect(tracker.push).toHaveBeenCalledWith(['trackEvent', 'toto'])
+    trackerFile.trackEvent(['trackEvent', 'foo'], tracker)
+    expect(tracker.push).toHaveBeenCalledWith(['trackEvent', 'foo'])
+  })
+})


### PR DESCRIPTION
The idea is to have a method to do the check and just expose a `trackEvent([])` for the app. No need to check if there is a tracker anymore. 

https://github.com/cozy/cozy-drive/pull/1908