### PR TITLE
feat: Add NestedSelect

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -41,7 +41,8 @@ module.exports = {
         '../react/Textarea/index.jsx',
         '../react/Toggle/index.jsx',
         '../react/FileInput/index.jsx',
-        '../react/DateMonthPicker/index.jsx'
+        '../react/DateMonthPicker/index.jsx',
+        '../react/NestedSelect/NestedSelect.jsx'
       ]
     },
     {

--- a/react/CompositeRow/index.jsx
+++ b/react/CompositeRow/index.jsx
@@ -54,18 +54,18 @@ CompositeRow.propTypes = {
   /** Custom class */
   className: PropTypes.string,
   /** First line */
-  primaryText: PropTypes.element,
+  primaryText: PropTypes.node,
   /** Second line */
-  secondaryText: PropTypes.element,
+  secondaryText: PropTypes.node,
   /** Image to the left of the row */
-  image: PropTypes.element,
+  image: PropTypes.node,
   /**
    * Actions are shown below primary and secondary texts. Pass fragment for multiple elements.
    * Good to use with Chips.
    */
-  actions: PropTypes.element,
+  actions: PropTypes.node,
   /* Element(s) to the show to the right of the CompositeRow */
-  right: PropTypes.element,
+  right: PropTypes.node,
   /** Row height will be fixed to 48px */
   dense: PropTypes.bool
 }

--- a/react/CompositeRow/index.jsx
+++ b/react/CompositeRow/index.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { Media, Bd, Img } from '../Media'
 import { Text, Caption } from '../Text'
+import styles from './styles.styl'
 
 const denseStyle = { height: '48px' }
 
@@ -22,7 +23,11 @@ const CompositeRow = ({
 }) => {
   return (
     <Media
-      className={cx(className, dense ? 'u-ph-1' : 'u-p-1')}
+      className={cx(
+        className,
+        styles.CompositeRow,
+        dense ? styles.CompositeRow__dense : null
+      )}
       style={dense ? Object.assign({}, denseStyle, style) : style}
       {...rest}
     >

--- a/react/CompositeRow/styles.styl
+++ b/react/CompositeRow/styles.styl
@@ -1,4 +1,4 @@
-@require 'utilities/spaces.styl'
+@require 'settings/spaces.styl'
 
 // Cannot use spacing_values.m directly otherwise stylus
 // does not pick it up, we have to use a temporary variable

--- a/react/CompositeRow/styles.styl
+++ b/react/CompositeRow/styles.styl
@@ -1,0 +1,13 @@
+@require 'utilities/spaces.styl'
+
+// Cannot use spacing_values.m directly otherwise stylus
+// does not pick it up, we have to use a temporary variable
+row_padding=spacing_values.m
+
+.CompositeRow
+    min-height 3rem
+    padding row_padding
+
+    &__dense
+        padding-top 0
+        padding-bottom 0

--- a/react/NestedSelect/Modal.jsx
+++ b/react/NestedSelect/Modal.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import Icon from 'cozy-ui/react/Icon'
+import Modal, {
+  ModalHeader as UIModalHeader,
+  ModalContent as UIModalContent
+} from 'cozy-ui/react/Modal'
+import { Media, Bd, Img } from 'cozy-ui/react/Media'
+import palette from 'cozy-ui/react/palette'
+import NestedSelect from './NestedSelect'
+
+import styles from './styles.styl'
+
+const ModalTitle = ({ showBack, onClickBack, title }) => (
+  <Media>
+    {showBack && (
+      <Img className={styles.Modal__back} onClick={onClickBack}>
+        <Icon icon="left" color={palette['coolGrey']} />
+      </Img>
+    )}
+    <Bd>
+      <h2>{title}</h2>
+    </Bd>
+  </Media>
+)
+
+const ModalHeader = ({ showBack, onClickBack, title }) => (
+  <UIModalHeader className={styles.Modal__title}>
+    <ModalTitle showBack={showBack} onClickBack={onClickBack} title={title} />
+  </UIModalHeader>
+)
+
+const ModalContent = ({ children }) => (
+  <UIModalContent className={styles.Modal__content}>{children}</UIModalContent>
+)
+
+const NestedSelectModal = props => {
+  return (
+    <Modal
+      closeBtnClassName={props.closeBtnClassName}
+      overflowHidden
+      dismissAction={props.onCancel}
+      into="body"
+    >
+      <NestedSelect
+        {...props}
+        HeaderComponent={ModalHeader}
+        ContentComponent={ModalContent}
+      />
+    </Modal>
+  )
+}
+
+export default NestedSelectModal

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -1,0 +1,163 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import CompositeRow from '../CompositeRow'
+import Icon from '../Icon'
+import styles from './styles.styl'
+import UIRadio from '../Radio'
+import cx from 'classnames'
+import omit from 'lodash/omit'
+
+const Radio = ({ className, ...props }) => (
+  <UIRadio className={cx(styles.Radio, className)} {...props} />
+)
+
+const Row = ({ children }) => <div className={styles.Row}>{children}</div>
+
+const Divider = () => <div className={styles.Divider} />
+
+const ItemRow = ({ item, onClick, isSelected }) => {
+  return (
+    <Row>
+      <CompositeRow
+        dense
+        image={item.icon}
+        primaryText={item.title}
+        onClick={() => onClick(item)}
+        right={
+          item.children && item.children.length > 0 ? (
+            <Icon icon="right" color="var(--coolGrey)" />
+          ) : (
+            <Radio checked={isSelected(item)} />
+          )
+        }
+      />
+    </Row>
+  )
+}
+
+/**
+ * Select like component to choose an option among a list of options.
+ * Options can have children; selecting an option that has children
+ * will show the children of the chosen option instead of selecting
+ * the option.
+ */
+class NestedSelect extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      history: [props.options]
+    }
+  }
+
+  componentWillUnmount() {
+    this.unmounted = true
+  }
+
+  resetHistory() {
+    if (this.unmounted) {
+      return
+    }
+    this.setState({ history: [this.props.options] })
+  }
+
+  handleBack = () => {
+    const [item, ...newHistory] = this.state.history
+    this.setState({
+      history: newHistory
+    })
+    return item
+  }
+
+  handleNavToChildren = item => {
+    const newHistory = [item, ...this.state.history]
+    this.setState({
+      history: newHistory
+    })
+  }
+
+  handleSelect = item => {
+    this.props.onSelect(item)
+    setTimeout(() => {
+      this.resetHistory()
+    }, 500)
+  }
+
+  handleClickItem = item => {
+    if (item.children && item.children.length > 0) {
+      this.handleNavToChildren(item)
+    } else {
+      this.handleSelect(item)
+    }
+  }
+
+  render() {
+    const {
+      ContentComponent,
+      HeaderComponent,
+      canSelectParent,
+      isSelected,
+      title,
+      transformParentItem
+    } = this.props
+    const { history } = this.state
+    const current = history[0]
+    const children = current.children || []
+    const level = history.length - 1
+    const isSelectedWithLevel = item => isSelected(item, level)
+
+    return (
+      <>
+        {HeaderComponent ? (
+          <HeaderComponent
+            title={current.title || title}
+            showBack={history.length > 1}
+            onClickBack={this.handleBack}
+          />
+        ) : null}
+        <ContentComponent>
+          {canSelectParent && level > 0 ? (
+            <>
+              <ItemRow
+                item={transformParentItem(omit(current, 'children'))}
+                onClick={this.handleClickItem}
+                isSelected={isSelectedWithLevel}
+              />
+              <Divider />
+            </>
+          ) : null}
+          {children.map(item => (
+            <ItemRow
+              key={item.title}
+              item={item}
+              onClick={this.handleClickItem}
+              isSelected={isSelectedWithLevel}
+            />
+          ))}
+        </ContentComponent>
+      </>
+    )
+  }
+}
+
+NestedSelect.defaultProps = {
+  ContentComponent: 'div',
+  HeaderComponent: null,
+  transformParentItem: x => x
+}
+
+const ItemPropType = PropTypes.shape({
+  icon: PropTypes.element.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.arrayOf(ItemPropType)
+})
+
+NestedSelect.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+  isSelected: PropTypes.func.isRequired,
+  options: PropTypes.shape({
+    children: PropTypes.arrayOf(ItemPropType)
+  }),
+  canSelectParent: PropTypes.bool
+}
+
+export default NestedSelect

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -7,32 +7,6 @@ import UIRadio from '../Radio'
 import cx from 'classnames'
 import omit from 'lodash/omit'
 
-const Radio = ({ className, ...props }) => (
-  <UIRadio className={cx(styles.Radio, className)} {...props} />
-)
-
-const Divider = () => <div className={styles.Divider} />
-
-const ItemRow = ({ item, onClick, isSelected }) => {
-  return (
-    <div className={cx(styles.Row, isSelected ? styles.Row__selected : null)}>
-      <CompositeRow
-        dense
-        image={item.icon}
-        primaryText={item.title}
-        onClick={() => onClick(item)}
-        right={
-          item.children && item.children.length > 0 ? (
-            <Icon icon="right" color="var(--coolGrey)" />
-          ) : (
-            <Radio checked={isSelected} />
-          )
-        }
-      />
-    </div>
-  )
-}
-
 /**
  * Select like component to choose an option among a list of options.
  * Options can have children; selecting an option that has children
@@ -160,3 +134,34 @@ NestedSelect.propTypes = {
 }
 
 export default NestedSelect
+
+export const Radio = ({ className, ...props }) => (
+  <UIRadio label="" className={cx(styles.Radio, className)} {...props} />
+)
+
+const Divider = () => <div className={styles.Divider} />
+
+export const ItemRow = ({ item, onClick, isSelected }) => {
+  return (
+    <div className={cx(styles.Row, isSelected ? styles.Row__selected : null)}>
+      <CompositeRow
+        dense
+        image={item.icon}
+        primaryText={item.title}
+        onClick={() => onClick(item)}
+        right={
+          item.children && item.children.length > 0 ? (
+            <Icon icon="right" color="var(--coolGrey)" />
+          ) : (
+            <Radio
+              readOnly
+              name={item.title}
+              value={item.title}
+              checked={!!isSelected}
+            />
+          )
+        }
+      />
+    </div>
+  )
+}

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -49,6 +49,13 @@ class NestedSelect extends Component {
 
   handleSelect = item => {
     this.props.onSelect(item)
+    // It is important to reset history if the NestedSelected is used
+    // multiple times in a row without being dismounted. For example
+    // if it displayed in Carousel that slides in the NestedSelect
+    // and slides it out on selection.
+    // But, we want in this case that the resetting does not happen
+    // while the animation is running.
+    // There is probably a better way to do this.
     setTimeout(() => {
       this.resetHistory()
     }, 500)

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -125,12 +125,39 @@ const ItemPropType = PropTypes.shape({
 })
 
 NestedSelect.propTypes = {
+  /**
+   * The whole option item is passed to this function when selected
+   */
   onSelect: PropTypes.func.isRequired,
+
+  /**
+   * Determines if the row looks selected. The `option` is
+   * passed as an argument.
+   */
   isSelected: PropTypes.func.isRequired,
+
+  /**
+   * Options that will be rendered as nested lists of choices
+   */
   options: PropTypes.shape({
     children: PropTypes.arrayOf(ItemPropType)
   }),
-  canSelectParent: PropTypes.bool
+
+  /** If true, parent option will be shown at the top of its children */
+  canSelectParent: PropTypes.bool,
+
+  /**
+   * `parentItem` is passed into this function before being used to render
+   * the parent item row (canSelectParent must be true).
+   * Use this if you want the parent to have a different text on the "outer"
+   * row than inside the "inner" row.
+   *
+   * @example
+   * ```
+   * const transformParentItem = item => ({ ...item, title: "Everything"})
+   * ````
+   */
+  transformParentItem: PropTypes.func
 }
 
 export default NestedSelect

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -6,6 +6,7 @@ import styles from './styles.styl'
 import UIRadio from '../Radio'
 import cx from 'classnames'
 import omit from 'lodash/omit'
+import palette from 'cozy-ui/react/palette'
 
 /**
  * Select like component to choose an option among a list of options.
@@ -185,7 +186,7 @@ export const ItemRow = ({ item, onClick, isSelected }) => {
         onClick={() => onClick(item)}
         right={
           item.children && item.children.length > 0 ? (
-            <Icon icon="right" color="var(--coolGrey)" />
+            <Icon icon="right" color={palette.coolGrey} />
           ) : (
             <Radio
               readOnly

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -119,9 +119,9 @@ NestedSelect.defaultProps = {
 }
 
 const ItemPropType = PropTypes.shape({
-  icon: PropTypes.element.isRequired,
+  icon: PropTypes.element,
   title: PropTypes.string.isRequired,
-  children: PropTypes.arrayOf(ItemPropType)
+  children: PropTypes.array
 })
 
 NestedSelect.propTypes = {

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -11,13 +11,11 @@ const Radio = ({ className, ...props }) => (
   <UIRadio className={cx(styles.Radio, className)} {...props} />
 )
 
-const Row = ({ children }) => <div className={styles.Row}>{children}</div>
-
 const Divider = () => <div className={styles.Divider} />
 
 const ItemRow = ({ item, onClick, isSelected }) => {
   return (
-    <Row>
+    <div className={cx(styles.Row, isSelected ? styles.Row__selected : null)}>
       <CompositeRow
         dense
         image={item.icon}
@@ -27,11 +25,11 @@ const ItemRow = ({ item, onClick, isSelected }) => {
           item.children && item.children.length > 0 ? (
             <Icon icon="right" color="var(--coolGrey)" />
           ) : (
-            <Radio checked={isSelected(item)} />
+            <Radio checked={isSelected} />
           )
         }
       />
-    </Row>
+    </div>
   )
 }
 
@@ -104,6 +102,7 @@ class NestedSelect extends Component {
     const children = current.children || []
     const level = history.length - 1
     const isSelectedWithLevel = item => isSelected(item, level)
+    const parentItem = transformParentItem(omit(current, 'children'))
 
     return (
       <>
@@ -118,9 +117,9 @@ class NestedSelect extends Component {
           {canSelectParent && level > 0 ? (
             <>
               <ItemRow
-                item={transformParentItem(omit(current, 'children'))}
+                item={parentItem}
                 onClick={this.handleClickItem}
-                isSelected={isSelectedWithLevel}
+                isSelected={isSelectedWithLevel(parentItem)}
               />
               <Divider />
             </>
@@ -130,7 +129,7 @@ class NestedSelect extends Component {
               key={item.title}
               item={item}
               onClick={this.handleClickItem}
-              isSelected={isSelectedWithLevel}
+              isSelected={isSelectedWithLevel(item)}
             />
           ))}
         </ContentComponent>

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -11,27 +11,33 @@ const Image = ({ letter }) => (
   </Circle>
 )
 
+const letterOption = letter => ({
+  title: letter,
+  icon: <Image letter={letter} />
+})
+
 const options = {
   children: [
+    letterOption('A'),
     {
-      title: 'A',
-      icon: <Image letter='A' />
-    },
-    {
-      title: 'B',
-      icon: <Image letter='B' />, 
+      ...letterOption('B'), 
       children: [
-        {
-          title: 'B1',
-          icon: <Image letter='B1' />
-        }, {
-          title: 'B2',
-          icon: <Image letter='B2' />
-        }] },
-    {
-      title: 'C',
-      icon: <Image letter='C' />
+        letterOption('B1'),
+        letterOption('B2')
+      ]
     },
+    letterOption('C'),
+    letterOption('D'),
+    letterOption('E'),
+    letterOption('F'),
+    letterOption('G'),
+    letterOption('H'),
+    letterOption('I'),
+    letterOption('J'),
+    letterOption('K'),
+    letterOption('L'),
+    letterOption('M'),
+    letterOption('N'),
   ]
 }
 

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -1,0 +1,96 @@
+```
+import Button from '../Button'
+import Circle from '../Circle'
+import NestedSelectModal from './Modal';
+import { useState } from 'react'
+
+
+const Image = ({ letter }) => (
+  <Circle backgroundColor='var(--melon)'>
+    { letter }
+  </Circle>
+)
+
+const options = {
+  children: [
+    {
+      title: 'A',
+      icon: <Image letter='A' />
+    },
+    {
+      title: 'B',
+      icon: <Image letter='B' />, 
+      children: [
+        {
+          title: 'B1',
+          icon: <Image letter='B1' />
+        }, {
+          title: 'B2',
+          icon: <Image letter='B2' />
+        }] },
+    {
+      title: 'C',
+      icon: <Image letter='C' />
+    },
+  ]
+}
+
+const transformParentItem = item => ({
+  ...item,
+  title: 'All of ' + item.title
+})
+
+const StaticExample = () => {
+  return (
+    <NestedSelectModal
+      canSelectParent={true}
+      onSelect={x => x}
+      dismissAction={x => x}
+      isSelected={x => x.title === 'C'}
+      options={options}
+      title="Please select letter"
+      transformParentItem={transformParentItem}
+    />
+  )
+}
+
+const RADIO_BUTTON_ANIM_DURATION = 500
+
+const InteractiveExample = () => {
+  const [showingModal, setShowingModal] = useState(false)
+  const [selectedItem, setSelected] = useState(null)
+  const showModal = () => setShowingModal(true)
+  const hideModal = () => setShowingModal(false)
+  const isSelected = item => selectedItem && selectedItem.title === item.title
+  const handleSelect = item => {
+    setSelected(item)
+
+    setTimeout(() => {
+      hideModal()
+    }, RADIO_BUTTON_ANIM_DURATION)
+  }
+
+  return (
+    <>
+      { selectedItem ? <>Selected: { selectedItem.title }<br/></> : null }
+      <Button label='Select' onClick={showModal} ></Button>
+      { showingModal ?
+        <NestedSelectModal
+          canSelectParent={true}
+          onSelect={handleSelect}
+          dismissAction={hideModal}
+          isSelected={isSelected}
+          options={options}
+          title="Please select letter"
+          transformParentItem={transformParentItem}
+        /> : null }
+    </>
+  )
+};
+
+<>
+  { isTesting()
+    ? <StaticExample />
+    : <InteractiveExample /> }
+</>
+```

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -56,15 +56,29 @@ const StaticExample = () => {
 
 const RADIO_BUTTON_ANIM_DURATION = 500
 
+// Crude parent-children relationship
+const isParent = (item, childItem) => {
+  return childItem.title.includes(item.title)
+}
+
 const InteractiveExample = () => {
   const [showingModal, setShowingModal] = useState(false)
   const [selectedItem, setSelected] = useState(null)
   const showModal = () => setShowingModal(true)
   const hideModal = () => setShowingModal(false)
-  const isSelected = item => selectedItem && selectedItem.title === item.title
+  const isSelected = (item, level) => {
+    if (!selectedItem) { 
+      return false
+    } else if (level === 0 && isParent(item, selectedItem)) {
+      return true
+    } else if (item.title === selectedItem.title) {
+      return true
+    }
+    return false
+  }
+
   const handleSelect = item => {
     setSelected(item)
-
     setTimeout(() => {
       hideModal()
     }, RADIO_BUTTON_ANIM_DURATION)

--- a/react/NestedSelect/NestedSelect.spec.jsx
+++ b/react/NestedSelect/NestedSelect.spec.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import NestedSelect, { ItemRow } from './NestedSelect'
+import CompositeRow from '../CompositeRow'
+
+describe('NestedSelect', () => {
+  const options = {
+    children: [
+      { title: 'A' },
+      { title: 'B', children: [{ title: 'B1' }, { title: 'B2' }] },
+      { title: 'C' }
+    ]
+  }
+
+  const findSelectedRow = root => {
+    return root.findWhere(n => {
+      if (n.type() != ItemRow) {
+        return false
+      }
+      return n.props().isSelected
+    })
+  }
+
+  const simulateClick = row =>
+    row
+      .find(CompositeRow)
+      .props()
+      .onClick()
+
+  const setup = ({ canSelectParent, itemSelected }) => {
+    // Very crude notion of parenting
+    const isParent = (item, childItem) => {
+      return childItem && childItem.title.includes(item.title)
+    }
+
+    const isSelected = (item, level) => {
+      if (level === 0 && isParent(item, itemSelected)) {
+        return true
+      } else if (itemSelected && itemSelected.title === item.title) {
+        return true
+      } else {
+        return false
+      }
+    }
+
+    const root = mount(
+      <NestedSelect
+        canSelectParent={canSelectParent}
+        options={options}
+        isSelected={isSelected}
+        onSelect={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    )
+    return { root }
+  }
+
+  describe('when selecting a normal category', () => {
+    it('should show only one selected item', () => {
+      const { root } = setup({
+        itemSelected: { title: 'B1' }
+      })
+      const selectedRow = findSelectedRow(root)
+      expect(selectedRow.length).toBe(1)
+      expect(selectedRow.text()).toBe('B')
+      simulateClick(selectedRow)
+      root.update()
+
+      const selectedRow2 = findSelectedRow(root)
+      expect(selectedRow2.length).toBe(1)
+      expect(selectedRow2.text()).toBe('B1')
+    })
+  })
+
+  describe('when allowing parent to be selected', () => {
+    it('should show a line for the parent inside the category', () => {
+      const { root } = setup({
+        itemSelected: { title: 'B1' },
+        canSelectParent: true
+      })
+      const selectedRow = findSelectedRow(root)
+      expect(selectedRow.length).toBe(1)
+      simulateClick(selectedRow)
+      root.update()
+
+      expect(root.find(ItemRow).length).toBe(3)
+    })
+  })
+})

--- a/react/NestedSelect/Row.jsx
+++ b/react/NestedSelect/Row.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Media, Bd, Img, Icon } from 'cozy-ui/transpiled/react'
+import styles from './Row.styl'
+import cx from 'classnames'
+
+export const RowBody = ({ children }) => (
+  <Bd className="u-ellipsis">{children}</Bd>
+)
+
+const Row = ({
+  isSelected,
+  icon,
+  label,
+  children,
+  hasArrow,
+  onClick,
+  className
+}) => (
+  <Media
+    className={cx(
+      styles.Row,
+      'u-row-m',
+      isSelected ? 'u-text-bold' : '',
+      className
+    )}
+    onClick={onClick}
+  >
+    {icon && <Img>{icon}</Img>}
+    {label ? <RowBody>{label}</RowBody> : null}
+    {children}
+    {hasArrow && (
+      <Img>
+        <Icon icon="right" color="var(--coolGrey)" />
+      </Img>
+    )}
+  </Media>
+)
+
+export default Row

--- a/react/NestedSelect/index.jsx
+++ b/react/NestedSelect/index.jsx
@@ -1,0 +1,2 @@
+export { default } from './NestedSelect'
+export { default as NestedSelectModal } from './Modal'

--- a/react/NestedSelect/styles.styl
+++ b/react/NestedSelect/styles.styl
@@ -10,6 +10,9 @@
     &:last-child
         border-bottom 0
 
+.Row__selected
+    font-weight bold
+
 .Modal__title
     border-bottom 1px solid var(--silver)
     margin-bottom 0
@@ -31,3 +34,4 @@
 .Divider
     border-bottom 1px solid var(--silver)
     height .5rem
+

--- a/react/NestedSelect/styles.styl
+++ b/react/NestedSelect/styles.styl
@@ -1,0 +1,33 @@
+.Row
+    padding-left 0.5rem
+    padding-right 0.5rem
+    border-bottom 1px solid var(--silver)
+
+    &:hover
+        background-color var(--paleGrey)
+        cursor pointer
+
+    &:last-child
+        border-bottom 0
+
+.Modal__title
+    border-bottom 1px solid var(--silver)
+    margin-bottom 0
+
+.Modal__content
+    padding 0
+
+.Modal__back
+    cursor pointer
+    margin-right 1.25rem
+    margin-left -0.25rem
+    font-size 1.5rem
+
+.Radio
+    margin-bottom 0
+    min-height 1rem
+    width 1rem
+
+.Divider
+    border-bottom 1px solid var(--silver)
+    height .5rem

--- a/react/index.js
+++ b/react/index.js
@@ -90,3 +90,4 @@ export {
   ViewStackContext
 } from './ViewStack'
 export { default as DateMonthPicker } from './DateMonthPicker'
+export { default as NestedSelect, NestedSelectModal } from './NestedSelect'

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -131,6 +131,8 @@ const main = async () => {
     dest: 'styleguideDir',
     type: pathArgument
   })
+  parser.addArgument('--component')
+
   const args = parser.parseArgs()
 
   await prepareFS(args.styleguideDir, args.screenshotDir)
@@ -140,8 +142,14 @@ const main = async () => {
     args.styleguideDir,
     '/index.html'
   )}`
+  const components = (await fetchAllComponents(
+    page,
+    styleguideIndexURL
+  )).filter(
+    args.component ? component => component.name === args.component : () => true
+  )
 
-  console.log('Screenshotting all components')
+  console.log('Screenshotting components')
   for (const component of components) {
     await screenshotComponent(page, component, args.screenshotDir)
   }

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -5,7 +5,9 @@ try {
   puppeteer = require('puppeteer')
 } catch (e) {
   console.error(e)
-  console.log('Could not import puppeteer, you should install it if you want to take screenshots')
+  console.log(
+    'Could not import puppeteer, you should install it if you want to take screenshots'
+  )
   process.exit(1)
 }
 const path = require('path')
@@ -118,17 +120,26 @@ const pathArgument = p => {
  */
 const main = async () => {
   const parser = new ArgumentParser()
-  
-  parser.addArgument('--screenshot-dir', { required: true, dest: 'screenshotDir', type: pathArgument })
-  parser.addArgument('--styleguide-dir', { required: true, dest: 'styleguideDir', type: pathArgument })
-  
+
+  parser.addArgument('--screenshot-dir', {
+    required: true,
+    dest: 'screenshotDir',
+    type: pathArgument
+  })
+  parser.addArgument('--styleguide-dir', {
+    required: true,
+    dest: 'styleguideDir',
+    type: pathArgument
+  })
   const args = parser.parseArgs()
 
   await prepareFS(args.styleguideDir, args.screenshotDir)
   const { browser, page } = await prepareBrowser()
 
-  const styleguideIndexURL = `file://${path.join(args.styleguideDir, '/index.html')}`
-  const components = await fetchAllComponents(page, styleguideIndexURL)
+  const styleguideIndexURL = `file://${path.join(
+    args.styleguideDir,
+    '/index.html'
+  )}`
 
   console.log('Screenshotting all components')
   for (const component of components) {

--- a/stylus/settings/spaces.styl
+++ b/stylus/settings/spaces.styl
@@ -1,0 +1,31 @@
+sizes = {
+    'auto': auto
+    '0': 0,
+    'half': rem(8),
+    '1': rem(16),
+    '1-half': rem(24),
+    '2': rem(32),
+    '2-half': rem(40),
+    '3': rem(48)
+}
+
+// These are the values used by the design team, they should used
+// instead of the `sizes` variable above that is only kept for retro-compatibility
+spacing_values = {
+    m: 1rem, // the standard, no modifier needed
+    xs: .5rem,
+    s: .75rem,
+    l: 1.5rem,
+    xl: 2rem
+    xxl: 3rem
+}
+
+directions = {
+    '': all,
+    t: top,
+    b: bottom,
+    l: left,
+    r: right,
+    v: vertical,
+    h: horizontal
+}

--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -3,32 +3,12 @@
 \*------------------------------------*/
 @require '../settings/breakpoints'
 @require '../tools/mixins'
+@require '../settings/spaces'
 
 // @stylint off
 types = {
     p: padding,
     m: margin
-}
-sizes = {
-    'auto': auto
-    '0': 0,
-    'half': rem(8),
-    '1': rem(16),
-    '1-half': rem(24),
-    '2': rem(32),
-    '2-half': rem(40),
-    '3': rem(48)
-}
-
-// These are the values used by the design team, they should used
-// instead of the `sizes` variable above that is only kept for retro-compatibility
-spacing_values = {
-    m: 1rem, // the standard, no modifier needed
-    xs: .5rem,
-    s: .75rem,
-    l: 1.5rem,
-    xl: 2rem
-    xxl: 3rem
 }
 
 directions = {


### PR DESCRIPTION
Originally a component from Banks to select the category of a transaction. Categories can be nested hence the need.

At the moment, there is no transition/animation (a part from the Radio button), I think NestedSelect could use ModalStack/ViewStack in the future (depending on desktop/mobile).

Visible on https://ptbrowne.github.io/cozy-ui/react/#/NestedSelect