### PR TITLE
fix: ViewerExposer uses USE_PREACT

### DIFF
--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -47,10 +47,5 @@ module.exports = {
   },
   plugins: [
     isUsingDevStyleguidist() ? null : new MiniCssExtractPlugin('[name].css'),
-    new webpack.DefinePlugin({
-      'process.env': {
-        USE_REACT: 'true'
-      }
-    })
   ].filter(Boolean)
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jest": "yarn test:jest",
     "screenshots": "node scripts/screenshots.js --screenshot-dir ./screenshots --styleguide-dir ./build/react",
     "test": "yarn test:jest",
-    "test:jest": "env USE_REACT=true jest --verbose",
+    "test:jest": "jest --verbose",
     "transpile": "env BABEL_ENV=transpilation babel react/ --out-dir transpiled/react --verbose && babel helpers/ --out-dir transpiled/helpers --verbose",
     "posttranspile": "postcss transpiled/react/stylesheet.css --replace",
     "travis-deploy-once": "travis-deploy-once",

--- a/react/Viewer/ViewerExposer.js
+++ b/react/Viewer/ViewerExposer.js
@@ -1,8 +1,8 @@
 let defaultViewer
-if (process.env.USE_REACT) {
-  defaultViewer = require('./index').default
-} else {
+if (process.env.USE_PREACT) {
   defaultViewer = ''
+} else {
+  defaultViewer = require('./index').default
 }
 
 export default defaultViewer


### PR DESCRIPTION
I missed a reference to USE_REACT in the ViewerExposer.
I switched the condition to use USE_PREACT env variable.

Also removed the USE_REACT=true that webpack injected during
for the styleguidist since USE_REACT=true is the default now.