### PR TITLE
fix: Prevent webpack from erroring if preact-portal is not found

### DIFF
--- a/react/Portal/index.jsx
+++ b/react/Portal/index.jsx
@@ -1,6 +1,11 @@
 let Portal
 if (process.env.USE_PREACT) {
-  Portal = require('preact-portal')
+  try {
+    Portal = require('preact-portal')
+  } catch (e) {
+    // We need this try/catch for webpack not to error if preact-portal
+    // is not found
+  }
 } else {
   const ReactDOM = require('react-dom')
   Portal = ({ into, children }) => {


### PR DESCRIPTION
Since before we relied on injected env var to remove the preact
branch in the conditional, webpack was smart enough not to resolve the
require('preact-portal'). Since we inverted the condition and the host app does not define USE_PREACT, `webpack` cannot ignore the conditional block and
the `require` has to be resolved.

For it not to fail at build time, it must be wrapped in a try/catch.

I should have been more careful with this.

Related: https://github.com/cozy/cozy-libs/pull/874

