### PR TITLE
Add ContactPicker component

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -140,7 +140,11 @@ module.exports = {
     },
     {
       name: 'Contacts',
-      components: () => ['../react/ContactsList', '../react/ContactsListModal']
+      components: () => [
+        '../react/ContactsList',
+        '../react/ContactsListModal',
+        '../react/ContactPicker'
+      ]
     }
   ],
   components: '../react/**/*.jsx',

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@babel/cli": "7.6.2",
     "@babel/core": "7.6.2",
     "@material-ui/core": "3.9.3",
+    "@oskarer/enzyme-wait": "^1.5.0",
     "@semantic-release/changelog": "2.1.2",
     "@semantic-release/git": "5.0.0",
     "@semantic-release/npm": "3.4.1",
@@ -140,8 +141,8 @@
   "peerDependencies": {
     "@material-ui/core": "3.9.3",
     "cozy-client": "*",
-    "cozy-doctypes": "^1.69.0",
     "cozy-device-helper": "1.7.5",
+    "cozy-doctypes": "^1.69.0",
     "piwik-react-router": "^0.8.2",
     "preact": "^8.3.1",
     "preact-portal": "^1.1.3",

--- a/react/ContactPicker/Readme.md
+++ b/react/ContactPicker/Readme.md
@@ -1,0 +1,13 @@
+```jsx
+import ContactPicker from 'cozy-ui/transpiled/react/ContactPicker';
+import DemoProvider from '../ContactsListModal/DemoProvider';
+initialState = { selectedContact: null };
+
+<DemoProvider>
+  <ContactPicker
+    placeholder="Select a contact"
+    onChange={selectedContact => setState({ selectedContact })}
+    selectedContact={state.selectedContact}
+  />
+</DemoProvider>
+```

--- a/react/ContactPicker/index.jsx
+++ b/react/ContactPicker/index.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import ContactsListModal from '../ContactsListModal'
+import styles from './styles.styl'
+import cx from 'classnames'
+import { Contact } from 'cozy-doctypes'
+
+const SelectControl = props => {
+  const { className, children, ...rest } = props
+
+  return (
+    <button
+      type="button"
+      className={cx(styles.SelectControl, className)}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}
+
+const ContactPicker = props => {
+  const { placeholder, onChange, selectedContact, ...rest } = props
+  const [showContactsList, setShowContactsList] = useState(false)
+
+  const handleChange = contact => {
+    onChange(contact)
+  }
+
+  return (
+    <>
+      <SelectControl {...rest} onClick={() => setShowContactsList(true)}>
+        {selectedContact
+          ? Contact.getDisplayName(selectedContact)
+          : placeholder}
+      </SelectControl>
+      {showContactsList && (
+        <ContactsListModal
+          dismissAction={() => setShowContactsList(false)}
+          onItemClick={handleChange}
+        />
+      )}
+    </>
+  )
+}
+
+export default ContactPicker

--- a/react/ContactPicker/index.spec.jsx
+++ b/react/ContactPicker/index.spec.jsx
@@ -1,0 +1,57 @@
+import ContactPicker from '.'
+import { mount } from 'enzyme'
+import React from 'react'
+import DemoProvider from '../ContactsListModal/DemoProvider'
+import ContactsListModal from '../ContactsListModal'
+import ContactsList from '../ContactsList'
+import ContactRow from '../ContactsList/ContactRow'
+import contacts from '../ContactsList/data.json'
+import { createWaitForElement } from '@oskarer/enzyme-wait'
+
+it('should show a contacts list modal when clicking the control', () => {
+  const wrapper = mount(
+    <DemoProvider>
+      <ContactPicker placeholder="Select a contact" />
+    </DemoProvider>
+  )
+
+  const control = wrapper.find('button')
+  control.simulate('click')
+  const modal = wrapper.find(ContactsListModal)
+
+  expect(modal.length).toBe(1)
+})
+
+it('should call the onChange function when a contact is being selected', async () => {
+  const onChange = jest.fn()
+  const wrapper = mount(
+    <DemoProvider>
+      <ContactPicker placeholder="Select a contact" onChange={onChange} />
+    </DemoProvider>
+  )
+
+  const waitForContactsList = createWaitForElement(ContactsList)
+
+  const control = wrapper.find('button')
+  control.simulate('click')
+
+  const list = await waitForContactsList(wrapper)
+  const row = list.find(ContactRow).first()
+  row.simulate('click')
+
+  expect(onChange).toHaveBeenCalled()
+})
+
+it('should show the given select contact name in the select', () => {
+  const wrapper = mount(
+    <DemoProvider>
+      <ContactPicker
+        placeholder="Select a contact"
+        selectedContact={contacts[0]}
+      />
+    </DemoProvider>
+  )
+
+  const control = wrapper.find('button')
+  expect(control.text()).toBe('Alexis Bickers')
+})

--- a/react/ContactPicker/styles.styl
+++ b/react/ContactPicker/styles.styl
@@ -1,0 +1,5 @@
+@require 'tools/mixins'
+@require 'components/forms'
+
+.SelectControl
+    @extend $select

--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -130,6 +130,27 @@ const options = [
 </form>
 ```
 
+#### Field with ContactPicker
+
+```jsx
+import Field from 'cozy-ui/transpiled/react/Field';
+import DemoProvider from '../ContactsListModal/DemoProvider';
+initialState = { selectedContact: null };
+
+<DemoProvider>
+  <form>
+    <Field
+      label="Contact"
+      type="contact"
+      placeholder="Select a contact"
+      value={state.selectedContact}
+      onChange={selectedContact => setState({ selectedContact })}
+    />
+  </form>
+</DemoProvider>
+```
+
+
 #### Password field with show/hide button
 
 ```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -9,6 +9,7 @@ import Label from '../Label'
 import Input from '../Input'
 import SelectBox from '../SelectBox'
 import Textarea from '../Textarea'
+import ContactPicker from '../ContactPicker'
 
 /**
  * PropTypes to pass to Input but not to other components, like SelectBox
@@ -161,6 +162,16 @@ const Field = props => {
             secondaryComponent={secondaryComponent}
           />
         )
+
+      case 'contact':
+        return (
+          <ContactPicker
+            placeholder={placeholder}
+            onChange={onChange}
+            selectedContact={value}
+          />
+        )
+
       case 'date':
       case 'email':
       case 'url':
@@ -187,7 +198,7 @@ const Field = props => {
         )
       default:
         throw new Error(
-          `type must be text, password, email, date, url or textarea, got ${type}`
+          `${type} is not a valid type. Type must be ${allowedTypes.join(', ')}`
         )
     }
   }
@@ -211,6 +222,17 @@ const Field = props => {
   )
 }
 
+const allowedTypes = [
+  'date',
+  'email',
+  'password',
+  'select',
+  'textarea',
+  'text',
+  'url',
+  'number'
+]
+
 Field.propTypes = {
   ...inputSpecificPropTypes,
   disabled: PropTypes.bool,
@@ -220,16 +242,7 @@ Field.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string,
   name: PropTypes.string,
-  type: PropTypes.oneOf([
-    'date',
-    'email',
-    'password',
-    'select',
-    'textarea',
-    'text',
-    'url',
-    'number'
-  ]),
+  type: PropTypes.oneOf(allowedTypes),
   // value should be an object for type=select and string for others
   value: function(props, propName, componentName) {
     // not a required props

--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -9,7 +9,7 @@
     overflow hidden
 
 .select--autowidth
-    max-width 30rem
+    max-width 32rem
 
 .select--disabled
     @extends $select--disabled

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2054,6 +2054,14 @@ exports[`Field should render examples: Field 6`] = `
 exports[`Field should render examples: Field 7`] = `
 "<div>
   <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">Contact</label><button type=\\"button\\" class=\\"styles__SelectControl___2OxoO\\">Select a contact</button></div>
+  </form>
+</div>"
+`;
+
+exports[`Field should render examples: Field 8`] = `
+"<div>
+  <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldPassword\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'm a password label</label>
       <div class=\\"styles__o-field-input___vCqdV\\">
         <div class=\\"styles__c-label___o4ozG styles__o-field-input-action___2k7a8\\">Show</div><input type=\\"password\\" id=\\"idFieldPassword\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"\\" value=\\"\\">
@@ -2063,7 +2071,7 @@ exports[`Field should render examples: Field 7`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 8`] = `
+exports[`Field should render examples: Field 9`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"idFieldPassword\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'm a password label</label>
@@ -2075,7 +2083,7 @@ exports[`Field should render examples: Field 8`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 9`] = `
+exports[`Field should render examples: Field 10`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'm a label</label>
@@ -2085,7 +2093,7 @@ exports[`Field should render examples: Field 9`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 10`] = `
+exports[`Field should render examples: Field 11`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'm a label</label>
@@ -2095,7 +2103,7 @@ exports[`Field should render examples: Field 10`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 11`] = `
+exports[`Field should render examples: Field 12`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\" style=\\"color: teal;\\">I'm a label</label><input type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"\\" style=\\"border-color: teal;\\" value=\\"\\"></div>
@@ -2103,7 +2111,7 @@ exports[`Field should render examples: Field 11`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 12`] = `
+exports[`Field should render examples: Field 13`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\" style=\\"color: teal;\\">I'm a label</label>
@@ -2117,7 +2125,7 @@ exports[`Field should render examples: Field 12`] = `
 </div>"
 `;
 
-exports[`Field should render examples: Field 13`] = `
+exports[`Field should render examples: Field 14`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\"></label>

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -428,6 +428,7 @@ $select
     appearance none
     background embedurl('../../assets/icons/illus/bottom-select.svg') right rem(16) center no-repeat
     background-size rem(14)
+    text-align left
 
     &::-ms-expand
         display  none

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,13 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
+"@oskarer/enzyme-wait@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@oskarer/enzyme-wait/-/enzyme-wait-1.5.0.tgz#5a66da400f5c0c933a436841fff3382371575dc9"
+  integrity sha512-8GFIO7+3tAoEMJVckrv6VY1FTcFqSgZe9PsTpArjBXL6VjjdDgSIeuXez/KZ/NvW1PCaaQDUyeboqIb3SSBGzw==
+  dependencies:
+    assertion-error "^1.0.2"
+
 "@semantic-release/changelog@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-2.1.2.tgz#d232a61e193cad6fcea95600a9351e026c9f979f"
@@ -2467,6 +2474,11 @@ assert@^1.1.1:
   integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
   dependencies:
     util "0.10.3"
+
+assertion-error@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
:warning: Base branch should be changed to master after https://github.com/cozy/cozy-ui/pull/1273 has been merged.

Add a `ContactPicker` components that renders like a select, but opens a `ContactsListModal`. Also add the possibility to use it with a `Field` with `type="contact"`.

See https://drazik.github.io/cozy-ui/react/#!/ContactPicker and https://drazik.github.io/cozy-ui/react/#