### PR TITLE
fix: Don't trackEvent if no shouldEnableTracking

### DIFF
--- a/react/helpers/tracker.spec.js
+++ b/react/helpers/tracker.spec.js
@@ -26,4 +26,14 @@ describe('tracker / piwik action', () => {
     trackerFile.trackEvent(['trackEvent', 'foo'], tracker)
     expect(tracker.push).toHaveBeenCalledWith(['trackEvent', 'foo'])
   })
+
+  it('should memoize shouldEnableTracking', () => {
+    const querySelectorSpy = jest.fn()
+    Object.defineProperty(global.document, 'querySelector', {
+      value: querySelectorSpy
+    })
+    trackerFile.shouldEnableTracking()
+    trackerFile.shouldEnableTracking()
+    expect(querySelectorSpy).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
Call shouldEnableTracking in getTracker so we can't track if it's not enabled. 

shouldEnableTracking is memoized in order to avoir dom query 