### PR TITLE
fix: Set overflow scrolling to touch for elastic content

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -51,6 +51,7 @@ $elastic-content
     background-attachment local, local, scroll, scroll
     background-clip padding-box
     overflow auto
+    -webkit-overflow-scrolling touch
 
 $elastic-bar
     flex 0 0 auto


### PR DESCRIPTION
Important to have native feel when scrolling in modals for example.

![ezgif com-optimize](https://user-images.githubusercontent.com/465582/70217462-7fa42b80-1741-11ea-985f-0e57ecb5fda4.gif)
