### PR TITLE
fix(ContactsListModal): Get contacts app url correctly

### DIFF
--- a/react/ContactsListModal/AddContactButton.jsx
+++ b/react/ContactsListModal/AddContactButton.jsx
@@ -7,12 +7,12 @@ const DumbAddContactButton = props => {
   const { client, ...rest } = props
 
   const cozyURL = new URL(client.getStackClient().uri)
-  const { cozySubDomainType } = client.getInstanceOptions()
+  const { cozySubdomainType } = client.getInstanceOptions()
   const contactsAppSlug = 'contacts'
   const contactsAppHref = generateWebLink({
     cozyUrl: cozyURL.origin,
     slug: contactsAppSlug,
-    subDomainType: cozySubDomainType
+    subDomainType: cozySubdomainType
   })
 
   return (


### PR DESCRIPTION
The subdomain type was not retrieved correctly due to a typo. The type was always "flat" because that's the default value in `generateWebLink`.