### PR TITLE
fix: Removes useMemo in Icon

### DIFF
--- a/react/Icon/index.jsx
+++ b/react/Icon/index.jsx
@@ -43,10 +43,7 @@ function Icon(props) {
     ...restProps
   } = props
 
-  const Svg = useMemo(
-    () => (isReactComponent(icon) ? icon : getSvgObject(icon)),
-    [icon]
-  )
+  const Svg = isReactComponent(icon) ? icon : getSvgObject(icon)
 
   let style = props.style
   style = Object.assign({}, style)


### PR DESCRIPTION
The missing useMemo should ne create too much noise.
This is an indirect fix for https://pad.cozycloud.cc/p/cozy-sharing
in case we do not find the root cause (yes, this is not satisfying).

Do not merge yet.