### PR TITLE
fix(forms): Use dropdown icon instead of arrow

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -145,7 +145,7 @@ $form-select
         border               rem(1) solid var(--silver)
         color                var(--black)
         appearance           none
-        background-image     embedurl('../../assets/icons/ui/arrow.svg')
+        background-image     embedurl('../../assets/icons/ui/dropdown.svg')
         background-position  right rem(8) center
         background-repeat    no-repeat
 


### PR DESCRIPTION
We missed this one in https://github.com/cozy/cozy-ui/pull/983. It is
used via a `@extend $form-select` in a stylus file in cozy-settings.
Thus after updating cozy-ui, it thrown an error.