### PR TITLE
Update Infos component

### DIFF
--- a/react/Infos/Readme.md
+++ b/react/Infos/Readme.md
@@ -1,8 +1,18 @@
-### Infos display info
+### Infos display
 
 ```
 import Infos from 'cozy-ui/transpiled/react/Infos';
 import Button from 'cozy-ui/transpiled/react/Button';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Text, { SubTitle } from 'cozy-ui/transpiled/react/Text';
+import Variants from 'cozy-ui/docs/components/Variants';
+
+const initialVariants = [
+  { title: true, action: false, secondaryTheme: false, secondaryTheme: false },
+  { title: true, action: true, dangerTheme: true },
+  { title: true, multiActions: true, dangerTheme: false, dismissAction: true },
+];
+
 <div className='u-stack-m'>
     <Infos text="My small persistent information! " />
     <Infos text="In a slightly different style" className='u-maw-none u-bdrs-0'/>
@@ -17,5 +27,25 @@ import Button from 'cozy-ui/transpiled/react/Button';
         icon="warning"
         isImportant
     />
+
+    <hr />
+    <h2>New API</h2>
+
+    <Variants initialVariants={initialVariants}>{
+      variant => (
+        <Infos
+          theme={variant.secondaryTheme ? 'secondary' : variant.dangerTheme ? 'danger' : 'primary'}
+          description={<>
+            {variant.title && <SubTitle className={variant.dangerTheme ? 'u-pomegranate' : ''}>{content.ada.facts[0].title}</SubTitle>}
+            <Text>{content.ada.facts[0].description}</Text>
+          </>}
+          action={<>
+            {variant.action && <Button label="ok" theme={variant.dangerTheme ? 'danger' : 'primary'} />}
+            {variant.multiActions && ['one', 'two', 'three'].map(label => <Button label={label} theme={variant.dangerTheme ? 'danger' : 'primary'} />)}
+          </>}
+          dismissAction={variant.dismissAction ? () => alert('dismissed') : null}
+        />
+      )
+    }</Variants>
 </div>
 ```

--- a/react/Infos/Readme.md
+++ b/react/Infos/Readme.md
@@ -3,7 +3,6 @@
 ```
 import Infos from 'cozy-ui/transpiled/react/Infos';
 import Button from 'cozy-ui/transpiled/react/Button';
-import Icon from 'cozy-ui/transpiled/react/Icon';
 import Text, { SubTitle } from 'cozy-ui/transpiled/react/Text';
 import Variants from 'cozy-ui/docs/components/Variants';
 
@@ -14,23 +13,6 @@ const initialVariants = [
 ];
 
 <div className='u-stack-m'>
-    <Infos text="My small persistent information! " />
-    <Infos text="In a slightly different style" className='u-maw-none u-bdrs-0'/>
-    <Infos
-        text="My small persistent information, with an icon. And a lot of text ? Again and again..."
-        icon="info"
-    />
-    <Infos
-        actionButton={<Button theme="danger" label="A CTA button" />}
-        title="Infos breaking news"
-        text="My small persistent information, with an icon. And a lot of text ? Again and again..."
-        icon="warning"
-        isImportant
-    />
-
-    <hr />
-    <h2>New API</h2>
-
     <Variants initialVariants={initialVariants}>{
       variant => (
         <Infos

--- a/react/Infos/Readme.md
+++ b/react/Infos/Readme.md
@@ -7,13 +7,13 @@ import Button from 'cozy-ui/transpiled/react/Button';
     <Infos text="My small persistent information! " />
     <Infos text="In a slightly different style" className='u-maw-none u-bdrs-0'/>
     <Infos
-        text="My small persistent information, with an icon. And lot of text ? Again and again..."
+        text="My small persistent information, with an icon. And a lot of text ? Again and again..."
         icon="info"
     />
     <Infos
         actionButton={<Button theme="danger" label="A CTA button" />}
         title="Infos breaking news"
-        text="My small persistent information, with an icon. And lot of text ? Again and again..."
+        text="My small persistent information, with an icon. And a lot of text ? Again and again..."
         icon="warning"
         isImportant
     />

--- a/react/Infos/Readme.md
+++ b/react/Infos/Readme.md
@@ -39,7 +39,7 @@ const initialVariants = [
             {variant.title && <SubTitle className={variant.dangerTheme ? 'u-pomegranate' : ''}>{content.ada.facts[0].title}</SubTitle>}
             <Text>{content.ada.facts[0].description}</Text>
           </>}
-          action={<>
+          action={(variant.action || variant.multiActions) && <>
             {variant.action && <Button label="ok" theme={variant.dangerTheme ? 'danger' : 'primary'} />}
             {variant.multiActions && ['one', 'two', 'three'].map(label => <Button label={label} theme={variant.dangerTheme ? 'danger' : 'primary'} />)}
           </>}

--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -1,67 +1,117 @@
 import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import styles from './styles.styl'
-import Icon, { iconPropType } from '../Icon'
+import Icon from '../Icon'
 import Text, { SubTitle } from '../Text'
+import Stack from '../Stack'
+import palette from '../palette'
 
-const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
+import styles from './styles.styl'
+
+export const Infos = ({
+  description,
+  action,
+  dismissAction,
+  theme,
+  className
+}) => {
   return (
-    <div
-      className={cx(
-        styles['Infos'],
-        'u-stack-m',
-        isImportant ? 'u-bg-chablis' : 'u-bg-paleGrey',
-        className
+    <div className={cx(styles['Infos'], styles[`Infos--${theme}`], className)}>
+      <Stack spacing="m">
+        <div className={styles['Infos-description']}>
+          <Stack spacing="s">{description}</Stack>
+        </div>
+        {action && <div>{action}</div>}
+      </Stack>
+      {dismissAction && (
+        <button className={styles['Info-close']} onClick={dismissAction}>
+          <Icon icon="cross" color={palette['coolGrey']} />
+        </button>
       )}
-    >
-      {!!title && (
-        <SubTitle
-          className={cx({
-            'u-pomegranate': isImportant
-          })}
-        >
-          {title}
-        </SubTitle>
-      )}
-      <div className={cx('u-flex', 'u-w-100')}>
-        {icon && (
-          <Icon
-            icon={icon}
-            className={cx(
-              styles['Infos__icon'],
-              'u-w-1',
-              'u-h-1',
-              'u-flex-shrink-0'
-            )}
-          />
-        )}
-        <Text
-          className={cx('u-ta-left', {
-            ['u-pl-half']: icon !== null
-          })}
-        >
-          {text}
-        </Text>
-      </div>
-      {!!actionButton && <div className="u-flex-shrink-0">{actionButton}</div>}
     </div>
   )
 }
 
-Infos.defaultProps = {
-  icon: null
+Infos.propTypes = {
+  /** The textual part of the info, including titles */
+  description: PropTypes.element.isRequired,
+  /** One or more call to actions */
+  action: PropTypes.element,
+  /** If supplied, displays a cross in the top right corner that calls the prop when clicked */
+  dismissAction: PropTypes.func,
+  /** Extra classnames to apply to the root element */
+  className: PropTypes.string,
+  /** Controls the background color of the component */
+  theme: PropTypes.oneOf(['primary', 'secondary', 'danger'])
 }
 
-Infos.propTypes = {
-  /** A button that will be rendered at the bottom */
-  actionButton: PropTypes.element,
-  /** An icon to display at the left of the text */
-  icon: iconPropType,
-  /** An important information will be displayed with red colors */
-  isImportant: PropTypes.bool,
-  /** Can be either a Text, or an element (for instance a ReactMardown component) */
-  text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  title: PropTypes.string
+Infos.defaultProps = {
+  theme: 'primary'
 }
-export default Infos
+
+const InfosMigration = React.memo(props => {
+  const isUsingDeprecatedProps =
+    props.actionButton ||
+    props.icon ||
+    props.isImportant ||
+    props.text ||
+    props.title
+  if (isUsingDeprecatedProps) {
+    const {
+      title,
+      text,
+      icon,
+      actionButton,
+      isImportant,
+      ...otherProps
+    } = props
+    console.warn(
+      'The Infos component API has changed, using any of the following props is deprecated: title, text, icon, actionButton, isImportant'
+    )
+    return (
+      <Infos
+        className="u-maw-6"
+        theme={isImportant ? 'danger' : 'secondary'}
+        description={
+          <>
+            {title && (
+              <SubTitle
+                className={cx({
+                  'u-pomegranate': isImportant
+                })}
+              >
+                {title}
+              </SubTitle>
+            )}
+            <div className={cx('u-flex', 'u-w-100')}>
+              {icon && (
+                <Icon
+                  icon={icon}
+                  className={cx(
+                    styles['Infos__icon'],
+                    'u-w-1',
+                    'u-h-1',
+                    'u-flex-shrink-0'
+                  )}
+                />
+              )}
+              {text && (
+                <Text
+                  className={cx({
+                    ['u-pl-half']: icon !== null
+                  })}
+                >
+                  {text}
+                </Text>
+              )}
+            </div>
+          </>
+        }
+        action={actionButton}
+        {...otherProps}
+      />
+    )
+  } else return <Infos {...props} />
+})
+
+export default InfosMigration

--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -5,6 +5,7 @@ import Icon from '../Icon'
 import Text, { SubTitle } from '../Text'
 import Stack from '../Stack'
 import palette from '../palette'
+import createDepreciationLogger from '../helpers/createDepreciationLogger'
 
 import styles from './styles.styl'
 
@@ -49,6 +50,7 @@ Infos.defaultProps = {
   theme: 'primary'
 }
 
+const logInfosDepecrated = createDepreciationLogger()
 const InfosMigration = React.memo(props => {
   const isUsingDeprecatedProps =
     props.actionButton ||
@@ -65,7 +67,7 @@ const InfosMigration = React.memo(props => {
       isImportant,
       ...otherProps
     } = props
-    console.warn(
+    logInfosDepecrated(
       'The Infos component API has changed, using any of the following props is deprecated: title, text, icon, actionButton, isImportant'
     )
     return (

--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -10,12 +10,6 @@ const Infos = ({ actionButton, icon, isImportant, text, className, title }) => {
     <div
       className={cx(
         styles['Infos'],
-        'u-flex',
-        'u-flex-column',
-        'u-p-1',
-        'u-mih-2',
-        'u-flex-justify-center',
-        'u-ta-left',
         'u-stack-m',
         isImportant ? 'u-bg-chablis' : 'u-bg-paleGrey',
         className

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -1,14 +1,15 @@
 @require 'settings/palette'
 @require 'settings/breakpoints'
 @require 'tools/mixins'
+@require 'settings/spaces'
 
 .Infos
     position relative
     border-radius 8px
-    padding 2rem 1.5rem
+    padding spacing_values.xl spacing_values.l
 
     +mobile()
-        padding 1rem
+        padding spacing_values.m
 
     &.Infos--primary
         background-color var(--zircon)
@@ -26,7 +27,7 @@
     position absolute
     top 0
     right 0
-    padding 1rem
+    padding spacing_values.m
     cursor pointer
     border 0
     background transparent

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -1,16 +1,32 @@
+@require 'settings/palette'
+@require 'settings/breakpoints'
 @require 'tools/mixins'
-@require 'settings/spaces'
 
 .Infos
-    border-radius 4px
-    max-width 32rem
-    display flex
-    flex-direction column
-    justify-content center
-    text-align left
-    padding 1rem
-    min-height 2rem
+    position relative
+    border-radius 8px
+    padding 2rem 1.5rem
 
-.Infos__icon
-    padding-top .2rem
-    fill var(--slateGrey)
+    +mobile()
+        padding 1rem
+
+    &.Infos--primary
+        background-color var(--zircon)
+
+    &.Infos--secondary
+        background-color var(--paleGrey)
+
+    &.Infos--danger
+        background-color var(--chablis)
+
+.Infos-description
+    max-width 32rem
+
+.Info-close
+    position absolute
+    top 0
+    right 0
+    padding 1rem
+    cursor pointer
+    border 0
+    background transparent

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -1,9 +1,16 @@
 @require 'tools/mixins'
+@require 'settings/spaces'
 
 .Infos
     border-radius 4px
     max-width 32rem
+    display flex
+    flex-direction column
+    justify-content center
+    text-align left
+    padding 1rem
+    min-height 2rem
 
 .Infos__icon
-  padding-top .2rem
-  fill var(--slateGrey)
+    padding-top .2rem
+    fill var(--slateGrey)

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -4970,7 +4970,7 @@ exports[`Infos should render examples: Infos 1`] = `
       <div class=\\"u-flex u-w-100\\"><svg class=\\"styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#info\\"></use>
         </svg>
-        <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>
+        <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
       </div>
     </div>
     <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-chablis\\">
@@ -4978,7 +4978,7 @@ exports[`Infos should render examples: Infos 1`] = `
       <div class=\\"u-flex u-w-100\\"><svg class=\\"styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <use xlink:href=\\"#warning\\"></use>
         </svg>
-        <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And lot of text ? Again and again...</div>
+        <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
       </div>
       <div class=\\"u-flex-shrink-0\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><span>A CTA button</span></span></button></div>
     </div>

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -4956,31 +4956,95 @@ exports[`IconStack should render examples: IconStack 1`] = `
 exports[`Infos should render examples: Infos 1`] = `
 "<div>
   <div class=\\"u-stack-m\\">
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-paleGrey\\">
-      <div class=\\"u-flex u-w-100\\">
-        <div class=\\"u-text u-ta-left\\">My small persistent information! </div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--secondary___1AW6F u-maw-6\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-flex u-w-100\\">
+              <div class=\\"u-text u-pl-half\\">My small persistent information! </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-paleGrey u-maw-none u-bdrs-0\\">
-      <div class=\\"u-flex u-w-100\\">
-        <div class=\\"u-text u-ta-left\\">In a slightly different style</div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--secondary___1AW6F u-maw-none u-bdrs-0\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-flex u-w-100\\">
+              <div class=\\"u-text u-pl-half\\">In a slightly different style</div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-paleGrey\\">
-      <div class=\\"u-flex u-w-100\\"><svg class=\\"styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
-          <use xlink:href=\\"#info\\"></use>
-        </svg>
-        <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--secondary___1AW6F u-maw-6\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-flex u-w-100\\"><svg class=\\"u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+                <use xlink:href=\\"#info\\"></use>
+              </svg>
+              <div class=\\"u-text u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-    <div class=\\"styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-chablis\\">
-      <div class=\\"u-title-h3 u-pomegranate\\">Infos breaking news</div>
-      <div class=\\"u-flex u-w-100\\"><svg class=\\"styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
-          <use xlink:href=\\"#warning\\"></use>
-        </svg>
-        <div class=\\"u-text u-ta-left u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--danger___3wKYc u-maw-6\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-title-h3 u-pomegranate\\">Infos breaking news</div>
+            <div class=\\"u-flex u-w-100\\"><svg class=\\"u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+                <use xlink:href=\\"#warning\\"></use>
+              </svg>
+              <div class=\\"u-text u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
+            </div>
+          </div>
+        </div>
+        <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><span>A CTA button</span></span></button></div>
       </div>
-      <div class=\\"u-flex-shrink-0\\"><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><span>A CTA button</span></span></button></div>
+    </div>
+    <hr>
+    <h2>New API</h2>
+    <div class=\\"u-m-1\\">title: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">action: <input class=\\"u-mr-1\\" type=\\"checkbox\\">secondaryTheme: <input class=\\"u-mr-1\\" type=\\"checkbox\\"></div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--primary___3i4ll\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-title-h3\\">Date of birth</div>
+            <div class=\\"u-text\\">10 December 1815</div>
+          </div>
+        </div>
+        <div></div>
+      </div>
+    </div>
+    <div class=\\"u-m-1\\">title: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">action: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">dangerTheme: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\"></div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--danger___3wKYc\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-title-h3 u-pomegranate\\">Date of birth</div>
+            <div class=\\"u-text\\">10 December 1815</div>
+          </div>
+        </div>
+        <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><span>ok</span></span></button></div>
+      </div>
+    </div>
+    <div class=\\"u-m-1\\">title: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">multiActions: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">dangerTheme: <input class=\\"u-mr-1\\" type=\\"checkbox\\">dismissAction: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\"></div>
+    <div class=\\"styles__Infos___2ZZVs styles__Infos--primary___3i4ll\\">
+      <div class=\\"styles__Stack--m___1tSpV\\">
+        <div class=\\"styles__Infos-description___7P1NP\\">
+          <div class=\\"styles__Stack--s___22WMg\\">
+            <div class=\\"u-title-h3\\">Date of birth</div>
+            <div class=\\"u-text\\">10 December 1815</div>
+          </div>
+        </div>
+        <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>one</span></span></button><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>two</span></span></button><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>three</span></span></button></div>
+      </div><button class=\\"styles__Info-close___1RVQP\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"16\\" height=\\"16\\">
+          <use xlink:href=\\"#cross\\"></use>
+        </svg></button>
     </div>
   </div>
 </div>"

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -5017,7 +5017,6 @@ exports[`Infos should render examples: Infos 1`] = `
             <div class=\\"u-text\\">10 December 1815</div>
           </div>
         </div>
-        <div></div>
       </div>
     </div>
     <div class=\\"u-m-1\\">title: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">action: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">dangerTheme: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\"></div>

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -4956,58 +4956,6 @@ exports[`IconStack should render examples: IconStack 1`] = `
 exports[`Infos should render examples: Infos 1`] = `
 "<div>
   <div class=\\"u-stack-m\\">
-    <div class=\\"styles__Infos___2ZZVs styles__Infos--secondary___1AW6F u-maw-6\\">
-      <div class=\\"styles__Stack--m___1tSpV\\">
-        <div class=\\"styles__Infos-description___7P1NP\\">
-          <div class=\\"styles__Stack--s___22WMg\\">
-            <div class=\\"u-flex u-w-100\\">
-              <div class=\\"u-text u-pl-half\\">My small persistent information! </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class=\\"styles__Infos___2ZZVs styles__Infos--secondary___1AW6F u-maw-none u-bdrs-0\\">
-      <div class=\\"styles__Stack--m___1tSpV\\">
-        <div class=\\"styles__Infos-description___7P1NP\\">
-          <div class=\\"styles__Stack--s___22WMg\\">
-            <div class=\\"u-flex u-w-100\\">
-              <div class=\\"u-text u-pl-half\\">In a slightly different style</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class=\\"styles__Infos___2ZZVs styles__Infos--secondary___1AW6F u-maw-6\\">
-      <div class=\\"styles__Stack--m___1tSpV\\">
-        <div class=\\"styles__Infos-description___7P1NP\\">
-          <div class=\\"styles__Stack--s___22WMg\\">
-            <div class=\\"u-flex u-w-100\\"><svg class=\\"u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
-                <use xlink:href=\\"#info\\"></use>
-              </svg>
-              <div class=\\"u-text u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class=\\"styles__Infos___2ZZVs styles__Infos--danger___3wKYc u-maw-6\\">
-      <div class=\\"styles__Stack--m___1tSpV\\">
-        <div class=\\"styles__Infos-description___7P1NP\\">
-          <div class=\\"styles__Stack--s___22WMg\\">
-            <div class=\\"u-title-h3 u-pomegranate\\">Infos breaking news</div>
-            <div class=\\"u-flex u-w-100\\"><svg class=\\"u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
-                <use xlink:href=\\"#warning\\"></use>
-              </svg>
-              <div class=\\"u-text u-pl-half\\">My small persistent information, with an icon. And a lot of text ? Again and again...</div>
-            </div>
-          </div>
-        </div>
-        <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--danger___17T_C styles__c-btn--center___16_Xh\\"><span><span>A CTA button</span></span></button></div>
-      </div>
-    </div>
-    <hr>
-    <h2>New API</h2>
     <div class=\\"u-m-1\\">title: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">action: <input class=\\"u-mr-1\\" type=\\"checkbox\\">secondaryTheme: <input class=\\"u-mr-1\\" type=\\"checkbox\\"></div>
     <div class=\\"styles__Infos___2ZZVs styles__Infos--primary___3i4ll\\">
       <div class=\\"styles__Stack--m___1tSpV\\">

--- a/react/helpers/createDepreciationLogger.js
+++ b/react/helpers/createDepreciationLogger.js
@@ -1,0 +1,10 @@
+const createDepreciationLogger = () => {
+  let warned = false
+
+  return message => {
+    if (!warned) console.warn(message)
+    warned = true
+  }
+}
+
+export default createDepreciationLogger

--- a/react/helpers/createDepreciationLogger.spec.js
+++ b/react/helpers/createDepreciationLogger.spec.js
@@ -1,0 +1,21 @@
+import createDepreciationLogger from './createDepreciationLogger'
+
+describe('createDepreciationLogger', () => {
+  global.console = { warn: jest.fn() }
+
+  it('should not warn more than once per logger', () => {
+    const loggerOne = createDepreciationLogger()
+    const loggerTwo = createDepreciationLogger()
+
+    loggerOne()
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    loggerOne()
+    expect(console.warn).toHaveBeenCalledTimes(1)
+
+    loggerTwo()
+    expect(console.warn).toHaveBeenCalledTimes(2)
+    loggerOne()
+    loggerTwo()
+    expect(console.warn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
This PR updates the Infos component to suit new needs and fix old bugs, in particular:

- The line width should be capped
- More flexibility with the titles (adding subtitles, controlling their colors, …)
- Possibility to have a closing cross
- Compatibility with a InfosCarrousel component, which will be in a separate PR

The prop have changed, but there is a layer of compatibility, so no breaking changes. You can see the old components (and the new ones) in the [demo](https://yannick-lohse.fr/cozy-ui/react/#!/Infos), but I will remove the old examples before I merge this PR. The only changes are visual, the paddings and margins have slightly changed, but that is desired.

Just to be explicit about it: before this PR, we would pass a `title` prop, and the Infos component would render a `SubTitle` component. Now you are in charge of passing a `SubTitle` component to the `description` prop (or whatever other content you need, really).
