### PR TITLE
Add tag prop on Stack and force column layout

### DIFF
--- a/react/Stack/index.jsx
+++ b/react/Stack/index.jsx
@@ -3,9 +3,9 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
-const Stack = ({ spacing, ...props }) => {
+const Stack = ({ spacing, tag: Tag, ...props }) => {
   return (
-    <div
+    <Tag
       {...props}
       className={cx(props.className, spacing && styles['Stack--' + spacing])}
     />
@@ -17,7 +17,8 @@ Stack.propTypes = {
 }
 
 Stack.defaultProps = {
-  spacing: 'm'
+  spacing: 'm',
+  tag: 'div'
 }
 
 export default Stack


### PR DESCRIPTION
The tag prop enables us to change the tag used for the rendering of the Stack. It's useful to avoid rendering too many useless intermediary elements.

When some inline elements were children of a Stack, the margins were not
applied since vertical margins have no effect on inline elements. By adding
a flex display in column direction, we ensure that no matter which type of
element is rendered, it will have margins applied.

See https://drazik.github.io/cozy-ui/react/#!/Stack