### PR TITLE
feat(Stack): Force column rendering

### DIFF
--- a/react/Stack/index.jsx
+++ b/react/Stack/index.jsx
@@ -7,7 +7,11 @@ const Stack = ({ spacing, ...props }) => {
   return (
     <div
       {...props}
-      className={cx(props.className, spacing && styles['Stack--' + spacing])}
+      className={cx(
+        props.className,
+        styles.Stack,
+        spacing && styles['Stack--' + spacing]
+      )}
     />
   )
 }

--- a/react/Stack/styles.styl
+++ b/react/Stack/styles.styl
@@ -1,5 +1,9 @@
 @require 'utilities/spaces.styl'
 
+.Stack
+    display flex
+    flex-direction column
+
 for k,v in spacing_values
   modifier = "--" + k
   .Stack{modifier} > * + *

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -5119,8 +5119,8 @@ exports[`Label should render examples: Label 3`] = `
 exports[`Labs/CollectionField should render examples: Labs/CollectionField 1`] = `
 "<div>
   <div class=\\"styles__o-field___3n5HM\\"><label class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">Contacts</label>
-    <div class=\\"styles__Stack--m___1tSpV\\">
-      <div class=\\"styles__Stack--s___22WMg\\">
+    <div class=\\"styles__Stack___2Wsor styles__Stack--m___1tSpV\\">
+      <div class=\\"styles__Stack___2Wsor styles__Stack--s___22WMg\\">
         <div class=\\"styles__CollectionField__row___Z7bbf\\"><button type=\\"button\\" class=\\"styles__SelectControl___2OxoO\\">isabelle.durand@cozycloud.cc</button><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--center___16_Xh styles__c-btn--round___1Lkyl\\" title=\\"Remove this contact\\"><span><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#cross-small\\"></use></svg><span class=\\"u-visuallyhidden\\">Remove this contact</span></span></button></div>
       </div><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--text___2Vp-2 styles__c-btn--center___16_Xh styles__CollectionField__addBtn___Z0FO-\\"><span><svg class=\\"styles__CollectionField__addBtnIcon___1hA5b styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#plus\\"></use></svg><span>Add a contact</span></span></button>
     </div>
@@ -5131,8 +5131,8 @@ exports[`Labs/CollectionField should render examples: Labs/CollectionField 1`] =
 exports[`Labs/CollectionField should render examples: Labs/CollectionField 2`] = `
 "<div>
   <div class=\\"styles__o-field___3n5HM styles__o-field--inline___7JWZ8\\"><label class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">Contacts</label>
-    <div class=\\"styles__Stack--m___1tSpV\\">
-      <div class=\\"styles__Stack--s___22WMg\\">
+    <div class=\\"styles__Stack___2Wsor styles__Stack--m___1tSpV\\">
+      <div class=\\"styles__Stack___2Wsor styles__Stack--s___22WMg\\">
         <div class=\\"styles__CollectionField__row___Z7bbf\\"><button type=\\"button\\" class=\\"styles__SelectControl___2OxoO\\">isabelle.durand@cozycloud.cc</button><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--center___16_Xh styles__c-btn--round___1Lkyl\\" title=\\"Remove this contact\\"><span><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#cross-small\\"></use></svg><span class=\\"u-visuallyhidden\\">Remove this contact</span></span></button></div>
       </div><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--text___2Vp-2 styles__c-btn--center___16_Xh styles__CollectionField__addBtn___Z0FO-\\"><span><svg class=\\"styles__CollectionField__addBtnIcon___1hA5b styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#plus\\"></use></svg><span>Add a contact</span></span></button>
     </div>


### PR DESCRIPTION
When some inline elements were children of a Stack, the margins were not
applied since vertical margins have no effect on inline elements. By
adding a flex display in column direction, we ensure that no matter
which type of element is rendered, it will have margins applied.

This was originally submitted in https://github.com/cozy/cozy-ui/pull/1300, but it causes some visual regression in CollectionField (see https://github.com/cozy/cozy-ui/pull/1300#pullrequestreview-330530348). So we may need to add some flex properties to avoid problems.