### PR TITLE
fix: Always use transpiled cozy-ui

### DIFF
--- a/react/AppSections/Sections.jsx
+++ b/react/AppSections/Sections.jsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import { translate } from 'cozy-ui/react/I18n'
-import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
+import { translate } from '../I18n'
+import withBreakpoints from '../helpers/withBreakpoints'
 
 import AppsSection from './components/AppsSection'
 import DropdownFilter from './components/DropdownFilter'

--- a/react/AppSections/components/AppsSection.jsx
+++ b/react/AppSections/components/AppsSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { translate } from 'cozy-ui/react/I18n'
-import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
+import { translate } from '../../I18n'
+import withBreakpoints from '../../helpers/withBreakpoints'
 import { getTranslatedManifestProperty } from '../helpers'
 import sortBy from 'lodash/sortBy'
 import SmallAppItem from './SmallAppItem'

--- a/react/AppSections/components/DropdownFilter.jsx
+++ b/react/AppSections/components/DropdownFilter.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 
-import SelectBox from 'cozy-ui/react/SelectBox'
-import Icon from 'cozy-ui/react/Icon'
+import SelectBox from '../../SelectBox'
+import Icon from '../../Icon'
 import PropTypes from 'prop-types'
 import styles from './DropdownFilter.styl'
 import cx from 'classnames'

--- a/react/MuiCozyTheme/Dialog/DialogCloseButton.jsx
+++ b/react/MuiCozyTheme/Dialog/DialogCloseButton.jsx
@@ -1,3 +1,3 @@
-import ModalCross from 'cozy-ui/react/Modal/ModalCross'
+import ModalCross from '../../Modal/ModalCross'
 
 export default ModalCross

--- a/react/NestedSelect/Modal.jsx
+++ b/react/NestedSelect/Modal.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import Icon from 'cozy-ui/react/Icon'
+import Icon from '../Icon'
 import Modal, {
   ModalHeader as UIModalHeader,
   ModalContent as UIModalContent
-} from 'cozy-ui/react/Modal'
-import { Media, Bd, Img } from 'cozy-ui/react/Media'
-import palette from 'cozy-ui/react/palette'
+} from '../Modal'
+import { Media, Bd, Img } from '../Media'
+import palette from '../palette'
 import NestedSelect from './NestedSelect'
 
 import styles from './styles.styl'

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -6,7 +6,7 @@ import styles from './styles.styl'
 import UIRadio from '../Radio'
 import cx from 'classnames'
 import omit from 'lodash/omit'
-import palette from 'cozy-ui/react/palette'
+import palette from '../palette'
 
 /**
  * Select like component to choose an option among a list of options.


### PR DESCRIPTION
Some files did use an absolute path for cozy-ui
loading from `cozy-ui/react/…`. This breaks
if we use the components from a transpiled path
(it will escape the transpiled to go into non transpiled)

----

In early versions of B2B overrides, we needed to have absolute path for the files we wanted to overide. Files modified in this PR were using absolute path for that motive.

Today, our babel configuration does rewrite all path in order to use absolute path pointing at the transpiled version of each file. We don't need to write absolute path ourself in cozy-ui anymore (and we shouldn't).

