### PR TITLE
feat: Add PasswordInput to Labs components

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -134,7 +134,8 @@ module.exports = {
         '../react/Labs/GridItem',
         '../react/MuiCozyTheme/Dialog',
         '../react/Labs/IconGrid',
-        '../react/Labs/CollectionField'
+        '../react/Labs/CollectionField',
+        '../react/Labs/PasswordInput'
       ]
     },
     {

--- a/react/Labs/PasswordInput/Readme.md
+++ b/react/Labs/PasswordInput/Readme.md
@@ -1,0 +1,44 @@
+This component takes the same props as the `Input` component.
+`Input` props are spread to the underlying `Input`.
+
+### Original
+
+```jsx
+import PasswordInput from 'cozy-ui/transpiled/react/Labs/PasswordInput';
+const initialState = { password: '' };
+
+<PasswordInput
+  value={state.password}
+  onChange={e => setState({ password: e.target.value })}
+  placeholder="Enter your password"
+/>
+```
+
+### With strength
+
+```jsx
+import PasswordInput from 'cozy-ui/transpiled/react/Labs/PasswordInput';
+const initialState = { password: '' };
+
+<PasswordInput
+  value={state.password}
+  onChange={e => setState({ password: e.target.value })}
+  placeholder="Enter your password"
+  showStrength
+/>
+```
+
+### Errored
+
+```jsx
+import PasswordInput from 'cozy-ui/transpiled/react/Labs/PasswordInput';
+const initialState = { password: '' };
+
+<PasswordInput
+  value={state.password}
+  onChange={e => setState({ password: e.target.value })}
+  placeholder="Enter your password"
+  showStrength
+  error
+/>
+```

--- a/react/Labs/PasswordInput/helpers.js
+++ b/react/Labs/PasswordInput/helpers.js
@@ -1,0 +1,62 @@
+const charsets = [
+  // upper
+  { regexp: /[A-Z]/g, size: 26 },
+  // lower
+  { regexp: /[a-z]/g, size: 26 },
+  // digit
+  { regexp: /[0-9]/g, size: 10 },
+  // special
+  { regexp: /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/g, size: 30 }
+]
+
+/*
+ * Returns the strength (percentage and label) of a given password
+ *
+ * @param {String} password
+ * @returns {Object} An object with percentage and label properties
+ * representing the strenght of the password
+ */
+export const getStrength = password => {
+  if (!password && password !== '') {
+    throw new Error('password parameter is missing')
+  }
+  if (!password.length) {
+    return { percentage: 0, label: 'weak' }
+  }
+
+  const possibleChars = charsets.reduce(function(possibleChars, charset) {
+    if (charset.regexp.test(password)) possibleChars += charset.size
+    return possibleChars
+  }, 0)
+
+  const passwordStrength =
+    Math.log(Math.pow(possibleChars, password.length)) / Math.log(2)
+
+  // levels
+  const _at33percent = 50
+  const _at66percent = 100
+  const _at100percent = 150
+
+  let strengthLabel = ''
+  let strengthPercentage = 0
+
+  // between 0% and 33%
+  if (passwordStrength <= _at33percent) {
+    strengthPercentage = (passwordStrength * 33) / _at33percent
+    strengthLabel = 'weak'
+  } else if (
+    passwordStrength > _at33percent &&
+    passwordStrength <= _at66percent
+  ) {
+    // between 33% and 66%
+    strengthPercentage = (passwordStrength * 66) / _at66percent
+    strengthLabel = 'moderate'
+  } else {
+    // passwordStrength > 192
+    strengthPercentage = (passwordStrength * 100) / _at100percent
+    if (strengthPercentage > 100) strengthPercentage = 100
+    strengthLabel = 'strong'
+  }
+
+  return { percentage: strengthPercentage, label: strengthLabel }
+}

--- a/react/Labs/PasswordInput/helpers.spec.js
+++ b/react/Labs/PasswordInput/helpers.spec.js
@@ -1,0 +1,19 @@
+import { getStrength } from './helpers'
+
+describe('getStrength', () => {
+  it('should return the correct strength', () => {
+    const weak = getStrength('cozy')
+    expect(weak.label).toBe('weak')
+    expect(weak.percentage).toBeCloseTo(12.4, 1)
+
+    const moderate = getStrength('c0zycl0ud!;')
+    expect(moderate.label).toBe('moderate')
+    expect(moderate.percentage).toBeCloseTo(43.9, 1)
+
+    const strong = getStrength('thisis4verylongp@ssword!!!')
+    expect(strong.label).toBe('strong')
+    expect(strong.percentage).toBe(100)
+
+    expect(getStrength('').percentage).toBe(0)
+  })
+})

--- a/react/Labs/PasswordInput/index.jsx
+++ b/react/Labs/PasswordInput/index.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+import Icon from '../../Icon'
+import InputGroup from '../../InputGroup'
+import Input from '../../Input'
+import cx from 'classnames'
+import { getStrength } from './helpers'
+import styles from './styles.styl'
+import PropTypes from 'prop-types'
+
+const HideShowButton = props => {
+  const { hidden, className, ...rest } = props
+
+  return (
+    <button
+      type="button"
+      className={cx(styles['PasswordInput__visibilityButton'], className)}
+      {...rest}
+    >
+      <Icon
+        icon={hidden ? 'eye' : 'eye-closed'}
+        size={16}
+        color="var(--coolGrey)"
+      />
+    </button>
+  )
+}
+
+const Strength = props => {
+  const { password, className, ...rest } = props
+  const strength = getStrength(password)
+
+  return (
+    <progress
+      step="1"
+      min="0"
+      max="100"
+      value={strength.percentage}
+      className={cx(
+        styles['PasswordInput__strength'],
+        styles[`PasswordInput__strength--${strength.label}`],
+        className
+      )}
+      {...rest}
+    />
+  )
+}
+
+const PasswordInput = props => {
+  const { className, showStrength, error, ...rest } = props
+  const [hidden, setHidden] = useState(true)
+
+  return (
+    <div className={cx(styles.PasswordInput, className)}>
+      <InputGroup
+        append={
+          <HideShowButton hidden={hidden} onClick={() => setHidden(!hidden)} />
+        }
+        className={cx(showStrength && styles['PasswordInput--withStrength'])}
+        error={error}
+      >
+        <Input {...rest} type={hidden ? 'password' : 'text'} />
+      </InputGroup>
+      {showStrength ? <Strength password={props.value} /> : null}
+    </div>
+  )
+}
+
+PasswordInput.propTypes = {
+  showStrength: PropTypes.bool,
+  error: PropTypes.bool
+}
+
+PasswordInput.defaultProps = {
+  showStrength: false,
+  error: false
+}
+
+export default PasswordInput

--- a/react/Labs/PasswordInput/styles.styl
+++ b/react/Labs/PasswordInput/styles.styl
@@ -1,0 +1,49 @@
+@require 'tools/mixins'
+
+.PasswordInput
+    display inline-flex
+    flex-direction column
+    width 100%
+    max-width rem(512)
+
+.PasswordInput--withStrength
+    border-bottom-left-radius 0
+    border-bottom-right-radius 0
+
+.PasswordInput__strength
+    background-color var(--paleGrey)
+    border-radius rem(3)
+    border-top-left-radius 0
+    border-top-right-radius 0
+    border rem(1) solid var(--silver)
+    border-top 0
+    box-sizing border-box
+    height rem(4)
+
+.PasswordInput__strength--weak
+    color var(--pomegranate)
+    &::-webkit-progress-value
+        background-color var(--pomegranate)
+    &::-moz-progress-bar
+        background-color var(--pomegranate)
+
+.PasswordInput__strength--moderate
+    color var(--texasRose)
+    &::-webkit-progress-value
+        background-color var(--texasRose)
+    &::-moz-progress-bar
+        background-color var(--texasRose)
+
+
+.PasswordInput__strength--strong
+    color var(--emerald)
+    &::-webkit-progress-value
+        background-color var(--emerald)
+    &::-moz-progress-bar
+        background-color var(--emerald)
+
+.PasswordInput__visibilityButton
+    height 100%
+    width rem(48)
+    background-color transparent
+    border 0


### PR DESCRIPTION
This is a new form of input field. But it needs to stabilized and maybe merged with current Input/Field. Labs seems to be a good place for it at the moment.

Related to https://github.com/cozy/cozy-ui/issues/1304

See https://github.com/cozy/cozy-settings/pull/269#discussion_r357225768

See https://drazik.github.io/cozy-ui/react/#!/PasswordInput