### PR TITLE
WIP feat(TextField): Add inverted prop

### DIFF
--- a/react/MuiCozyTheme/TextField/Readme.md
+++ b/react/MuiCozyTheme/TextField/Readme.md
@@ -1,4 +1,6 @@
-Cozy themed MUI TextField. It is only a re-export of the component from MUI.
+Cozy themed MUI TextField. See
+[MUI V3 documentation](https://v3.material-ui.com/api/text-field/) to find the
+props.
 
 ```
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
@@ -40,3 +42,24 @@ import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField';
 </MuiCozyTheme>
 ```
 
+The only prop added is `inverted`. When `true`, the `TextField` uses colors
+that look good on a primary color background:
+
+```jsx
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField';
+
+<MuiCozyTheme>
+  <div style={{ backgroundColor: 'var(--primaryColor)', padding: '2rem' }}>
+    <TextField
+      id="inverted-field"
+      label="Label"
+      defaultValue="Default value"
+      margin="normal"
+      variant="outlined"
+      placeholder="placeholder"
+      inverted
+    />
+  </div>
+</MuiCozyTheme>
+```

--- a/react/MuiCozyTheme/TextField/index.js
+++ b/react/MuiCozyTheme/TextField/index.js
@@ -1,3 +1,24 @@
-import TextField from '@material-ui/core/TextField'
+import React from 'react'
+import MUITextField from '@material-ui/core/TextField'
+import cx from 'classnames'
+import styles from './styles.styl'
+
+const InvertedTextField = props => (
+  <div
+    className={cx('CozyMuiInvertedTextField', styles['TextField--fullWidth'])}
+  >
+    <MUITextField {...props} />
+  </div>
+)
+
+const TextField = props => {
+  const { inverted, ...rest } = props
+
+  if (inverted) {
+    return <InvertedTextField {...rest} />
+  }
+
+  return <MUITextField {...rest} />
+}
 
 export default TextField

--- a/react/MuiCozyTheme/TextField/styles.styl
+++ b/react/MuiCozyTheme/TextField/styles.styl
@@ -1,0 +1,2 @@
+.TextField--fullWidth
+    width 100%

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -66,15 +66,28 @@ export const theme = createMuiTheme({
 theme.overrides = {
   MuiOutlinedInput: {
     root: {
+      '.CozyMuiInvertedTextField &': {
+        color: 'var(--white)'
+      },
       '&$disabled': {
         background: 'var(--paleGrey)'
       },
       '&$focused $notchedOutline': {
         borderWidth: '0.0625rem'
+      },
+      '.CozyMuiInvertedTextField & $notchedOutline': {
+        borderColor: 'var(--white) !important'
       }
     },
     notchedOutline: {
       borderColor: 'var(--silver)'
+    }
+  },
+  MuiInputLabel: {
+    outlined: {
+      '.CozyMuiInvertedTextField &': {
+        color: 'var(--white)'
+      }
     }
   },
   MuiButton: {


### PR DESCRIPTION
This prop is used to show an « inverted » version of the TextField. E.g.
a version that looks good on a primary color background.

MUI doesn't have a prop to manage different « looks » of the TextField,
so I cheated by wrapping the component in a `div` with a particular
class name when `inverted` is true.

I'm not fully happy with this, but I didn't see another way to achieve it. If you have something better in mind, please tell me.

See https://drazik.github.io/cozy-ui/react/#!/TextField