### PR TITLE
feat(MuiCozyTheme): Add inverted theme for TextField

### DIFF
--- a/react/MuiCozyTheme/TextField/Readme.md
+++ b/react/MuiCozyTheme/TextField/Readme.md
@@ -1,4 +1,6 @@
-Cozy themed MUI TextField. It is only a re-export of the component from MUI.
+Cozy themed MUI TextField. See
+[MUI V3 documentation](https://v3.material-ui.com/api/text-field/) to find the
+props.
 
 ```
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
@@ -40,3 +42,22 @@ import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField';
 </MuiCozyTheme>
 ```
 
+#### Inverted theme
+
+```jsx
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField';
+
+<MuiCozyTheme variant="inverted">
+  <div style={{ backgroundColor: 'var(--primaryColor)', padding: '2rem' }}>
+    <TextField
+      id="inverted-field"
+      label="Label"
+      defaultValue="Default value"
+      margin="normal"
+      variant="outlined"
+      placeholder="placeholder"
+    />
+  </div>
+</MuiCozyTheme>
+```

--- a/react/MuiCozyTheme/index.jsx
+++ b/react/MuiCozyTheme/index.jsx
@@ -1,9 +1,19 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { MuiThemeProvider } from '@material-ui/core/styles'
-import theme from './theme.js'
+import { getTheme } from './theme.js'
 
-const MuiCozyTheme = ({ children }) => {
+const MuiCozyTheme = ({ variant, children }) => {
+  const theme = getTheme(variant)
   return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+}
+
+MuiCozyTheme.propTypes = {
+  variant: PropTypes.oneOf(['normal', 'inverted'])
+}
+
+MuiCozyTheme.defaultProps = {
+  variant: 'normal'
 }
 
 export default MuiCozyTheme

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -5,7 +5,7 @@ const defaultValues = {
   borderRadius: 6
 }
 
-export const theme = createMuiTheme({
+export const normalTheme = createMuiTheme({
   typography: {
     useNextVariants: true,
     fontFamily: getCssVariableValue('primaryFont'),
@@ -13,7 +13,30 @@ export const theme = createMuiTheme({
       color: 'white'
     }
   },
+  shape: {
+    borderRadius: defaultValues.borderRadius
+  },
+  breakpoints: {
+    // Define custom breakpoint values.
+    // These will apply to Material-UI components that use responsive
+    // breakpoints, such as `Grid` and `Hidden`. You can also use the
+    // theme breakpoint functions `up`, `down`, and `between` to create
+    // media queries for these breakpoints
+    // xs = all
+    // sm = tiny
+    // md = small
+    // lg = medium
+    // xl = large
+    values: {
+      xs: 0,
+      sm: 480,
+      md: 768,
+      lg: 1023,
+      xl: 1200
+    }
+  },
   palette: {
+    type: 'light',
     primary: {
       light: getCssVariableValue('primaryColorLight'),
       main: getCssVariableValue('primaryColor'),
@@ -38,32 +61,10 @@ export const theme = createMuiTheme({
       800: getCssVariableValue('charcoalGrey'),
       900: getCssVariableValue('black')
     }
-  },
-  shape: {
-    borderRadius: defaultValues.borderRadius
-  },
-  breakpoints: {
-    // Define custom breakpoint values.
-    // These will apply to Material-UI components that use responsive
-    // breakpoints, such as `Grid` and `Hidden`. You can also use the
-    // theme breakpoint functions `up`, `down`, and `between` to create
-    // media queries for these breakpoints
-    // xs = all
-    // sm = tiny
-    // md = small
-    // lg = medium
-    // xl = large
-    values: {
-      xs: 0,
-      sm: 480,
-      md: 768,
-      lg: 1023,
-      xl: 1200
-    }
   }
 })
 
-theme.overrides = {
+normalTheme.overrides = {
   MuiOutlinedInput: {
     root: {
       '&$disabled': {
@@ -226,10 +227,10 @@ theme.overrides = {
     },
     paper: {
       'box-sizing': 'border-box',
-      [theme.breakpoints.down('md')]: {
+      [normalTheme.breakpoints.down('md')]: {
         padding: '16px'
       },
-      [theme.breakpoints.up('md')]: {
+      [normalTheme.breakpoints.up('md')]: {
         padding: '32px'
       }
     },
@@ -258,7 +259,61 @@ theme.overrides = {
 }
 
 // Override default shadow for elevation 8 used for Popover
-theme.shadows[8] =
+normalTheme.shadows[8] =
   '0rem 0.125rem 0.375rem 0rem rgba(50, 54, 63, .19), 0rem 0.375rem 1.25rem 0rem rgba(50, 54, 63, .19)'
 
-export default theme
+export const invertedTheme = {
+  ...normalTheme,
+  palette: {
+    ...normalTheme.palette,
+    type: 'dark',
+    text: {
+      primary: getCssVariableValue('white')
+    }
+  }
+}
+
+invertedTheme.overrides = {
+  ...normalTheme.overrides,
+  MuiOutlinedInput: {
+    root: {
+      '&$focused $notchedOutline': {
+        borderColor: invertedTheme.palette.text.primary,
+        borderWidth: '0.0625rem'
+      },
+      '& $notchedOutline': {
+        borderColor: invertedTheme.palette.text.primary
+      }
+    }
+  },
+  MuiFormLabel: {
+    root: {
+      '&$focused': {
+        color: invertedTheme.palette.text.primary
+      }
+    }
+  },
+  MuiInputLabel: {
+    root: {
+      color: invertedTheme.palette.text.primary
+    }
+  }
+}
+
+const themes = {
+  normal: normalTheme,
+  inverted: invertedTheme
+}
+
+export const getTheme = variant => {
+  const theme = themes[variant]
+
+  if (!theme) {
+    const possibleThemes = Object.keys(themes).join(', ')
+    throw new Error(
+      `[MuiCozyTheme] Unknown theme variant: ${variant}. Possible variants are ${possibleThemes}`
+    )
+  }
+
+  return theme
+}


### PR DESCRIPTION
The inverted theme is made to look fine on non-white backgrounds. For
now we only have the TextField look for this theme, but with this
commit, everything should be ready to implement the theme for other MUI
components.

The discussion leading to this new theme was on https://github.com/cozy/cozy-ui/pull/1316. I decided to open another PR instead of amend the whole content of the previous one to avoid losing the context.

See https://drazik.github.io/cozy-ui/react/#!/TextField