### PR TITLE
fix: Spinner snapshot with translated msg ws wrong

### DIFF
--- a/react/Spinner/Readme.md
+++ b/react/Spinner/Readme.md
@@ -55,13 +55,11 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner';
 import I18n from 'cozy-ui/transpiled/react/I18n';
 
 <div>
-  <I18n lang='en' dictRequire={() => {
-      en: {
-        loading: {
-          helloWorld: 'Hello World !'
-        }
+  <I18n lang='en' dictRequire={() => ({
+      loading: {
+        helloWorld: 'Hello world !'
       }
-    }}>
+    })}>
     <Spinner size='xxlarge' loadingType='helloWorld' />
   </I18n>
 </div>

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -5845,7 +5845,7 @@ exports[`Spinner should render examples: Spinner 5`] = `
     <div class=\\"styles__c-spinner___1snK7\\"><svg class=\\"styles__icon___23x3R styles__icon--spin___ybfC1\\" style=\\"fill: var(--primaryColor);\\" width=\\"80\\" height=\\"80\\">
         <use xlink:href=\\"#spinner\\"></use>
       </svg>
-      <p>loading.helloWorld</p>
+      <p>Hello world !</p>
     </div>
   </div>
 </div>"


### PR DESCRIPTION
Lack of parenthesis around the returned locale object resulted in the phrases
inside the polyglot instance empty.