### PR TITLE
Contacts list realtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "commitlint": "7.6.1",
     "commitlint-config-cozy": "0.3.27",
     "copyfiles": "2.1.1",
-    "cozy-client": "8.2.0",
+    "cozy-client": "9.2.0",
     "cozy-device-helper": "1.7.5",
     "cozy-doctypes": "^1.69.0",
     "css-loader": "0.28.11",

--- a/react/ContactsListModal/AddContactButton.jsx
+++ b/react/ContactsListModal/AddContactButton.jsx
@@ -1,22 +1,66 @@
-import React from 'react'
-import { withClient } from 'cozy-client'
-import AppLinker, { generateWebLink } from '../AppLinker'
+import React, { useEffect } from 'react'
+import { withClient, models, queryConnect } from 'cozy-client'
+import AppLinker from '../AppLinker'
 import { ButtonLink } from '../Button'
+import compose from 'lodash/flowRight'
 
 const DumbAddContactButton = props => {
-  const { client, ...rest } = props
+  const { client, apps, ...rest } = props
 
-  const cozyURL = new URL(client.getStackClient().uri)
-  const { cozySubdomainType } = client.getInstanceOptions()
-  const contactsAppSlug = 'contacts'
-  const contactsAppHref = generateWebLink({
-    cozyUrl: cozyURL.origin,
-    slug: contactsAppSlug,
-    subDomainType: cozySubdomainType
-  })
+  const wantedApp = { slug: 'contacts' }
+  const installedApp = models.applications.isInstalled(apps.data, wantedApp)
+
+  let href
+
+  if (installedApp) {
+    href = models.applications.getUrl(installedApp)
+  } else {
+    href = models.applications.getStoreInstallationURL(apps.data, wantedApp)
+  }
+
+  useEffect(() => {
+    const refreshApps = () => {
+      apps.fetch()
+    }
+
+    const subscribeRealtime = async () => {
+      try {
+        await client.plugins.realtime.subscribe(
+          'created',
+          'io.cozy.apps',
+          refreshApps
+        )
+      } catch (err) {
+        console.error(err)
+        console.warning(
+          'Impossible to subscribe to io.cozy.apps creation in realtime. Your app should have io.cozy.apps permission and your client should have realtime initialized.'
+        )
+      }
+    }
+
+    subscribeRealtime()
+
+    return async () => {
+      try {
+        await client.plugins.realtime.unsubscribe(
+          'created',
+          'io.cozy.apps',
+          refreshApps
+        )
+      } catch (err) {
+        console.error(err)
+        console.warning(
+          'Impossible to unsubscribe from io.cozy.apps creation in realtime. Your app should have io.cozy.apps permission and your client should have realtime initialized.'
+        )
+      }
+    }
+  }, [])
 
   return (
-    <AppLinker slug={contactsAppSlug} href={contactsAppHref}>
+    <AppLinker
+      slug={installedApp ? installedApp.attributes.slug : 'store'}
+      href={href}
+    >
       {({ onClick, href }) => (
         <ButtonLink
           href={href}
@@ -31,6 +75,14 @@ const DumbAddContactButton = props => {
   )
 }
 
-const AddContactButton = withClient(DumbAddContactButton)
+const AddContactButton = compose(
+  withClient,
+  queryConnect({
+    apps: {
+      query: client => client.all('io.cozy.apps'),
+      as: 'apps'
+    }
+  })
+)(DumbAddContactButton)
 
 export default AddContactButton

--- a/react/ContactsListModal/AddContactButton.jsx
+++ b/react/ContactsListModal/AddContactButton.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { withClient, models, queryConnect } from 'cozy-client'
 import AppLinker from '../AppLinker'
 import { ButtonLink } from '../Button'
 import compose from 'lodash/flowRight'
+import useRealtime from './useRealtime'
 
 const DumbAddContactButton = props => {
   const { client, apps, ...rest } = props
@@ -18,43 +19,15 @@ const DumbAddContactButton = props => {
     href = models.applications.getStoreInstallationURL(apps.data, wantedApp)
   }
 
-  useEffect(() => {
-    const refreshApps = () => {
-      apps.fetch()
-    }
-
-    const subscribeRealtime = async () => {
-      try {
-        await client.plugins.realtime.subscribe(
-          'created',
-          'io.cozy.apps',
-          refreshApps
-        )
-      } catch (err) {
-        console.error(err)
-        console.warning(
-          'Impossible to subscribe to io.cozy.apps creation in realtime. Your app should have io.cozy.apps permission and your client should have realtime initialized.'
-        )
+  useRealtime(
+    client,
+    {
+      'io.cozy.apps': {
+        created: apps.fetch
       }
-    }
-
-    subscribeRealtime()
-
-    return async () => {
-      try {
-        await client.plugins.realtime.unsubscribe(
-          'created',
-          'io.cozy.apps',
-          refreshApps
-        )
-      } catch (err) {
-        console.error(err)
-        console.warning(
-          'Impossible to unsubscribe from io.cozy.apps creation in realtime. Your app should have io.cozy.apps permission and your client should have realtime initialized.'
-        )
-      }
-    }
-  }, [])
+    },
+    []
+  )
 
   return (
     <AppLinker

--- a/react/ContactsListModal/DemoProvider.jsx
+++ b/react/ContactsListModal/DemoProvider.jsx
@@ -8,11 +8,37 @@ const mockClient = new CozyClient({
   token: 'faketoken'
 })
 
-mockClient.__proto__.requestQuery = () =>
-  Promise.resolve({
-    fetchStatus: 'loaded',
-    data: contacts
-  })
+mockClient.__proto__.requestQuery = ({ doctype }) => {
+  if (doctype === 'io.cozy.contacts') {
+    return Promise.resolve({
+      fetchStatus: 'loaded',
+      data: contacts
+    })
+  }
+
+  if (doctype === 'io.cozy.apps') {
+    return Promise.resolve({
+      fetchStatus: 'loaded',
+      data: [
+        {
+          _id: 'io.cozy.apps/contacts',
+          _type: 'io.cozy.apps',
+          attributes: {
+            slug: 'contacts'
+          }
+        }
+      ]
+    })
+  }
+}
+
+mockClient.plugins = {
+  realtime: {
+    subscribe: () => {},
+    unsubscribe: () => {},
+    unsubscribeAll: () => {}
+  }
+}
 
 class Wrapper extends React.Component {
   getChildContext() {

--- a/react/ContactsListModal/Readme.md
+++ b/react/ContactsListModal/Readme.md
@@ -10,6 +10,7 @@ be up-to-date.
 
 ```jsx static
 import CozyClient, { CozyProvider } from 'cozy-client'
+import { RealtimePlugin } from 'cozy-realtime'
 
 const client = new CozyClient(/* ... */)
 client.registerPlugin(RealtimePlugin)

--- a/react/ContactsListModal/Readme.md
+++ b/react/ContactsListModal/Readme.md
@@ -1,6 +1,23 @@
 ## ContactsListModal
 
-A filterable list of contacts shown in a modal. This component should be wrapped in a CozyProvider since it does a request to fetch all contacts.
+A filterable list of contacts shown in a modal.
+
+Since this component does a request to fetch all contacts, it should be wrapped
+in a CozyProvider. Also, to take advantage of realtime updates of the contacts,
+the CozyClient passed to the provider should have a realtime plugin initialized.
+The component will work without realtime initialized, but the list will not always
+be up-to-date.
+
+```jsx static
+import CozyClient, { CozyProvider } from 'cozy-client'
+
+const client = new CozyClient(/* ... */)
+client.registerPlugin(RealtimePlugin)
+
+<CozyProvider client={client}>
+  {/* ... */}
+</CozyProvider>
+```
 
 ```jsx
 import ContactsListModal from 'cozy-ui/transpiled/react/ContactsListModal';

--- a/react/ContactsListModal/useRealtime.js
+++ b/react/ContactsListModal/useRealtime.js
@@ -1,0 +1,48 @@
+import { useEffect } from 'react'
+
+const useRealtime = (client, specs, deps) => {
+  if (!client.plugins || !client.plugins.realtime) {
+    console.error(
+      '[useRealtime] The provided CozyClient instance does not have a RealtimePlugin registered'
+    )
+    return
+  }
+
+  const subscribeRealtime = () => {
+    Object.entries(specs).forEach(([doctype, events]) => {
+      Object.entries(events).forEach(async ([event, callback]) => {
+        try {
+          await client.plugins.realtime.subscribe(doctype, event, callback)
+        } catch (err) {
+          console.error(err)
+          console.error(
+            `[useRealtime] Impossible to subscribe to ${event} event on ${doctype}. Does your app have the required permissions on this doctype?`
+          )
+        }
+      })
+    })
+  }
+
+  const unsubscribeRealtime = () => {
+    Object.entries(specs).forEach(([doctype, events]) => {
+      Object.entries(events).forEach(async ([event, callback]) => {
+        try {
+          await client.plugins.realtime.unsubscribe(doctype, event, callback)
+        } catch (err) {
+          console.error(err)
+          console.error(
+            `[useRealtime] Impossible to unsubscribe from ${event} event on ${doctype}. Does your app have the required permissions on this doctype?`
+          )
+        }
+      })
+    })
+  }
+
+  useEffect(() => {
+    subscribeRealtime()
+
+    return unsubscribeRealtime
+  }, deps)
+}
+
+export default useRealtime

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,13 +4371,13 @@ cosmiconfig@^5.0.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-client@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-8.2.0.tgz#41526f6882ff8ba94dac93d0ea6d2ed44d5ffc33"
-  integrity sha512-dxgbSVI0ras4XWS9/TYhU6rEweKeu1XJgcPiWVMfZnS/Otci1QT/eQMGciqOdcqndNnPv09pgYc7QKarTtulrA==
+cozy-client@9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.2.0.tgz#277f8fb36201f3767f7e116b112b8f416c38d43f"
+  integrity sha512-o2EVDrWlkqNdkwKbs5iaFSUhfoBY3sqQBdQgg5uE/PXxMo24Ee1jqiqTHEz927MRwHLjoHMQQaie/DahWscuiw==
   dependencies:
     cozy-device-helper "^1.7.3"
-    cozy-stack-client "^8.0.0"
+    cozy-stack-client "^9.2.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     prop-types "^15.6.2"
@@ -4421,10 +4421,17 @@ cozy-logger@^1.6.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-8.0.0.tgz#1c0d69b3b5261ba383ae2b2c293bd74b07b28bdf"
-  integrity sha512-Kawi0Qc9NedVQyCq8CHePRdxYHQlKrHfNQqZZoNZroma/NlxTB1kvhAbwh/UDuVx+jF1wh3PnDRdivKBdILVeQ==
+cozy-realtime@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.2.3.tgz#5fa6575e1e599d32bc8a71bec8eaaa25a4bc8e8e"
+  integrity sha512-YuBo7XEtX0POJn9CJ7OYemyGmDB9wq5aHS5Z5A4aDy3mOikrVzK9Sdp0koMU0SXHcIs0QWgbty7CTwUlTpojxQ==
+  dependencies:
+    minilog "https://github.com/cozy/minilog.git#master"
+
+cozy-stack-client@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-9.2.0.tgz#3d6a9af9e42f6f2d8fad7fe57e83713a3bcafc77"
+  integrity sha512-ivMjA+EtV7lu6lKzuOIiS00XcTVL6WRbycSmfO7SJrAU12kWp54rlKDS9rMFA2NjCEShjTVdu0intkxYbuimsw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -9853,7 +9860,7 @@ methods@~1.1.2:
   version "0.5.1"
   resolved "https://github.com/cozy/michelangelo.git#a3065fa84a814a35bbba903749b6e26f2b9d4e4d"
 
-microee@^0.0.6:
+microee@0.0.6, microee@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/microee/-/microee-0.0.6.tgz#a12bdb0103681e8b126a9b071eba4c467c78fffe"
   integrity sha1-oSvbAQNoHosSapsHHrpMRnx4//4=
@@ -10001,6 +10008,12 @@ mini-html-webpack-plugin@^0.2.3:
   integrity sha512-wfkLf+CmyDg++K1S0QdAvUvS29DfVHe9SQ63syX8aX375mInzC5uwHxb/1+3exiiv84xnPrf6zsOnReRe15rjg==
   dependencies:
     webpack-sources "^1.1.0"
+
+"minilog@https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This adds realtime to the contacts list. There are two features:

* If the contacts app is not installed, then in the ContactsListModal, the « add a contact » button links to the contacts' store install page. When the app has been installed, we update the button so it links to the contact page instead of the store
* When the user clicks on « add a contact », and creates or updates a contact in the contacts app, we update the contacts list, so when he comes back to the original app, he sees the new or updated contacts.

There is a thing that bothers me, it's that by adding cozy-realtime and using it in the ContactsListModal, which is exported by the main entry point (index.js), it will require apps to install cozy-realtime. We already have the problem with cozy-client sometimes. I don't know how to fix this without removing the export of this component in the main entry point. Do you have any ideas?

Also, snapshots are failing and I don't really know why :thinking: 

Edit : the app can use a cozy-realtime plugin in its client, see https://mattermost.cozycloud.cc/cozycloud/pl/41c6hhyhob8wdpybpri8k1416r