### PR TITLE
fix(MuiCozyTheme): Prevent overflowing OutlinedInput with adorn…

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -277,6 +277,7 @@ invertedTheme.overrides = {
   ...normalTheme.overrides,
   MuiOutlinedInput: {
     root: {
+      boxSizing: 'border-box',
       '&$focused $notchedOutline': {
         borderColor: invertedTheme.palette.text.primary,
         borderWidth: '0.0625rem'


### PR DESCRIPTION
When an adornment is added to an OutlinedInput, a padding is added to
it. Making an OutlinedInput with fullwidth + an adorment overflowing
from its container