### PR TITLE
Lenient prop types for Radio

### DIFF
--- a/react/Radio/index.jsx
+++ b/react/Radio/index.jsx
@@ -40,11 +40,11 @@ const Radio = props => {
 
 Radio.propTypes = {
   className: PropTypes.string,
-  value: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  name: PropTypes.string,
   error: PropTypes.bool,
   disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired
+  label: PropTypes.string
 }
 
 Radio.defaultProps = {


### PR DESCRIPTION
When used as a pure UI component and not in a form,
name, value and label are not required.