### PR TITLE
feat(ContactsListModal): Redirect to contacts app root page on…

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "commitlint": "7.6.1",
     "commitlint-config-cozy": "0.3.27",
     "copyfiles": "2.1.1",
-    "cozy-client": "9.2.0",
+    "cozy-client": "9.4.0",
     "cozy-device-helper": "1.7.5",
     "cozy-doctypes": "^1.69.0",
     "css-loader": "0.28.11",

--- a/react/ContactsListModal/AddContactButton.jsx
+++ b/react/ContactsListModal/AddContactButton.jsx
@@ -17,7 +17,7 @@ const DumbAddContactButton = props => {
   if (installedApp) {
     href = models.applications.getUrl(installedApp)
   } else {
-    href = models.applications.getStoreInstallationURL(apps.data, wantedApp)
+    href = models.applications.getStoreURL(apps.data, wantedApp)
   }
 
   useRealtime(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,10 +4401,10 @@ cosmiconfig@^5.0.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-client@9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.2.0.tgz#277f8fb36201f3767f7e116b112b8f416c38d43f"
-  integrity sha512-o2EVDrWlkqNdkwKbs5iaFSUhfoBY3sqQBdQgg5uE/PXxMo24Ee1jqiqTHEz927MRwHLjoHMQQaie/DahWscuiw==
+cozy-client@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.4.0.tgz#c57a05716a6d4184743fe2031e38a691fb85f93e"
+  integrity sha512-5YK7OhKH/hsHRYMWVfP4S8wzJk9D7VsQZb1gNUWbMtZnxKZ0lP6mIuyBL4iYg4olqmr4lj77k9utBzW1oZ8bag==
   dependencies:
     cozy-device-helper "^1.7.3"
     cozy-stack-client "^9.2.0"


### PR DESCRIPTION
The goal is to not have the permissions modal opened when the user is
redirected on the store to install the contacts app. With the
permissions modal opened, he don't have the context that he is going to
install the contacts app.