### PR TITLE
Fix/app linker don't crash

### DIFF
--- a/react/AppLinker/__snapshots__/index.spec.jsx.snap
+++ b/react/AppLinker/__snapshots__/index.spec.jsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app icon should not crash if no href 1`] = `
+<div>
+  <a
+    onClick={[Function]}
+  >
+    Open 
+    Cozy Drive
+  </a>
+</div>
+`;
+
 exports[`app icon should render correctly 1`] = `
 <div>
   <a

--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -81,7 +81,7 @@ export class AppLinker extends React.Component {
           href = generateUniversalLink({ slug, nativePath, fallbackUrl: href })
         } catch (err) {
           console.error(err)
-          href = ''
+          href = '#'
         }
       }
     }

--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -75,7 +75,14 @@ export class AppLinker extends React.Component {
       if (isAndroid()) {
         onClick = AppLinker.openNativeFromWeb.bind(this, props)
       } else {
-        href = generateUniversalLink({ slug, nativePath, fallbackUrl: href })
+        //Since generateUniversalLink can rise an error, let's catch it to not crash
+        //all the page.
+        try {
+          href = generateUniversalLink({ slug, nativePath, fallbackUrl: href })
+        } catch (err) {
+          console.error(err)
+          href = ''
+        }
       }
     }
 

--- a/react/AppLinker/index.spec.jsx
+++ b/react/AppLinker/index.spec.jsx
@@ -131,4 +131,21 @@ describe('app icon', () => {
     root.find('a').simulate('click')
     expect(appSwitchMock).toHaveBeenCalled()
   })
+
+  it('should not crash if no href', () => {
+    isMobileApp.mockReturnValue(true)
+    spyConsoleError.mockImplementation(() => {})
+    const root = shallow(
+      <AppLinker onAppSwitch={appSwitchMock} slug={app.slug}>
+        {({ onClick, href, name }) => (
+          <div>
+            <a href={href} onClick={onClick}>
+              Open {name}
+            </a>
+          </div>
+        )}
+      </AppLinker>
+    )
+    expect(root.getElement()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
We encountered the issue on Notes. If you mount an `<AppLinker>` with an empty `href`, `generateUniversalLink` throws an error but we don't catch it and we finished by having a blank screen. 

This PR fix the behavior by catching the error and logging it with an console.error(). It's better to have a link that doesn't work instead of the all app. 