### PR TITLE
feat: Allows undefined values in useEventListener

### DIFF
--- a/react/hooks/useEventListener.js
+++ b/react/hooks/useEventListener.js
@@ -2,12 +2,13 @@ import { useEffect } from 'react'
 
 const useEventListener = (element, event, cb) => {
   useEffect(() => {
-    element.addEventListener(event, cb)
+    if (element && event && cb) {
+      element.addEventListener(event, cb)
 
-    return () => {
-      element.removeEventListener(event, cb)
+      return () => {
+        element.removeEventListener(event, cb)
+      }
     }
   }, [event, cb, element])
 }
-
 export default useEventListener

--- a/react/hooks/useEventListener.spec.js
+++ b/react/hooks/useEventListener.spec.js
@@ -6,15 +6,44 @@ const triggerEvent = (element, eventType) => {
   element.dispatchEvent(event)
 }
 
-it('should subscribe to the given event on the given element', async () => {
-  const cb = jest.fn()
-  renderHook(() => useEventListener(document, 'click', cb))
-  triggerEvent(document, 'click')
+describe('useEventListener', () => {
+  it('should subscribe to the given event on the given element', async () => {
+    const cb = jest.fn()
+    renderHook(() => useEventListener(document, 'click', cb))
+    triggerEvent(document, 'click')
 
-  expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledTimes(1)
 
-  await cleanup()
+    await cleanup()
 
-  triggerEvent(document, 'click')
-  expect(cb).toHaveBeenCalledTimes(1)
+    triggerEvent(document, 'click')
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not subscribe for an undefined element', async () => {
+    const cb = jest.fn()
+    const { result } = renderHook(() =>
+      useEventListener(undefined, 'click', cb)
+    )
+    expect(result.error).not.toBeDefined()
+
+    await cleanup()
+  })
+
+  it('should not subscribe for an undefined event', async () => {
+    const cb = jest.fn()
+    const { result } = renderHook(() => useEventListener(window, undefined, cb))
+    expect(result.error).not.toBeDefined()
+
+    await cleanup()
+  })
+
+  it('should not subscribe for an undefined callback', async () => {
+    const { result } = renderHook(() =>
+      useEventListener(window, 'click', undefined)
+    )
+    expect(result.error).not.toBeDefined()
+
+    await cleanup()
+  })
 })


### PR DESCRIPTION
To attach an event to an element, we often use a ref
to this element. The ref begins with a null value
which breaks useEventListener.

This change allows to keep the call to the hook
whatever the argument are, and only attach an
event if we have something to work with.