### PR TITLE
test(useEventListener): Remove cleanups

### DIFF
--- a/react/hooks/useEventListener.spec.js
+++ b/react/hooks/useEventListener.spec.js
@@ -1,5 +1,5 @@
 import useEventListener from './useEventListener'
-import { renderHook, cleanup } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react-hooks'
 
 const triggerEvent = (element, eventType) => {
   const event = new Event(eventType)
@@ -9,12 +9,14 @@ const triggerEvent = (element, eventType) => {
 describe('useEventListener', () => {
   it('should subscribe to the given event on the given element', async () => {
     const cb = jest.fn()
-    renderHook(() => useEventListener(document, 'click', cb))
-    triggerEvent(document, 'click')
+    const { unmount } = renderHook(() =>
+      useEventListener(document, 'click', cb)
+    )
 
+    triggerEvent(document, 'click')
     expect(cb).toHaveBeenCalledTimes(1)
 
-    await cleanup()
+    unmount()
 
     triggerEvent(document, 'click')
     expect(cb).toHaveBeenCalledTimes(1)
@@ -26,16 +28,12 @@ describe('useEventListener', () => {
       useEventListener(undefined, 'click', cb)
     )
     expect(result.error).not.toBeDefined()
-
-    await cleanup()
   })
 
   it('should not subscribe for an undefined event', async () => {
     const cb = jest.fn()
     const { result } = renderHook(() => useEventListener(window, undefined, cb))
     expect(result.error).not.toBeDefined()
-
-    await cleanup()
   })
 
   it('should not subscribe for an undefined callback', async () => {
@@ -43,7 +41,5 @@ describe('useEventListener', () => {
       useEventListener(window, 'click', undefined)
     )
     expect(result.error).not.toBeDefined()
-
-    await cleanup()
   })
 })


### PR DESCRIPTION
In react-hooks-testing-library, cleanup is done automatically if the
test framework (jest in our case) exposes an `afterEach` function. For
the only case in which we need to manually unmount, we use the `unmount`
function returned by `renderHook`.