### PR TITLE
fix(PasswordInput): The getStrength function was not pure

### DIFF
--- a/react/Labs/PasswordInput/helpers.js
+++ b/react/Labs/PasswordInput/helpers.js
@@ -1,12 +1,12 @@
 const charsets = [
   // upper
-  { regexp: /[A-Z]/g, size: 26 },
+  { regexp: /[A-Z]/, size: 26 },
   // lower
-  { regexp: /[a-z]/g, size: 26 },
+  { regexp: /[a-z]/, size: 26 },
   // digit
-  { regexp: /[0-9]/g, size: 10 },
+  { regexp: /[0-9]/, size: 10 },
   // special
-  { regexp: /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/g, size: 30 }
+  { regexp: /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/, size: 30 }
 ]
 
 /*

--- a/react/Labs/PasswordInput/helpers.spec.js
+++ b/react/Labs/PasswordInput/helpers.spec.js
@@ -16,4 +16,12 @@ describe('getStrength', () => {
 
     expect(getStrength('').percentage).toBe(0)
   })
+
+  it('should return the same strength when called multiple times with the same password', () => {
+    const password = 'this1s@veRYCompl3xp4ssw0rd!'
+    const strength1 = getStrength(password)
+    const strength2 = getStrength(password)
+
+    expect(strength1).toEqual(strength2)
+  })
 })


### PR DESCRIPTION
Due to how RegExp.test works with RegExp with the `g` flag, the
getStrength function returned a different result when called multiple
times with the same inputs.
See https://frama.link/d5dgGURD for more infos.

This problem appeared when we extracted the regexp from the function.
Before, they were recreated on each call, which was more expensive, but
not buggy. To fix the problem without putting the regexp in the function
again, we can just remove the `g` flags that are useless here.