### PR TITLE
feat(Field): Label prop accepts a node

### DIFF
--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -256,7 +256,7 @@ Field.propTypes = {
   labelProps: PropTypes.object,
   fieldProps: PropTypes.object,
   fullwidth: PropTypes.bool,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   id: PropTypes.string,
   name: PropTypes.string,
   type: PropTypes.oneOf(allowedTypes),


### PR DESCRIPTION
By requiring the label prop to be a string, we get a warning when we do

```jsx
<Field label={<span>Some label</span>} />
```

We can have the need to pass a node for a lot of reasons, but the one we
have now is that we need to obfuscate the label in cozy-harvest-lib. The
according PR is coming, but in brief we need to put some fake visually
hidden content in the label so password manager extensions don't target
some inputs. It can also be useful for styling purpose, for example.