### PR TITLE
fix: Should not fail when import doesnt have imported attribute

### DIFF
--- a/codemods/utils.js
+++ b/codemods/utils.js
@@ -78,7 +78,7 @@ module.exports = function(j) {
   }
 
   const isSameSpec = (eSpec, spec) => {
-    return eSpec.imported.name == spec.imported.name
+    return eSpec.imported && eSpec.imported.name == spec.imported.name
   }
 
   const mergeSpecifiersToImport = (importDeclaration, specifiers) => {


### PR DESCRIPTION
When only the default import is imported, there is no imported property
in the default specifier.