### PR TITLE
fix(Infos): Add display name to migration component

### DIFF
--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -51,7 +51,7 @@ Infos.defaultProps = {
 }
 
 const logInfosDepecrated = createDepreciationLogger()
-const InfosMigration = React.memo(props => {
+const InfosMigration = React.memo(function InfosMigration(props) {
   const isUsingDeprecatedProps =
     props.actionButton ||
     props.icon ||


### PR DESCRIPTION
The InfosMigration component is an anonymous function wrapped in
InfosMigration. Thus it didn't have any name and it resulted in enzyme
rendering it with the name `Unknown` in tests.