### PR TITLE
fix(Modal): Use overflow auto

### DIFF
--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -49,7 +49,7 @@ $modal-wrapper
     box-sizing border-box
     width 100vw
     height 100%
-    overflow-y scroll
+    overflow-y auto
     padding large-margin
 
     +small-screen()


### PR DESCRIPTION
The modal wrapper was using `overflow-y: scroll`. The problem is that
the `scroll` value makes scrollbar appear even if it's disabled. Using
the `auto` value fixes it.

Before 
![image](https://user-images.githubusercontent.com/1606068/72526882-b2286480-3867-11ea-856b-a8aec9455230.png)

After
![image](https://user-images.githubusercontent.com/1606068/72526900-bbb1cc80-3867-11ea-8db6-bcbefae20bb7.png)
