### PR TITLE
feat: Adds useConfirmExit React hook

### DIFF
--- a/react/hooks/useConfirmExit.js
+++ b/react/hooks/useConfirmExit.js
@@ -1,0 +1,30 @@
+import { useCallback, useRef } from 'react'
+import useEventListener from './useEventListener'
+
+/**
+ * When provided a message, will warn the user before exiting the page
+ *
+ * Warning: The confirmation message is required but will usually
+ * be replaced by an internal message by the browser, and never displayed.
+ *
+ * A falsy error message would deactivate to confirmation popup.
+ *
+ * @param {string|null} message - Confirmation message
+ * @param {function} callback - will be executed before returning
+ */
+export default function useConfirmExit(message, callback) {
+  // Using a ref in order to have an event listener that does not
+  // need to be deregistered, recreated and registered again at each
+  // message or callback change. If not, the lag introduced by the
+  // useEffect inside useEventListener may create wrong behaviours
+  // for fast changing calls to useConfirmExit.
+  const state = useRef()
+  state.current = { message, callback }
+  const beforeunload = useCallback(event => {
+    state.current.callback && state.current.callback()
+    const returnValue = state.current.message || null
+    if (returnValue) event.returnValue = returnValue
+    return returnValue
+  }, [])
+  useEventListener(window, 'beforeunload', beforeunload)
+}

--- a/react/hooks/useConfirmExit.spec.js
+++ b/react/hooks/useConfirmExit.spec.js
@@ -1,0 +1,40 @@
+import useConfirmExit from './useConfirmExit'
+import { renderHook } from '@testing-library/react-hooks'
+
+const triggerBeforeUnload = () => {
+  const event = new Event('beforeunload')
+  return window.dispatchEvent(event)
+}
+
+describe('useConfirmExit', () => {
+  it('should subscribe to window.onbeforeunload at mount', async () => {
+    const cb = jest.fn()
+    renderHook(() => useConfirmExit('message', cb))
+
+    triggerBeforeUnload()
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('should unsubscribe to window.onbeforeunload at dismount', async () => {
+    const cb = jest.fn()
+    const { unmount } = renderHook(() => useConfirmExit('message', cb))
+    unmount()
+
+    triggerBeforeUnload()
+    expect(cb).toHaveBeenCalledTimes(0)
+  })
+
+  it('should allow a null message', async () => {
+    const cb = jest.fn()
+    renderHook(() => useConfirmExit(null, cb))
+
+    triggerBeforeUnload()
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('should allow a null callback', async () => {
+    renderHook(() => useConfirmExit('message'))
+
+    triggerBeforeUnload()
+  })
+})


### PR DESCRIPTION
This hook was needed for cozy-notes. It allows to hook the onBeforeUnloadevent to warn about unsaved changes.