### PR TITLE
Merge pull request #1361 from cozy/page-par-section

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -3,6 +3,7 @@ const webpackMerge = require('webpack-merge')
 
 module.exports = {
   title: 'Cozy UI React components',
+  pagePerSection: true,
   sections: [
     {
       name: 'Bar',


### PR DESCRIPTION
Since we start to have a lot of examples, performance starts
to degrade when loading the styleguidist. Having only one page
per section could help.

This is done to be able to add more complex examples ("organisms" in atomic design parlance) that would
showcase for example how we want to render a settings page
(discussed with @joel-costa).