### PR TITLE
feat(I18n): Do not copy proptypes from wrapped component

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -97,10 +97,6 @@ export const translate = () => WrappedComponent => {
   }
   Wrapper.displayName = `withI18n(${WrappedComponent.displayName ||
     WrappedComponent.name})`
-  Wrapper.propTypes = {
-    //!TODO Remove this check after fixing https://github.com/cozy/cozy-drive/issues/1848
-    ...(WrappedComponent ? WrappedComponent.propTypes : undefined)
-  }
   return Wrapper
 }
 


### PR DESCRIPTION
It is unnecessary since proptypes will be checked one level below, and
it can actually lead to false positives, for example when a component
set the t PropType : since the translate()-wrapped component does not
receive the t prop from above, it triggers a warning when there is no
real problem (since t is provided to the component below by translate()