### PR TITLE
fix: Make getCssVariableValue return mocked value in test environment

### DIFF
--- a/react/utils/color.js
+++ b/react/utils/color.js
@@ -1,8 +1,15 @@
 import memoize from 'lodash/memoize'
 
-export const getCssVariableValue = memoize(variableName =>
+const mockedGetCssVariableValue = () => '#fff'
+
+const realGetCssVariableValue = memoize(variableName =>
   window
     .getComputedStyle(document.body)
     .getPropertyValue(`--${variableName}`)
     .trim()
 )
+
+export const getCssVariableValue =
+  process.env.NODE_ENV === 'test'
+    ? mockedGetCssVariableValue
+    : realGetCssVariableValue

--- a/react/utils/color.spec.js
+++ b/react/utils/color.spec.js
@@ -1,0 +1,8 @@
+import { getCssVariableValue } from './color'
+
+describe('getCssVariableValue', () => {
+  it('should return a mocked value in test env', () => {
+    expect(getCssVariableValue('dodgerBlue')).toBe('#fff')
+    expect(getCssVariableValue('whatever')).toBe('#fff')
+  })
+})


### PR DESCRIPTION
This fixes #1214