### PR TITLE
Feat/confirm exit labels

### DIFF
--- a/react/hooks/useConfirmExit/index.js
+++ b/react/hooks/useConfirmExit/index.js
@@ -22,8 +22,8 @@ function ConfirmModal({
   message,
   onConfirm,
   onCancel,
-  cancel,
-  confirm
+  cancelLabel,
+  confirmLabel
 }) {
   return (
     <Modal
@@ -31,20 +31,23 @@ function ConfirmModal({
       mobileFullscreen={false}
       primaryAction={onConfirm}
       primaryType="danger"
-      primaryText={confirm || t('useConfirmExit.leave')}
+      primaryText={confirmLabel || t('useConfirmExit.leave')}
+      dismissAction={onCancel}
       secondaryAction={onCancel}
       secondaryType="secondary"
-      secondaryText={cancel || t('useConfirmExit.back')}
+      secondaryText={cancelLabel || t('useConfirmExit.back')}
       description={message || t('useConfirmExit.message')}
       title={title || t('useConfirmExit.title')}
     />
   )
 }
-ConfirmModal.PropTypes = {
+ConfirmModal.propTypes = {
   message: PropTypes.string,
   title: PropTypes.string,
   onConfirm: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired
+  onCancel: PropTypes.func.isRequired,
+  cancelLabel: PropTypes.string,
+  confirmLabel: PropTypes.string
 }
 const dictRequire = { en, fr }
 const LocalizedConfirmModal = withLocales(dictRequire)(ConfirmModal)
@@ -100,8 +103,8 @@ export default function useConfirmExit({
   onLeave,
   message,
   title,
-  leave,
-  cancel
+  leaveLabel,
+  cancelLabel
 }) {
   // `onbeforeunload` event on the browser:
   // Using a ref in order to have an event listener that does not
@@ -152,8 +155,8 @@ export default function useConfirmExit({
       title={title}
       onCancel={onCloseModalRequest}
       onConfirm={onConfirm}
-      confirm={leave}
-      cancel={cancel}
+      confirmLabel={leaveLabel}
+      cancelLabel={cancelLabel}
     />
   )
   return {

--- a/react/hooks/useConfirmExit/index.js
+++ b/react/hooks/useConfirmExit/index.js
@@ -16,17 +16,25 @@ import fr from './locales/fr.json'
  * @param {function} onConfirm - will be executed on confirmation
  * @param {function} onCancel - will be executed on cancelation
  */
-function ConfirmModal({ t, title, message, onConfirm, onCancel }) {
+function ConfirmModal({
+  t,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  cancel,
+  confirm
+}) {
   return (
     <Modal
       closable={false}
       mobileFullscreen={false}
       primaryAction={onConfirm}
-      primaryType="regular"
-      primaryText={t('useConfirmExit.leave')}
+      primaryType="danger"
+      primaryText={confirm || t('useConfirmExit.leave')}
       secondaryAction={onCancel}
       secondaryType="secondary"
-      secondaryText={t('useConfirmExit.back')}
+      secondaryText={cancel || t('useConfirmExit.back')}
       description={message || t('useConfirmExit.message')}
       title={title || t('useConfirmExit.title')}
     />
@@ -91,7 +99,9 @@ export default function useConfirmExit({
   activate = true,
   onLeave,
   message,
-  title
+  title,
+  leave,
+  cancel
 }) {
   // `onbeforeunload` event on the browser:
   // Using a ref in order to have an event listener that does not
@@ -142,6 +152,8 @@ export default function useConfirmExit({
       title={title}
       onCancel={onCloseModalRequest}
       onConfirm={onConfirm}
+      confirm={leave}
+      cancel={cancel}
     />
   )
   return {

--- a/react/hooks/useConfirmExit/locales/en.json
+++ b/react/hooks/useConfirmExit/locales/en.json
@@ -1,8 +1,8 @@
 {
   "useConfirmExit": {
-    "back": "Back",
-    "leave": "Leave",
-    "title": "Do you want to leave?",
-    "message": "Some changes are not saved yet. Do you really want to leave and lose these changes?"
+    "back": "Cancel",
+    "leave": "Leave without saving",
+    "title": "Abandon your changes?",
+    "message": "Some changes may not be saved yet. Do you really want to leave and lose these changes?"
   }
 }

--- a/react/hooks/useConfirmExit/locales/fr.json
+++ b/react/hooks/useConfirmExit/locales/fr.json
@@ -2,7 +2,7 @@
   "useConfirmExit": {
     "back": "Retour",
     "leave": "Quitter",
-    "title": "Voulez-vous quitter ?",
-    "message": "Des modifications n'ont pas encore pu être enregistrées. Voulez-vous vraiment quitter et perdre ces modifications ?"
+    "title": "Abandonner les modifications ?",
+    "message": "Des modifications n'ont pas encore pu être enregistrées. Voulez-vous vraiment quitter et perdre ces modifications ?"
   }
 }


### PR DESCRIPTION
Change to the exit confirmation modal:
-  Translations
- The confirmation button is now a "danger"
