### PR TITLE
fix: InfosCarrousel handles removing children

### DIFF
--- a/react/InfosCarrousel/index.jsx
+++ b/react/InfosCarrousel/index.jsx
@@ -1,15 +1,28 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import clamp from 'lodash/clamp'
 import SwipeableViews from 'react-swipeable-views'
 
 import styles from './styles.styl'
 import Icon from '../Icon'
 import IconButton from '../IconButton'
 
+const useClampedValue = (initialValue, min, max) => {
+  const [value, setValue] = useState(initialValue)
+
+  const setClampedValue = newVal => setValue(clamp(newVal, min, max))
+
+  useEffect(() => {
+    setClampedValue(value)
+  }, [min, max])
+
+  return [clamp(value, min, max), setClampedValue]
+}
+
 const InfosCarrousel = ({ children, theme, className, swipeableProps }) => {
   const count = React.Children.count(children)
-  const [index, setIndex] = useState(0)
+  const [index, setIndex] = useClampedValue(0, 0, count - 1)
   const goToNextInfos = useCallback(() => setIndex(index + 1), [index])
   const goToPreviousInfos = useCallback(() => setIndex(index - 1), [index])
   const hasPreviousInfos = index === 0

--- a/react/InfosCarrousel/index.spec.jsx
+++ b/react/InfosCarrousel/index.spec.jsx
@@ -10,28 +10,21 @@ import SwipeableViews from 'react-swipeable-views'
 // This is necessary for tests to be predictable
 const swipeableProps = { disableLazyLoading: true }
 
-const Example = () => (
+const Example = ({ numberOfChildren = 2 }) => (
   <div className="u-stack-m">
     <InfosCarrousel theme="danger" swipeableProps={swipeableProps}>
-      <Infos
-        description={
-          <>
-            <SubTitle>News 1</SubTitle>
-            <Text>Breaking news 1</Text>
-          </>
-        }
-        action={<Button theme="secondary" label="A CTA button" />}
-      />
-      <Infos
-        description={
-          <>
-            <SubTitle>News 2</SubTitle>
-            <Text>Breaking news 2</Text>
-          </>
-        }
-        theme="primary"
-        action={<Button theme="secondary" label="A CTA button" />}
-      />
+      {[...new Array(numberOfChildren)].map((child, index) => (
+        <Infos
+          key={index}
+          description={
+            <>
+              <SubTitle>News {index}</SubTitle>
+              <Text>Breaking news {index}</Text>
+            </>
+          }
+          action={<Button theme="secondary" label="A CTA button" />}
+        />
+      ))}
     </InfosCarrousel>
   </div>
 )
@@ -65,5 +58,16 @@ describe('InfosCarrousel', () => {
     expect(getArrowsDisabledProps(root)).toEqual([false, true])
     simulateSwipeToSlideIndex(root, 0)
     expect(getArrowsDisabledProps(root)).toEqual([true, false])
+  })
+
+  it('should change index when a child is removed', () => {
+    const root = mount(<Example numberOfChildren={3} />)
+    expect(root.find(SwipeableViews).prop('index')).toEqual(0)
+    simulateSwipeToSlideIndex(root, 2)
+    expect(root.find(SwipeableViews).prop('index')).toEqual(2)
+    root.setProps({ numberOfChildren: 2 })
+    root.update()
+    expect(root.find(Infos).length).toBe(2)
+    expect(root.find(SwipeableViews).prop('index')).toEqual(1)
   })
 })


### PR DESCRIPTION
Fixes a bug with InfosCarrousel: when we navigate to the last slide, and remove a child, the internal `index` points to a slide that no longer exists. We now force the index back one slide when that happens.

This component can still "break" if it ends up with no children at all, but I don't think that the component itself should guard against that..?