### PR TITLE
feat: Optimize the output of the CSS

### DIFF
--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -125,24 +125,26 @@ global(selector, placeholder, type = extend)
                 {placeholder}() // @stylint ignore
 
 cssModulesUtils(props, breakpoints)
-    for kProp, vProp in props
-        for kBp, vBp in breakpoints
-            if vBp == ''
+    for kBp, vBp in breakpoints
+        if vBp == ''
+            for kProp, vProp in props
                 :global(.u-{vProp})
                     {kProp}()
-            else
-                @media (max-width: rem(lookup('BP-'+kBp)))
+        else
+            @media (max-width: rem(lookup('BP-'+kBp)))
+                for kProp, vProp in props
                     :global(.u-{vProp}-{vBp})
                         {kProp}()
 
 nativeUtils(props, breakpoints)
-    for kProp, vProp in props
-        for kBp, vBp in breakpoints
-            if vBp == ''
+    for kBp, vBp in breakpoints
+        if vBp == ''
+            for kProp, vProp in props
                 .u-{vProp}
                     {kProp}()
-            else
-                @media (max-width: rem(lookup('BP-'+kBp)))
+        else
+            @media (max-width: rem(lookup('BP-'+kBp)))
+                for kProp, vProp in props
                     .u-{vProp}-{vBp}
                         {kProp}()
 


### PR DESCRIPTION
The minified CSS is quite heavy, and a large part of the wright is due to media queries. I think we can do a lot better. The first optimization is to regroup media queries from the cssModulesUtils and nativeUtils mixins. Before this commit, cozy-ui.min.css took 129kb, and after, it tooks now 123kb.
