### PR TITLE
test: Take individual screenshots for the examples

### DIFF
--- a/react/MuiCozyTheme/Menus/index.js
+++ b/react/MuiCozyTheme/Menus/index.js
@@ -27,7 +27,7 @@ const styles = {
   }
 }
 
-class Menu extends Component {
+class MuiMenu extends Component {
   state = { open: false, anchorEl: null }
 
   toggle = event => {
@@ -105,13 +105,13 @@ class Menu extends Component {
   }
 }
 
-Menu.defaultProps = {
+MuiMenu.defaultProps = {
   disabled: false,
   component: null,
   placement: 'bottom-end'
 }
 
-Menu.propTypes = {
+MuiMenu.propTypes = {
   /** Disables the menu */
   disabled: PropTypes.bool,
   /** Specifies a custom component for the opener */
@@ -120,7 +120,7 @@ Menu.propTypes = {
   placement: PropTypes.oneOf(['bottom-start', 'bottom-end'])
 }
 
-Menu.MenuButton = MenuButton
-export default withStyles(styles, { name: 'MuiMenu' })(Menu)
+MuiMenu.MenuButton = MenuButton
+export default withStyles(styles, { name: 'MuiMenu' })(MuiMenu)
 
 export { MenuButton }

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -65,7 +65,7 @@ const fetchAllComponents = async (page, styleguideIndexURL) => {
   })
 
   console.log('Extracting links')
-  //We want to take screenshot for individual exemple, so we : 
+  //We want to take screenshot for individual example, so we : 
   //-extract categories (link from the side menu with no ?id=)
   //- go to category's page
   //- look for `.rsg--controls-40 a` which is the open isolated for exemples

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -68,7 +68,7 @@ const fetchAllComponents = async (page, styleguideIndexURL) => {
   //We want to take screenshot for individual example, so we : 
   //-extract categories (link from the side menu with no ?id=)
   //- go to category's page
-  //- look for `.rsg--controls-40 a` which is the open isolated for exemples
+  //- look for `.rsg--controls-40 a` which is the open isolated for examples
   //- look for its closest data-testid to get the name
   const categoriesName = await page.evaluate(() => {
     return Array.from(document.querySelectorAll('.rsg--sidebar-4 a'))

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -65,11 +65,11 @@ const fetchAllComponents = async (page, styleguideIndexURL) => {
   })
 
   console.log('Extracting links')
-  //We want to take screenshot for individual example, so we : 
-  //-extract categories (link from the side menu with no ?id=)
-  //- go to category's page
-  //- look for `.rsg--controls-40 a` which is the open isolated for examples
-  //- look for its closest data-testid to get the name
+  // We want to take screenshot for individual example, so we :
+  // - extract categories (link from the side menu with no ?id=)
+  // - go to category's page
+  // - look for `.rsg--controls-40 a` which is the open isolated for examples
+  // - look for its closest data-testid to get the name
   const categoriesName = await page.evaluate(() => {
     return Array.from(document.querySelectorAll('.rsg--sidebar-4 a'))
       .filter(v => !v.href.includes('?id='))
@@ -82,23 +82,22 @@ const fetchAllComponents = async (page, styleguideIndexURL) => {
     })),
     x => x.name
   )
-  const allLinks = [];
-  for (cate of sortedCategoriesNames){
-      console.log('Go to category page', cate.link)
-      await page.goto(cate.link, { waitUntil: 'load', timeout: 0 })
-      await sleep(100)
-       
-        const links = await page.evaluate(() => {
-          
-         return Array.from(document.querySelectorAll('.rsg--controls-40 a'))
-            .map(x => {
-              return {
-                name: x.closest("div[data-testid]").dataset.testid,
-                link: x.href
-              }
-            })
-        })
-        allLinks.push(links)      
+  const allLinks = []
+  for (const cate of sortedCategoriesNames) {
+    await page.goto(cate.link, { waitUntil: 'load', timeout: 0 })
+    await sleep(100)
+
+    const links = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('.rsg--controls-40 a')).map(
+        x => {
+          return {
+            name: x.closest('div[data-testid]').dataset.testid,
+            link: x.href
+          }
+        }
+      )
+    })
+    allLinks.push(links)
   }
   return flattenDeep(allLinks)
 }
@@ -215,10 +214,7 @@ const main = async () => {
     args.styleguideDir,
     '/index.html'
   )}`
-  const components = (await fetchAllComponents(
-    page,
-    styleguideIndexURL
-  ))
+  const components = await fetchAllComponents(page, styleguideIndexURL)
   console.log('Screenshotting components')
   for (const component of components) {
     await screenshotComponent(page, {

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -13,6 +13,7 @@ try {
 const path = require('path')
 const fs = require('fs')
 const sortBy = require('lodash/sortBy')
+const flattenDeep = require('lodash/flattenDeep')
 const { ArgumentParser } = require('argparse')
 
 const emptyDirectory = directory => {
@@ -64,22 +65,42 @@ const fetchAllComponents = async (page, styleguideIndexURL) => {
   })
 
   console.log('Extracting links')
-  //Categories have link like : #/Labs. Components' link: Labs?id=component
-  //So we filter to not have the categories, and get the component's name from
-  //the text attribute of the a. Like that we can create the right url
-  const names = await page.evaluate(() => {
+  //We want to take screenshot for individual exemple, so we : 
+  //-extract categories (link from the side menu with no ?id=)
+  //- go to category's page
+  //- look for `.rsg--controls-40 a` which is the open isolated for exemples
+  //- look for its closest data-testid to get the name
+  const categoriesName = await page.evaluate(() => {
     return Array.from(document.querySelectorAll('.rsg--sidebar-4 a'))
-      .filter(v => v.href.includes('?id='))
+      .filter(v => !v.href.includes('?id='))
       .map(x => x.text)
   })
-
-  return sortBy(
-    names.map(name => ({
-      link: styleguideIndexURL + '#!/' + name,
-      name
+  const sortedCategoriesNames = sortBy(
+    categoriesName.map(catName => ({
+      link: styleguideIndexURL + '#/' + catName,
+      name: catName
     })),
     x => x.name
   )
+  const allLinks = [];
+  for (cate of sortedCategoriesNames){
+      console.log('Go to category page', cate.link)
+      await page.goto(cate.link, { waitUntil: 'load', timeout: 0 })
+      await sleep(100)
+       
+        const links = await page.evaluate(() => {
+          
+         return Array.from(document.querySelectorAll('.rsg--controls-40 a'))
+            .map(x => {
+              return {
+                name: x.closest("div[data-testid]").dataset.testid,
+                link: x.href
+              }
+            })
+        })
+        allLinks.push(links)      
+  }
+  return flattenDeep(allLinks)
 }
 
 /**
@@ -197,10 +218,7 @@ const main = async () => {
   const components = (await fetchAllComponents(
     page,
     styleguideIndexURL
-  )).filter(
-    args.component ? component => component.name === args.component : () => true
-  )
-
+  ))
   console.log('Screenshotting components')
   for (const component of components) {
     await screenshotComponent(page, {


### PR DESCRIPTION
Before this PR we were taking screenshot for a component page. But this page could contain several examples and sometimes it doesn't work well since examples can override each other. For instance, if we had a page with several modals, only the latest will appear on the screenshot.

This PR fix this behavior by creating a screenshot for every example we have in the styleguidist 