### PR TITLE
feat: Add Variant to IconStack

### DIFF
--- a/react/IconStack/Readme.md
+++ b/react/IconStack/Readme.md
@@ -1,6 +1,6 @@
 ### IconStack
 
-A component to put something in the background and center an
+A component to put something in the background and align (default center) an
 other component on the foreground
 
 ```
@@ -10,4 +10,60 @@ import Icon from 'cozy-ui/transpiled/react/Icon';
   background={<Icon icon="file-duotone" color="blue"  size={32} />}
   foreground={<Icon icon="bank" color="red" height={16} width={16} />}
 />
+```
+
+### IconStack with bottom right aligment
+
+```
+import IconStack from 'cozy-ui/transpiled/react/IconStack';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Circle from 'cozy-ui/transpiled/react/Circle';
+ <IconStack
+      align="bottom-right"
+      background={<Icon icon="file-duotone" color="blue"  size={32} />}
+      foreground={
+        <div
+          style={{
+            borderRadius: '10px',
+            width: '20px',
+            height: '20px',
+            border: 'solid 1px var(--silver)',
+            backgroundColor: '#ffffff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxSizing: 'border-box'
+          }}
+        >
+          <Icon icon="link" height={10} width={10} />
+        </div>
+      }
+    />
+```
+
+```
+import IconStack from 'cozy-ui/transpiled/react/IconStack';
+import Icon from 'cozy-ui/transpiled/react/Icon';
+import Circle from 'cozy-ui/transpiled/react/Circle';
+ <IconStack
+      align="bottom-right"
+      background={<Icon icon="file-duotone" color="blue"  size={32} />}
+      foreground={
+        <div
+          style={{
+            borderRadius: '6px',
+            width: '24px',
+            height: '24px',
+            border: 'solid 1px var(--silver)',
+            backgroundColor: '#ffffff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxSizing: 'border-box'
+          }}
+        >
+          <Icon icon="folder" size={16} />
+        </div>
+      }
+    />
 ```

--- a/react/IconStack/index.jsx
+++ b/react/IconStack/index.jsx
@@ -1,16 +1,23 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import styles from './styles.styl'
 
-const IconStack = ({ className, background, foreground }) => {
+const IconStack = ({ className, background, foreground, align = 'center' }) => {
   return (
     <div className={classNames(styles['IconStack-wrapper'], className)}>
       {background}
-      <div className={classNames(styles['IconStack-foregroundIcon'])}>
+      <div className={classNames(styles[`IconStack-foregroundIcon-${align}`])}>
         {foreground}
       </div>
     </div>
   )
 }
 
+IconStack.propTypes = {
+  className: PropTypes.string,
+  background: PropTypes.node,
+  foreground: PropTypes.node,
+  align: PropTypes.oneOf(['center', 'bottom-right'])
+}
 export default IconStack

--- a/react/IconStack/styles.styl
+++ b/react/IconStack/styles.styl
@@ -2,9 +2,20 @@
     position relative
     display inline-block
 }
-.IconStack-foregroundIcon{
+.IconStack-foregroundIcon-center{
     position absolute
     left 50%
     top 50%
     transform translate(-50%,-50%)
+}
+
+.IconStack-foregroundIcon-bottom-right{
+    position absolute
+    top 12px
+    left 16px
+    width 24px
+    height 24px
+    display flex
+    align-items center
+    justify-content center
 }

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -5052,9 +5052,37 @@ exports[`IconStack should render examples: IconStack 1`] = `
   <div class=\\"styles__IconStack-wrapper___10dhG\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: blue;\\" width=\\"32\\" height=\\"32\\">
       <use xlink:href=\\"#file-duotone\\"></use>
     </svg>
-    <div class=\\"styles__IconStack-foregroundIcon___ZvY-t\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: red;\\" width=\\"16\\" height=\\"16\\">
+    <div class=\\"styles__IconStack-foregroundIcon-center___1Jel_\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: red;\\" width=\\"16\\" height=\\"16\\">
         <use xlink:href=\\"#bank\\"></use>
       </svg></div>
+  </div>
+</div>"
+`;
+
+exports[`IconStack should render examples: IconStack 2`] = `
+"<div>
+  <div class=\\"styles__IconStack-wrapper___10dhG\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: blue;\\" width=\\"32\\" height=\\"32\\">
+      <use xlink:href=\\"#file-duotone\\"></use>
+    </svg>
+    <div class=\\"styles__IconStack-foregroundIcon-bottom-right___1s3VH\\">
+      <div style=\\"border-radius: 10px; width: 20px; height: 20px; background-color: rgb(255, 255, 255); display: flex; align-items: center; justify-content: center; box-sizing: border-box;\\"><svg class=\\"styles__icon___23x3R\\" width=\\"10\\" height=\\"10\\">
+          <use xlink:href=\\"#link\\"></use>
+        </svg></div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`IconStack should render examples: IconStack 3`] = `
+"<div>
+  <div class=\\"styles__IconStack-wrapper___10dhG\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: blue;\\" width=\\"32\\" height=\\"32\\">
+      <use xlink:href=\\"#file-duotone\\"></use>
+    </svg>
+    <div class=\\"styles__IconStack-foregroundIcon-bottom-right___1s3VH\\">
+      <div style=\\"border-radius: 6px; width: 24px; height: 24px; background-color: rgb(255, 255, 255); display: flex; align-items: center; justify-content: center; box-sizing: border-box;\\"><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+          <use xlink:href=\\"#folder\\"></use>
+        </svg></div>
+    </div>
   </div>
 </div>"
 `;


### PR DESCRIPTION
Add a new variant for the IconStack component : bottom-right alignment. 

I created a container of 24x24 following @joel-costa 's advice. In this container, we will have either a 20x20 Circle (I can't use circle, since 20x20 is not one of our size) or a 24x24 rectangle.


At the end of the implementation, I'm not sure that it's still an IconStack :/ 

https://crash--.github.io/cozy-ui/react/#/

- [x] Deployed the styleguidist

