### PR TITLE
fix(Modal): Check if dismissAction is defined before calling it

### DIFF
--- a/react/Modal/index.jsx
+++ b/react/Modal/index.jsx
@@ -33,7 +33,8 @@ class Modal extends Component {
   }
 
   handleOutsideClick = e => {
-    if (e.target === e.currentTarget) this.props.dismissAction()
+    if (e.target === e.currentTarget && this.props.dismissAction)
+      this.props.dismissAction()
   }
 
   componentDidMount() {
@@ -206,7 +207,9 @@ Modal.propTypes = {
   /** className to apply to wrapper element */
   wrapperClassName: PropTypes.string,
   /** className to apply to the container element */
-  containerClassName: PropTypes.string
+  containerClassName: PropTypes.string,
+  /** A function to be executed when the modal is dismissed */
+  dismissAction: PropTypes.func
 }
 
 Modal.defaultProps = {


### PR DESCRIPTION
Since `dismissAction` is not always defined, we may check it's defined before calling it explicitly when clicking outside the modal.

Related to https://github.com/cozy/cozy-keys-lib/pull/78#discussion_r375665232