### PR TITLE
Fix/use media query to disable animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "preact-portal": "1.1.3",
     "pretty": "2.0.0",
     "prop-types": "15.7.2",
-    "puppeteer": "1.20.0",
+    "puppeteer": "2.1.1",
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-redux": "^7.2.0",

--- a/react/BottomDrawer/styles.styl
+++ b/react/BottomDrawer/styles.styl
@@ -4,7 +4,7 @@
 @require 'generic/animations'
 
 .with-transition
-    @extends $with-transition
+    @extends $transition-transform-ease-out
 
 .BottomDrawer-content
     z-index        $drawer-index

--- a/react/BottomDrawer/styles.styl
+++ b/react/BottomDrawer/styles.styl
@@ -1,9 +1,10 @@
 @require 'tools/mixins'
 @require 'settings/spaces'
 @require 'settings/z-index'
+@require 'generic/animations'
 
 .with-transition
-    transition transform .1s ease-out
+    @extends $with-transition
 
 .BottomDrawer-content
     z-index        $drawer-index

--- a/react/Icon/index.jsx
+++ b/react/Icon/index.jsx
@@ -2,8 +2,6 @@ import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 import cx from 'classnames'
-import isTesting from '../../helpers/isTesting'
-const isTestingValue = isTesting()
 const DEFAULT_SIZE = '16'
 
 function getSvgObject(icon) {
@@ -60,7 +58,7 @@ function Icon(props) {
 
   const iconClassName = preserveColor ? 'icon--preserveColor' : 'icon'
   const iconClass = cx(className, styles[iconClassName], {
-    [styles['icon--spin']]: spin && !isTestingValue
+    [styles['icon--spin']]: spin
   })
 
   return Svg ? (

--- a/scripts/screenshots.js
+++ b/scripts/screenshots.js
@@ -141,6 +141,9 @@ const prepareBrowser = async options => {
   await page.setUserAgent(
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36; Argos'
   )
+  await page.emulateMediaFeatures([
+    { name: 'prefers-reduced-motion', value: 'reduce' }
+  ])
   page.setViewport(options.viewport)
   await page.setDefaultNavigationTimeout(0)
   console.log('Browser opened and set up')

--- a/stylus/generic/animations.styl
+++ b/stylus/generic/animations.styl
@@ -37,7 +37,7 @@ $spin-anim
     // so that scoping works
     animation  spin 1s linear infinite
 
-@media (prefers-reduced-motion: reduce) 
+@media (prefers-reduced-motion: reduce)
     $with-transition
         transition none
     $spin-anim

--- a/stylus/generic/animations.styl
+++ b/stylus/generic/animations.styl
@@ -29,7 +29,7 @@
     40%, 60%
         transform translate3d(4px, 0, 0)
 
-$with-transition
+$transition-transform-ease-out
     transition transform .1s ease-out
 
 $spin-anim
@@ -38,7 +38,7 @@ $spin-anim
     animation  spin 1s linear infinite
 
 @media (prefers-reduced-motion: reduce)
-    $with-transition
+    $transition-transform-ease-out
         transition none
     $spin-anim
         animation none

--- a/stylus/generic/animations.styl
+++ b/stylus/generic/animations.styl
@@ -28,3 +28,17 @@
 
     40%, 60%
         transform translate3d(4px, 0, 0)
+
+$with-transition
+    transition transform .1s ease-out
+
+$spin-anim
+    // arguments' order is important: the animation name must stay first
+    // so that scoping works
+    animation  spin 1s linear infinite
+
+@media (prefers-reduced-motion: reduce) 
+    $with-transition
+        transition none
+    $spin-anim
+        animation none

--- a/stylus/settings/icons.styl
+++ b/stylus/settings/icons.styl
@@ -1,5 +1,6 @@
 @require '../generic/animations'
 @require '../tools/mixins'
+@require 'generic/animations'
 
 /*------------------------------------*\
   Icons
@@ -96,10 +97,7 @@ $icon-centered
     left       50%
     transform  translateX(-50%) translateY(-50%)
 
-$spin-anim
-    // arguments' order is important: the animation name must stay first
-    // so that scoping works
-    animation  spin 1s linear infinite
 
 $icon-spin
-    @extend           $spin-anim
+    @extend $spin-anim
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,6 +1704,11 @@
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
 
+"@types/mime-types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
+  integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2058,6 +2063,11 @@ agent-base@4, agent-base@^4.1.0, agent-base@~4.2.1:
   integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
   dependencies:
     es6-promisify "^5.0.0"
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agent-base@^4.3.0:
   version "4.3.0"
@@ -4845,17 +4855,17 @@ debug@3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -7236,6 +7246,14 @@ https-proxy-agent@^2.2.3:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -9888,12 +9906,24 @@ mime-db@1.40.0, "mime-db@>= 1.40.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
   integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
   dependencies:
     mime-db "1.40.0"
+
+mime-types@^2.1.25:
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
+  dependencies:
+    mime-db "1.43.0"
 
 mime@1.6.0, mime@^1.6.0:
   version "1.6.0"
@@ -12817,15 +12847,17 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.20.0.tgz#e3d267786f74e1d87cf2d15acc59177f471bbe38"
-  integrity sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==
+puppeteer@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.1.1.tgz#ccde47c2a688f131883b50f2d697bd25189da27e"
+  integrity sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==
   dependencies:
+    "@types/mime-types" "^2.1.0"
     debug "^4.1.0"
     extract-zip "^1.6.6"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^4.0.0"
     mime "^2.0.3"
+    mime-types "^2.1.25"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"


### PR DESCRIPTION
In order to have a global solution to disable animation in our test, we can use the new https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion 

But it seems that : 
- We can't negate this media query we can't do : `@media not (prefers-reduced-motion: reduce)`. 
- So we need to override our animation in this media query. 
- I tried to override only the keyframe in ` generic/animations.styl` but with no luck. I don't know if we should not override the animation and not the keyframe ? 🤔 


On a aussi des animations sur : 
- BottomDrawer (with-animation) 
- ActionMenu 

Il faudrait centraliser les déclarations d'animation à un endroit pour pouvoir facilement les désactiver