### PR TITLE
fix: Children is not mandatory for Overlay

### DIFF
--- a/react/Overlay/index.jsx
+++ b/react/Overlay/index.jsx
@@ -68,7 +68,7 @@ class Overlay extends Component {
 
 Overlay.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   onEscape: PropTypes.func
 }
 


### PR DESCRIPTION
Sometimes we use Overlay to just handle click
outside of an area (Menu for instance).

I was tired of seeing this warning in drive
