### PR TITLE
fix: Default to align items center

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -76,6 +76,7 @@ $button
     text-transform   uppercase
     text-decoration  none
     cursor           pointer
+    align-items      center
 
     svg
         fill         currentColor


### PR DESCRIPTION
I migrated to Chromium (82.0.4078.0) again and the button's content were not correctly centered. 

It seems that the default user agent stylesheet for button in Chromium is `align-items: flex-start;`. I don't know if this behavior has been changed recently? 
<img width="303" alt="Capture d’écran 2020-03-05 à 11 43 19" src="https://user-images.githubusercontent.com/1107936/75974100-896f3380-5ed6-11ea-92cf-7bdc6b0892f2.png">


exemple: 
<img width="66" alt="Capture d’écran 2020-03-05 à 11 39 14" src="https://user-images.githubusercontent.com/1107936/75973722-f504d100-5ed5-11ea-8ac1-1a03cec846f6.png">
