### PR TITLE
fix: Badge proptypes

### DIFF
--- a/react/Badge/index.jsx
+++ b/react/Badge/index.jsx
@@ -34,7 +34,7 @@ export const Badge = ({
 
 Badge.propTypes = {
   /** The content of the badge */
-  content: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  content: PropTypes.node,
   /** The type of the badge */
   type: PropTypes.oneOf(['normal', 'new', 'error']),
   alignment: PropTypes.oneOf(['bottom-right'])


### PR DESCRIPTION
I forgot to change the badge's proptypes... we now pass a node element to the content 