### PR TITLE
fix: Viewer Warning and accessibility

### DIFF
--- a/react/Viewer/PdfJsViewer.jsx
+++ b/react/Viewer/PdfJsViewer.jsx
@@ -7,6 +7,7 @@ import { Spinner } from '../Spinner'
 import withFileUrl from './withFileUrl'
 import ToolbarButton from './PdfToolbarButton'
 import NoViewer from './NoViewer'
+import { translate } from '../I18n'
 import styles from './styles.styl'
 
 export const MIN_SCALE = 0.25
@@ -98,7 +99,7 @@ export class PdfJsViewer extends Component {
   }
 
   render() {
-    const { url, file, renderFallbackExtraContent } = this.props
+    const { url, file, renderFallbackExtraContent, t } = this.props
     const {
       loaded,
       errored,
@@ -108,7 +109,6 @@ export class PdfJsViewer extends Component {
       width,
       renderAllPages
     } = this.state
-
     if (errored)
       return (
         <NoViewer
@@ -157,12 +157,14 @@ export class PdfJsViewer extends Component {
                   icon="top"
                   onClick={this.previousPage}
                   disabled={currentPage === 1}
+                  label={t('Viewer.previous')}
                 />
                 {currentPage}/{totalPages}
                 <ToolbarButton
                   icon="bottom"
                   onClick={this.nextPage}
                   disabled={currentPage === totalPages}
+                  label={t('Viewer.next')}
                 />
               </span>
             )}
@@ -172,11 +174,13 @@ export class PdfJsViewer extends Component {
                 icon="dash"
                 onClick={this.scaleDown}
                 disabled={scale === MIN_SCALE}
+                label={t('Viewer.scaledown')}
               />
               <ToolbarButton
                 icon="plus"
                 onClick={this.scaleUp}
                 disabled={scale === MAX_SCALE}
+                label={t('Viewer.scaleup')}
               />
             </span>
           </div>
@@ -192,4 +196,4 @@ PdfJsViewer.propTypes = {
   renderFallbackExtraContent: PropTypes.func
 }
 
-export default withFileUrl(PdfJsViewer)
+export default withFileUrl(translate()(PdfJsViewer))

--- a/react/Viewer/PdfJsViewer.spec.jsx
+++ b/react/Viewer/PdfJsViewer.spec.jsx
@@ -13,7 +13,7 @@ describe('PDFViewer', () => {
   }
   beforeEach(() => {
     component = shallow(
-      <PdfJsViewer url={'test'} file={{}} gestures={gesturesMock} />
+      <PdfJsViewer url={'test'} file={{}} gestures={gesturesMock} t={x => x} />
     )
   })
   afterEach(() => {

--- a/react/Viewer/PdfToolbarButton.jsx
+++ b/react/Viewer/PdfToolbarButton.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Button from '../Button'
 
-const PdfToolbarButton = ({ icon, onClick, disabled }) => (
+const PdfToolbarButton = ({ icon, onClick, disabled, label }) => (
   <Button
     iconOnly
     subtle
@@ -11,13 +11,15 @@ const PdfToolbarButton = ({ icon, onClick, disabled }) => (
     icon={icon}
     onClick={onClick}
     disabled={disabled}
+    label={label}
   />
 )
 
 PdfToolbarButton.propTypes = {
   icon: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  label: PropTypes.string.isRequired
 }
 
 export default PdfToolbarButton

--- a/react/Viewer/__snapshots__/index.spec.jsx.snap
+++ b/react/Viewer/__snapshots__/index.spec.jsx.snap
@@ -60,7 +60,7 @@ exports[`Viewer should render the various viewers: noviewer 1`] = `
 `;
 
 exports[`Viewer should render the various viewers: pdfviewer 1`] = `
-<PdfJsViewer
+<withI18n(PdfJsViewer)
   file={
     Object {
       "_id": "pdffileid",

--- a/react/Viewer/locales/en.json
+++ b/react/Viewer/locales/en.json
@@ -4,6 +4,10 @@
     "retry": "Retry",
     "error": "This file could not be loaded. Do you have a working internet connection right now?",
     "close": "close",
-    "goto": "Go to %{url}"
+    "goto": "Go to %{url}",
+    "next": "Next",
+    "previous": "Previous",
+    "scaledown": "Zoom out",
+    "scaleup": "Zoom in"
   }
 }

--- a/react/Viewer/locales/fr.json
+++ b/react/Viewer/locales/fr.json
@@ -4,6 +4,10 @@
     "retry": "Réessayer",
     "error": "Ce fichier n'a pas pu être chargé. Avez-vous une connexion internet qui fonctionne actuellement ?",
     "close": "Fermer",
-    "goto": "Ouvrir %{url}"
+    "goto": "Ouvrir %{url}",
+    "next": "Suivante",
+    "previous": "Précédente",
+    "scaledown": "Zoom arrière",
+    "scaleup": "Zoom avant"
   }
 }


### PR DESCRIPTION
We display a button icon only for the PDF viewer, but we have to provide a label to make it mare accessible. It also fixes a few warnings in the console ;) 