### PR TITLE
fix: Zindex dialog

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -232,7 +232,8 @@ normalTheme.overrides = {
   MuiDialog: {
     root: {
       color: getCssVariableValue('charcoalGrey'),
-      'border-radius': '8px'
+      'border-radius': '8px',
+      zIndex: getCssVariableValue('zIndex-modal')
     },
     paper: {
       'box-sizing': 'border-box',

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -46,3 +46,18 @@ $file-action-menu   = 60 // replaced by $drawer-index
 $drawer-index       = 60
 $modal-index        = 70
 $alert-index        = 80
+
+:root
+    --zIndex-below $below-index
+    --zIndex-app $app-index
+    --zIndex-low $low-index
+    --zIndex-alertMobile $alert-index-mobile
+    --zIndex-nav $nav-index
+    --zIndex-bar $bar-index
+    --zIndex-selection $selection-index
+    --zIndex-popover $popover-index
+    --zIndex-overlay $overlay-index
+    --zIndex-fileActionMenu $file-action-menu
+    --zIndex-drawer $drawer-index
+    --zIndex-modal $modal-index
+    --zindex-alert $alert-index


### PR DESCRIPTION
MUI's dialog comes with a 1300 zindex. We need to fix it back to 70 as our previous modal. 

To do that, I expose a few more CSS variables 