### PR TITLE
feat: Allows to push modals ModalStack

### DIFF
--- a/react/ViewStack/ModalStack.jsx
+++ b/react/ViewStack/ModalStack.jsx
@@ -12,6 +12,9 @@ import { useStack } from './hooks'
  * - Several modals can be stacked in this manner
  * - The <Modal /> element wrapping <View /> can receive props via the 2nd
  * argument of stackPush : `stackPush(<SmallView />, { size: 'xsmall' })`
+ * Passing `{ noModalStackWrapper: true }` will avoid wrapping your
+ * component inside a `<Modal />`, if the component already embed one.
+ * When doing so, it's up to you to use the `stackPop` method.
  *
  * Can be used as a replacement of a <ViewStack /> on mobile
  */
@@ -29,11 +32,16 @@ const ModalStack = ({ children }) => {
         const hasProps = child.length > 1
         const props = hasProps ? child[1] : null
         child = hasProps ? child[0] : child
-        return (
-          <Modal mobileFullscreen key={i} dismissAction={stackPop} {...props}>
-            {child}
-          </Modal>
-        )
+        const shouldWrap = props ? !props.noModalStackWrapper : true
+        if (shouldWrap) {
+          return (
+            <Modal mobileFullscreen key={i} dismissAction={stackPop} {...props}>
+              {child}
+            </Modal>
+          )
+        } else {
+          return React.cloneElement(child, { key: i })
+        }
       })}
     </ViewStackContext.Provider>
   )

--- a/react/ViewStack/ModalStack.spec.jsx
+++ b/react/ViewStack/ModalStack.spec.jsx
@@ -1,0 +1,47 @@
+import { mount } from 'enzyme'
+import React, { useEffect } from 'react'
+import ModalStack from './ModalStack'
+import { useViewStack } from './context'
+import Modal from '../Modal'
+
+function Inside() {
+  return <aside>Inside</aside>
+}
+
+describe('ModalStack', () => {
+  it('should wrap the component inside a modal', () => {
+    function Main({ component }) {
+      const { stackPush } = useViewStack()
+      useEffect(() => {
+        stackPush(component)
+      }, [])
+      return <main>Main content</main>
+    }
+
+    const root = mount(
+      <ModalStack>
+        <Main component={<Inside />} />
+      </ModalStack>
+    )
+    expect(root.find(Modal)).toHaveLength(1)
+  })
+
+  describe('when using noModalStackWrapper:true as props', () => {
+    it('should not wrap the component inside a modal', () => {
+      function Main({ component }) {
+        const { stackPush } = useViewStack()
+        useEffect(() => {
+          stackPush(component, { noModalStackWrapper: true })
+        }, [])
+        return <main>Main content</main>
+      }
+
+      const root = mount(
+        <ModalStack>
+          <Main component={<Inside />} />
+        </ModalStack>
+      )
+      expect(root.find(Modal)).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
This change is useful to push a QuotaAlert in the stack, and avoid
the ModalStack to wrap a Modal to a component which already has one.
