### PR TITLE
Improve UploadQueue screenshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - yarn test
   - yarn build:css:all
   - yarn build:doc:react
-  - yarn screenshots
+  - yarn screenshots --viewport desktop
   - yarn screenshots --no-empty-screenshot-dir --viewport 300x600
   - yarn argos --token $ARGOS_TOKEN --branch $TRAVIS_BRANCH --commit $TRAVIS_COMMIT
 deploy:

--- a/react/UploadQueue/Readme.md
+++ b/react/UploadQueue/Readme.md
@@ -10,6 +10,8 @@ the upload queue:
 - underneath the top-bar on mobile  
 
 ```
+import isTesting from '../../helpers/isTesting'
+
 const initialState = {
   popover: false
 }
@@ -44,5 +46,15 @@ const data = {
     successCount={data.successCount}
     popover={state.popover}
   />
+  {isTesting() ?
+    <UploadQueue
+      lang='fr'
+      app='Cozy Drive'
+      getMimeTypeIcon={() => 'file'}
+      queue={data.queue}
+      doneCount={data.doneCount}
+      successCount={data.successCount}
+      popover={true}
+    /> : null }
 </>
 ```

--- a/rsgscreenshots.json
+++ b/rsgscreenshots.json
@@ -1,0 +1,7 @@
+{
+  "UploadQueue": {
+    "viewports": {
+      "desktop": "1200x700"
+    }
+  }
+}


### PR DESCRIPTION
#### Add popover=true variant during screenshots

`isTesting` is use to show the popover variant during screenshots.

#### Override desktop resolution

Previously, in both 800x600 and 300x600 screenshots, the UploadQueue
screenshots would show the mobile version, now we configure a specific
resolution for this component, through a JSON config file.