### PR TITLE
fix: ActionMenu placements

### DIFF
--- a/react/ActionMenu/Readme.md
+++ b/react/ActionMenu/Readme.md
@@ -109,6 +109,51 @@ const anchorRef = React.createRef();
 </div>
 ```
 
+### ActionMenu within other components and containerElRef
+
+The ActionMenu component is rendered at the root of the DOM tree using a [Portal](https://reactjs.org/docs/portals.html) and a fixed z-index. Since Modals for example have a higher z-index than ActionMenus, an ActionMenu _inside_ a Modal will be displayed behind it, instead of over it.
+
+In that case, we can use the `containerElRef` prop to provide a reference to an element where ActionMenu will be rendered. Here is an example for the most common case, an ActionMenu inside a Modal:
+
+```
+import ActionMenu, { ActionMenuItem, ActionMenuHeader } from './index';
+import Icon from '../Icon';
+import Modal, { ModalDescription } from '../Modal';
+import Filename from '../Filename';
+
+initialState = { modalDisplayed: isTesting(), menuDisplayed: isTesting() };
+
+const showModal = () => setState({ modalDisplayed: true });
+const hideModal = () => setState({ modalDisplayed: false });
+
+const showMenu = () => setState({ menuDisplayed: true });
+const hideMenu = () => setState({ menuDisplayed: false });
+
+const insideModalRef = React.createRef();
+
+<div>
+  <button onClick={showModal}>Show modal</button>
+  {state.modalDisplayed &&
+    <Modal dismissAction={hideModal}>
+      <ModalDescription>
+        <div ref={insideModalRef}>
+          <button onClick={showMenu}>Show action menu</button>
+        </div>
+        {state.menuDisplayed &&
+          <ActionMenu
+            containerElRef={insideModalRef}
+            onClose={hideMenu}>
+            <ActionMenuHeader>
+              <Filename icon="file" filename="my_awesome_paper" extension=".pdf" />
+            </ActionMenuHeader>
+            <ActionMenuItem onClick={() => alert('click')}left={<Icon icon='file' />}>Item 1</ActionMenuItem>
+        </ActionMenu>}
+      </ModalDescription>
+    </Modal>
+  }
+</div>
+```
+
 ### preventOverflow
 
 Set `preventOverflow` to `true` to keep the ActionMenu visible on desktop, even if `anchorElRef` is outside the viewport.

--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -12,13 +12,18 @@ const ActionMenuWrapper = ({
   inline,
   onClose,
   anchorElRef,
+  containerElRef,
   placement,
   preventOverflow,
   children
 }) => {
-  const getAnchorElement = useCallback(() => {
-    return anchorElRef.current
-  }, [anchorElRef])
+  const getElementFromRefCallback = ref =>
+    useCallback(() => {
+      return ref ? ref.current : undefined
+    }, [ref])
+
+  const getAnchorElement = getElementFromRefCallback(anchorElRef)
+  const getContainerElement = getElementFromRefCallback(containerElRef)
   const normalOverflowModifiers = {
     preventOverflow: { enabled: false },
     hide: { enabled: false }
@@ -27,12 +32,11 @@ const ActionMenuWrapper = ({
   return inline ? (
     <Popper
       anchorEl={getAnchorElement}
+      container={getContainerElement}
       modifiers={preventOverflow ? null : normalOverflowModifiers}
       open
       placement={placement}
-      disablePortal={true}
       style={{
-        position: 'fixed',
         zIndex: getCssVariableValue('zIndex-popover')
       }}
     >
@@ -50,6 +54,7 @@ const ActionMenu = ({
   placement,
   preventOverflow,
   anchorElRef,
+  containerElRef,
   breakpoints: { isDesktop }
 }) => {
   const shouldDisplayInline = isDesktop
@@ -60,6 +65,7 @@ const ActionMenu = ({
         onClose={onClose}
         inline={shouldDisplayInline}
         anchorElRef={anchorElRef || containerRef}
+        containerElRef={containerElRef}
         placement={placement}
         preventOverflow={preventOverflow}
       >
@@ -100,7 +106,9 @@ ActionMenu.propTypes = {
   /** Will keep the menu visible when scrolling */
   preventOverflow: PropTypes.bool,
   /** The reference element for the menu placement and overflow prevention. */
-  anchorElRef: PropTypes.object
+  anchorElRef: PropTypes.object,
+  /** ActionMenu will be rendered inside the elemnt of this ref. Useful when rendering inside Modals for example. */
+  containerElRef: PropTypes.object
 }
 
 ActionMenu.defaultProps = {

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -100,6 +100,12 @@ exports[`ActionMenu should render examples: ActionMenu 4`] = `
 </div>"
 `;
 
+exports[`ActionMenu should render examples: ActionMenu 5`] = `
+"<div>
+  <div><button>Show modal</button></div>
+</div>"
+`;
+
 exports[`AppTitle should render examples: AppTitle 1`] = `
 "<div>
   <h1 class=\\"u-title-h1 styles__c-apptitle___eqV9l\\">Drive</h1>


### PR DESCRIPTION
`ActionMenu` on desktop relies on `Popper` from MUI, itself being a small wrapper around `Popper.js`. By default, Popper will portal-render itself at the root of the DOM. This caused ActionMenu to malfunction when used within a modal (see https://github.com/cozy/cozy-ui/commit/92cccc24fb732371c4c38bb8e687771a164f7468).

The previous fix was to disable portaling. This solved the z-index problem but caused overflowing problems, so `position: fixed` was used as well. The problem is that as soon as `disablePortal` is activated, Popper won't honor the `placement` attribute anymore. So that prop has been broken since 92cccc24fb732371c4c38bb8e687771a164f7468.

Since *not* using Portal isn't an option, we need to control where the Portal is rendered. We can dothis using the [`container` prop](https://v3.material-ui.com/api/popper/#popper-api). So this PR adds a `containerElRef`, similar to the existing `anchorElRef`. It can be used to portal the ActionMenu into the Modal, which solves the initial z-index problem.

This PR is marked as breaking change because unfortunately, it does mean that there is a manual action required when the ActionMenu is used inside a Modal (for example). If no `containerElRef` is provided it will work as usual. The only affected lib by this change is cozy-scanner.

My cozy-ui preview is currently busy with another PR, i'll update this PR once the new preview is online.