### PR TITLE
Draft feat: Take less screenshots

### DIFF
--- a/rsgscreenshots.json
+++ b/rsgscreenshots.json
@@ -3,5 +3,11 @@
     "viewports": {
       "desktop": "1200x700"
     }
+  },
+  "ActionMenu": {
+    "perExampleScreenshot": true
+  },
+  "Modal": {
+    "perExampleScreenshot": true
   }
 }


### PR DESCRIPTION
Argos limits us to 500 screenshots so instead of screenshotting each
example, we screenshot each component page

One additional challenge introduced by screenshotting at component level, is that for some examples, we *need* to screenshot at example levels, for example with modals or action menus. To support this usecase, a configuration attribute `perExampleScreenshot` is introduced. When this is configured, screenshot are taken at example level.