### PR TITLE
Fix upload queue item for directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "commitlint": "7.6.1",
     "commitlint-config-cozy": "0.3.27",
     "copyfiles": "2.1.1",
-    "cozy-client": "^12.4.0",
+    "cozy-client": "^13.4.1",
     "cozy-device-helper": "1.7.5",
     "cozy-doctypes": "^1.69.0",
     "css-loader": "0.28.11",
@@ -144,7 +144,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "3.9.4",
-    "cozy-client": "*",
+    "cozy-client": "^13.4.0",
     "cozy-device-helper": "1.7.5",
     "cozy-doctypes": "^1.69.0",
     "piwik-react-router": "^0.8.2",

--- a/react/UploadQueue/Readme.md
+++ b/react/UploadQueue/Readme.md
@@ -30,7 +30,7 @@ const data = {
     },
     status: 'loading'
   }, {
-    file: { name: 'File.jpg' },
+    file: { name: 'Directory' },
     status: 'pending'
   }],
   doneCount: 1,

--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -36,9 +36,10 @@ const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA]
 
 const splitFilename = filename => {
   const parts = filename.split('.')
+  const hasExtension = parts.length > 1
   return {
-    filename: parts.slice(0, -1).join('.') + '.',
-    extension: parts.length > 1 ? parts[parts.length - 1] : ''
+    filename: hasExtension ? parts.slice(0, -1).join('.') + '.' : parts[0],
+    extension: hasExtension ? parts[parts.length - 1] : ''
   }
 }
 

--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -11,6 +11,7 @@ import palette from '../../stylus/settings/palette.json'
 import styles from './styles.styl'
 import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
 import cx from 'classnames'
+import { splitFilename } from 'cozy-client/dist/models/file'
 
 import localeEn from './locales/en.json'
 import localeEs from './locales/es.json'
@@ -33,15 +34,6 @@ const QUOTA = 'quota'
 const NETWORK = 'network'
 const DONE_STATUSES = [CREATED, UPDATED]
 const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA]
-
-const splitFilename = filename => {
-  const parts = filename.split('.')
-  const hasExtension = parts.length > 1
-  return {
-    filename: hasExtension ? parts.slice(0, -1).join('.') + '.' : parts[0],
-    extension: hasExtension ? parts[parts.length - 1] : ''
-  }
-}
 
 export const uploadStatus = {
   CANCEL,
@@ -97,7 +89,7 @@ const FileUploadProgress = ({ progress }) => {
 const Item = translate()(
   ({ file, status, isDirectory, progress, getMimeTypeIcon }) => {
     const { CANCEL, LOADING, DONE_STATUSES, ERROR_STATUSES } = uploadStatus
-    const { filename, extension } = splitFilename(file.name)
+    const { filename, extension } = splitFilename(file)
     let statusIcon
     let done = false
     let error = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -4441,21 +4441,22 @@ cosmiconfig@^5.0.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-client@^12.4.0:
-  version "12.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-12.4.0.tgz#82ada9226c615b398c948b774310933758e4143e"
-  integrity sha512-1eqiaodhebVHJ8adWw5jLNKv4yuOJ4K3d3fMab4x/8gW0pe+PXrFyoC45/rxjrI0RoixZ3emWz4skfnax4CLsQ==
+cozy-client@^13.4.1:
+  version "13.4.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.4.1.tgz#bcb3620fdabe0c5e9d0de30901a99f7b6d21ac3d"
+  integrity sha512-Xn61nmIbRC+9WwS2X8MJN8/RLbbRQtgUNuO90u7qArBsI5FF2muaH28WGGvZqM0Ldv2LvoRqb8j+CNY7K1Vsmw==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^12.2.0"
+    cozy-stack-client "^13.3.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
+    minilog "https://github.com/cozy/minilog.git#master"
     open "^7.0.2"
     prop-types "^15.6.2"
-    react-redux "^5.0.7"
+    react-redux "^7.2.0"
     redux "^3.7.2"
     redux-thunk "^2.3.0"
     server-destroy "^1.0.1"
@@ -4496,10 +4497,10 @@ cozy-logger@^1.6.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-12.2.0.tgz#fb3b5cd24824e67187d41674a40d297624f33dfa"
-  integrity sha512-cilexeSjgCRsP4T0do/ufmiEY52SVrnQdtIJbSaRU1Tg/WnJs83mDw8H+aVpp9xLpD0ugtVwOWF48J6Cqz7zfw==
+cozy-stack-client@^13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.3.0.tgz#e77870048d286aad42db4b5b383840d2e4b754cc"
+  integrity sha512-fBblkKVR7N3eMq305GdOVxZrn2I1uDKRf5p84Do24ig2U14UPyUVVzYHdW1qxfF5T6VUXk7J0KG0z/lwbB3iBA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -10022,7 +10023,7 @@ methods@~1.1.2:
   version "0.5.1"
   resolved "https://github.com/cozy/michelangelo.git#a3065fa84a814a35bbba903749b6e26f2b9d4e4d"
 
-microee@^0.0.6:
+microee@0.0.6, microee@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/microee/-/microee-0.0.6.tgz#a12bdb0103681e8b126a9b071eba4c467c78fffe"
   integrity sha1-oSvbAQNoHosSapsHHrpMRnx4//4=
@@ -10182,6 +10183,12 @@ mini-html-webpack-plugin@^0.2.3:
   integrity sha512-wfkLf+CmyDg++K1S0QdAvUvS29DfVHe9SQ63syX8aX375mInzC5uwHxb/1+3exiiv84xnPrf6zsOnReRe15rjg==
   dependencies:
     webpack-sources "^1.1.0"
+
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -13417,12 +13424,12 @@ react-is@^16.12.0, react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
-react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -13451,19 +13458,6 @@ react-pdf@^4.0.5:
     merge-class-names "^1.1.1"
     pdfjs-dist "2.1.266"
     prop-types "^15.6.2"
-
-react-redux@^5.0.7:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.2.tgz#b19cf9e21d694422727bf798e934a916c4080f57"
-  integrity sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
-    loose-envify "^1.1.0"
-    prop-types "^15.6.1"
-    react-is "^16.6.0"
-    react-lifecycles-compat "^3.0.0"
 
 react-redux@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
Splitting the filename had a bug when there was no extension: it would return { filename: ".", extension: "" } if the filename had no extension, resulting in upload queue rows with only "." if the item was a directory or an extension less file.