### PR TITLE
feat: Add testing utility for Stepper

### DIFF
--- a/react/Stepper/testing.jsx
+++ b/react/Stepper/testing.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import {
+  Stepper,
+  Step,
+  StepLabel,
+  StepButton
+} from 'cozy-ui/transpiled/react/Stepper'
+
+const renderSVGWarningIcon = () => {
+  const { getByRole } = render(
+    <Stepper>
+      <Step>
+        <StepButton>
+          <StepLabel error={true}>error</StepLabel>
+        </StepButton>
+      </Step>
+    </Stepper>
+  )
+  const button = getByRole('button')
+  const svg = button.querySelector('svg')
+  return svg
+}
+
+let warningSvg
+
+const findStepButtonFromLabelNode = node => {
+  return node.parentNode.parentNode.parentNode
+}
+
+const haveSameClassList = (node1, node2) => {
+  const cs1 = node1.classList.toString()
+  const cs2 = node2.classList.toString()
+  return cs1 === cs2
+}
+
+const isWarningStep = stepLabelNode => {
+  const stepButtonNode = findStepButtonFromLabelNode(stepLabelNode)
+  const icon = stepButtonNode.querySelector('svg')
+  return haveSameClassList(warningSvg, icon)
+}
+
+beforeEach(() => {
+  warningSvg = renderSVGWarningIcon()
+})
+
+export { isWarningStep }


### PR DESCRIPTION
Add testing utility near the component, for use downstream in apps.

It was pretty difficult to test if a step was in warning (with react testing library). I propose in those cases to have testing utilities here in cozy-ui for easier usage in Apps. 

See https://github.com/cozy/cozy-passwords/pull/26 for context.