### PR TITLE
feat: Completely disables ripples in MUI

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -21,6 +21,12 @@ export const normalTheme = createMuiTheme({
       color: 'white'
     }
   },
+  props: {
+    MuiButtonBase: {
+      // The properties to apply
+      disableRipple: true // No more ripple, on the whole application 💣!
+    }
+  },
   shape: {
     borderRadius: defaultValues.borderRadius
   },


### PR DESCRIPTION
Unfortunately this removes the "active" state of buttons where there is
an overlay showing that the button is being clicked upon

We should find a way to disable the ripple effect and still keeping the darker
overlay. I have tried with the keyframes (setting the 0% keyframe to already have
a scale of 1), but could not make it work (as if my changes were not picked).
I still think it is possible though.