### PR TITLE
fix: Upload queue bugs

### DIFF
--- a/react/UploadQueue/Readme.md
+++ b/react/UploadQueue/Readme.md
@@ -18,10 +18,10 @@ const initialState = {
 
 const data = {
   queue: [{
-    file: { name: 'Photo.jpg' },
+    file: { name: 'Photo.jpg', type: 'file' },
     status: 'created'
   }, {
-    file: { name: 'Readme.txt' },
+    file: { name: 'File with a very long name - really long - 2020/04/16.txt', type: 'file' },
     progress: {
       loaded: 100,
       total: 400,

--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -12,7 +12,7 @@ import styles from './styles.styl'
 import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
 import cx from 'classnames'
 import { splitFilename } from 'cozy-client/dist/models/file'
-
+import { Media, Bd, Img } from '../Media'
 import localeEn from './locales/en.json'
 import localeEs from './locales/es.json'
 import localeFr from './locales/fr.json'
@@ -124,33 +124,33 @@ const Item = translate()(
     }
 
     return (
-      <div
+      <Media
         data-test-id="upload-queue-item"
-        className={classNames(styles['upload-queue-item'], {
+        className={classNames('u-ph-1', styles['upload-queue-item'], {
           [styles['upload-queue-item--done']]: done,
           [styles['upload-queue-item--error']]: error
         })}
       >
-        <div className={styles['item-file']}>
-          {getMimeTypeIcon ? (
+        {getMimeTypeIcon ? (
+          <Img>
             <Icon
               icon={getMimeTypeIcon(isDirectory, file.name, file.type)}
               size={32}
-              className="u-flex-shrink-0 u-mr-1"
+              className="u-mr-1"
             />
-          ) : null}
-          <div>
-            <div data-test-id="upload-queue-item-name" className="u-ellipsis">
-              {filename}
-              {extension && (
-                <span className={styles['item-ext']}>{extension}</span>
-              )}
-            </div>
-            {progress ? <FileUploadProgress progress={progress} /> : null}
+          </Img>
+        ) : null}
+        <Bd className={styles['item-file']}>
+          <div data-test-id="upload-queue-item-name" className="u-ellipsis">
+            {filename}
+            {extension && (
+              <span className={styles['item-ext']}>{extension}</span>
+            )}
           </div>
-        </div>
-        <div className={styles['item-status']}>{statusIcon}</div>
-      </div>
+          {progress ? <FileUploadProgress progress={progress} /> : null}
+        </Bd>
+        <Img className={styles['item-status']}>{statusIcon}</Img>
+      </Media>
     )
   }
 )

--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -26,7 +26,6 @@ $coz-bar-size=3rem
     height 1rem
 
 .upload-queue__upload-progress
-    justify-content center
     align-items center
     display flex
     margin-top 0.125rem // Must tweak a bit the margin-top
@@ -107,21 +106,10 @@ progress.upload-queue-progress::-moz-progress-bar
 .upload-queue-item
     height          3rem
     box-sizing      border-box
-    display         flex
-    flex-direction  row
-    align-items     center
-    flex            0 0 auto
-    width           100%
     border-bottom   .0625rem solid var(--silver)
-    max-width       'calc(100vw - %s)' % 13.75rem
 
     .item-file
-        flex        0 0 85%
-        display flex
-        align-items center
-        padding spacing_values.m
         user-select none
-        box-sizing  border-box
         color          var(--charcoalGrey)
         overflow hidden
 
@@ -130,7 +118,7 @@ progress.upload-queue-progress::-moz-progress-bar
 
     .item-status
         flex       0 0 15%
-        text-align center
+        text-align right
 
     .item-pending
         text-transform uppercase


### PR DESCRIPTION
- No ellipsis was showing in case of long filename
- Content was centered, this would result in misalignment when progress
width was shorter than filename
- Used Media to reduce the amount of code
- Texte de statut aligné à droite

On a une différence de padding sur le côté droit, du au fait que c est maintenant la ligne qui porte le padding, ca fait que le padding est uniforme à gauche et à droite. A mon avis, c'est mieux qu'avant, @joel-costa tu peux confirmer ? cf [avant](https://argos-ci-production.s3.eu-west-1.amazonaws.com/aa8da7fd28c86fc1c6baadf4f73bbeeb?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVTMHH3OS5ZZGS3AJ%2F20200423%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20200423T100814Z&X-Amz-Expires=7200&X-Amz-Signature=e4581a09986917793b036e09b53da831a395857b88d30bb579b007f9be4c22c0&X-Amz-SignedHeaders=host) / [après](https://argos-ci-production.s3.eu-west-1.amazonaws.com/3290be804f3014b8d5a58d0285d82271?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVTMHH3OS5ZZGS3AJ%2F20200423%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20200423T095528Z&X-Amz-Expires=7200&X-Amz-Signature=c51b3aa6f2be224755f9df9b01d309c5af265c49d97ef7b345d5c5e54d56dcbb&X-Amz-SignedHeaders=host) sur [argos](https://www.argos-ci.com/cozy/cozy-ui/builds/222)