### PR TITLE
fix: No wrap status for upload queue

### DIFF
--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -119,6 +119,8 @@ progress.upload-queue-progress::-moz-progress-bar
     .item-status
         flex       0 0 15%
         text-align right
+        white-space nowrap
+        padding-left (spacing_values.m)
 
     .item-pending
         text-transform uppercase


### PR DESCRIPTION
I could not see this bug in the styleguidist since the "pending" in French has no space. 