### PR TITLE
feat: Ability to have the radio buttons to the left

### DIFF
--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -77,7 +77,8 @@ class NestedSelect extends Component {
       canSelectParent,
       isSelected,
       title,
-      transformParentItem
+      transformParentItem,
+      radioPosition
     } = this.props
     const { history } = this.state
     const current = history[0]
@@ -99,6 +100,7 @@ class NestedSelect extends Component {
           {canSelectParent && level > 0 ? (
             <>
               <ItemRow
+                radioPosition={radioPosition}
                 item={parentItem}
                 onClick={this.handleClickItem}
                 isSelected={isSelectedWithLevel(parentItem)}
@@ -108,6 +110,7 @@ class NestedSelect extends Component {
           ) : null}
           {children.map(item => (
             <ItemRow
+              radioPosition={radioPosition}
               key={item.key || item.title}
               item={item}
               onClick={this.handleClickItem}
@@ -123,7 +126,8 @@ class NestedSelect extends Component {
 NestedSelect.defaultProps = {
   ContentComponent: 'div',
   HeaderComponent: null,
-  transformParentItem: x => x
+  transformParentItem: x => x,
+  radioPosition: 'right'
 }
 
 const ItemPropType = PropTypes.shape({
@@ -139,6 +143,11 @@ const ItemPropType = PropTypes.shape({
 })
 
 NestedSelect.propTypes = {
+  /**
+   * Can be set to "right" or "left". Defaults to "right"
+   */
+  radioPosition: PropTypes.oneOf(['left', 'right']),
+
   /**
    * The whole option item is passed to this function when selected
    */
@@ -182,19 +191,32 @@ export const Radio = ({ className, ...props }) => (
 
 const Divider = () => <div className={styles.Divider} />
 
-export const ItemRow = ({ item, onClick, isSelected }) => {
+export const ItemRow = ({ item, onClick, isSelected, radioPosition }) => {
   return (
     <div className={cx(styles.Row, isSelected ? styles.Row__selected : null)}>
       <CompositeRow
         dense
-        image={item.icon}
+        image={
+          <div className="u-flex">
+            {radioPosition === 'left' ? (
+              <Radio
+                className="u-mr-1"
+                readOnly
+                name={item.title}
+                value={item.title}
+                checked={!!isSelected}
+              />
+            ) : null}
+            {item.icon}
+          </div>
+        }
         primaryText={item.title}
         secondaryText={item.description}
         onClick={() => onClick(item)}
         right={
           item.children && item.children.length > 0 ? (
             <Icon icon="right" color={palette.coolGrey} />
-          ) : (
+          ) : radioPosition !== 'right' ? null : (
             <Radio
               readOnly
               name={item.title}

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -3,7 +3,8 @@ import Button from '../Button'
 import Circle from '../Circle'
 import NestedSelectModal from './Modal';
 import { useState } from 'react'
-
+import Checkbox from '../Checkbox'
+import useBreakpoints, { BreakpointsProvider } from '../hooks/useBreakpoints'
 
 const Image = ({ letter }) => (
   <Circle backgroundColor='var(--melon)'>
@@ -50,8 +51,10 @@ const transformParentItem = item => ({
 })
 
 const StaticExample = () => {
+  const { isMobile } = useBreakpoints()
   return (
     <NestedSelectModal
+      radioPosition={isMobile ? 'left' : 'right'}
       canSelectParent={true}
       onSelect={x => x}
       dismissAction={x => x}
@@ -71,6 +74,7 @@ const isParent = (item, childItem) => {
 }
 
 const InteractiveExample = () => {
+  const [leftRadio, setLeftRadio] = useState(false)
   const [showingModal, setShowingModal] = useState(false)
   const [selectedItem, setSelected] = useState(null)
   const showModal = () => setShowingModal(true)
@@ -86,6 +90,10 @@ const InteractiveExample = () => {
     return false
   }
 
+  const handleClickLeftRadio = () => {
+    setLeftRadio(!leftRadio)
+  }
+
   const handleSelect = item => {
     setSelected(item)
     setTimeout(() => {
@@ -95,6 +103,7 @@ const InteractiveExample = () => {
 
   return (
     <>
+      <Checkbox label='radio to the left' readOnly name='leftRadio' value={leftRadio} checked={leftRadio} onClick={handleClickLeftRadio} />
       { selectedItem ? <>Selected: { selectedItem.title }<br/></> : null }
       <Button label='Select' onClick={showModal} ></Button>
       { showingModal ?
@@ -113,7 +122,7 @@ const InteractiveExample = () => {
 
 <>
   { isTesting()
-    ? <StaticExample />
+    ? <BreakpointsProvider><StaticExample /></BreakpointsProvider>
     : <InteractiveExample /> }
 </>
 ```


### PR DESCRIPTION
Add the ability to position the radio buttons of the nested select to the left instead of the right.

Added a `radioPosition` prop that defaults to `right`.

Edit: This option is screenshotted on mobile on Argos.

cc @joel-costa @fffflo