### PR TITLE
feat: Enable ActionMenu to automatically close itself

### DIFF
--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -54,6 +54,7 @@ const ActionMenuWrapper = ({
 
 const ActionMenu = ({
   children,
+  autoclose,
   className,
   onClose,
   placement,
@@ -65,7 +66,11 @@ const ActionMenu = ({
   const shouldDisplayInline = isDesktop
   const containerRef = React.createRef()
   return (
-    <div className={className} ref={containerRef}>
+    <div
+      className={className}
+      ref={containerRef}
+      onClick={autoclose ? onClose : null}
+    >
       <ActionMenuWrapper
         onClose={onClose}
         inline={shouldDisplayInline}
@@ -93,6 +98,8 @@ ActionMenu.propTypes = {
   className: PropTypes.string,
   /** What to do on close */
   onClose: PropTypes.func,
+  /** Whether the menu should automatically close itself when an item is clicked */
+  autoclose: PropTypes.bool,
   /** Controls the placement of the menu on desktop */
   placement: PropTypes.oneOf([
     'bottom-end',
@@ -118,7 +125,8 @@ ActionMenu.propTypes = {
 
 ActionMenu.defaultProps = {
   placement: 'bottom-start',
-  preventOverflow: false
+  preventOverflow: false,
+  autoclose: false
 }
 
 const ActionMenuHeader = ({ children }) => {
@@ -126,18 +134,10 @@ const ActionMenuHeader = ({ children }) => {
 }
 
 const ActionMenuItem = ({ left, children, right, onClick }) => {
-  const onClickEnhanced = e => {
-    if (onClick) {
-      // we need to stop propagation here so that the menu doesn't close itself
-      e.stopPropagation()
-      onClick()
-    }
-  }
-
   return (
     <Media
       className={styles['c-actionmenu-item']}
-      onClick={onClickEnhanced}
+      onClick={onClick}
       align="top"
     >
       {left && <Img className="u-mh-1">{left}</Img>}

--- a/react/ActionMenu/index.spec.jsx
+++ b/react/ActionMenu/index.spec.jsx
@@ -21,4 +21,36 @@ describe('ActionMenu', () => {
         .getElement()
     ).toMatchSnapshot()
   })
+
+  it('should support auto-closing the menu', () => {
+    const closeMenu = jest.fn()
+    const menuAction1 = jest.fn()
+    const menuAction2 = jest.fn()
+    const menuActionStoppingPropagation = e => {
+      e.stopPropagation()
+      menuAction2()
+    }
+
+    const comp = mount(
+      <ActionMenu onClose={closeMenu} autoclose>
+        <ActionMenuItem onClick={menuAction1}>Item 1</ActionMenuItem>
+        <ActionMenuItem onClick={menuActionStoppingPropagation}>
+          Item 2
+        </ActionMenuItem>
+      </ActionMenu>
+    )
+
+    comp
+      .find(ActionMenuItem)
+      .at(1)
+      .simulate('click')
+    expect(menuAction2).toHaveBeenCalled()
+    expect(closeMenu).not.toHaveBeenCalled()
+    comp
+      .find(ActionMenuItem)
+      .at(0)
+      .simulate('click')
+    expect(menuAction1).toHaveBeenCalled()
+    expect(closeMenu).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
At the moment, the ActionMenu stays open when an item is clicked. This is not the default behavior of most of our menus, where the menu is be closed as soon as an action is picked.

Eventually this should be the default behavior, but I couldn't find a way to make it the default without introducing a breaking change. So this PR adds an `autoclose` prop that can be set for new menus while the old ones are migrated, and after a period we can remove this prop entirely or switch its default value to `true`.

Menus that need updating, off the top of my head: in cozy-sharing, cozy-scanner, cozy-notes.