### PR TITLE
feat: Add ActionMenuRadio

### DIFF
--- a/react/ActionMenu/Readme.md
+++ b/react/ActionMenu/Readme.md
@@ -3,7 +3,7 @@ Use an ActionMenu to show a list of actions. ActionMenus automatically switch th
 ### Classic
 
 ```
-import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu';
+import ActionMenu, { ActionMenuItem, ActionMenuRadio } from 'cozy-ui/transpiled/react/ActionMenu';
 import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton';
 import Icon from 'cozy-ui/transpiled/react/Icon';
 import { Caption } from 'cozy-ui/transpiled/react/Text';
@@ -19,7 +19,7 @@ const hideMenu = () => setState({ menuDisplayed: false });
     <ActionMenu
       onClose={hideMenu}>
       <ActionMenuItem left={<Icon icon='file' />} right={<Icon icon='warning' />}>Item 1</ActionMenuItem>
-      <ActionMenuItem left={<Icon icon='right' />}>Item 2</ActionMenuItem>
+      <ActionMenuItem left={<ActionMenuRadio />}>Item 2</ActionMenuItem>
       <ActionMenuItem left={<Icon icon='file' />}>
         <div>
           Item 3

--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -9,6 +9,7 @@ import withBreakpoints from '../helpers/withBreakpoints'
 import Popper from '@material-ui/core/Popper'
 import { getCssVariableValue } from '../utils/color'
 import PopperContainerContext from '../PopperContainerContext'
+import Radio from '../Radio'
 
 const ActionMenuWrapper = ({
   inline,
@@ -156,6 +157,10 @@ const ActionMenuItem = ({ left, children, right, onClick, className }) => {
   )
 }
 
+const ActionMenuRadio = props => {
+  return <Radio {...props} className={styles['c-actionmenu-radio']} />
+}
+
 ActionMenuItem.propTypes = {
   left: PropTypes.node,
   right: PropTypes.node,
@@ -164,4 +169,4 @@ ActionMenuItem.propTypes = {
   className: PropTypes.string
 }
 export default withBreakpoints()(ActionMenu)
-export { ActionMenuHeader, ActionMenuItem }
+export { ActionMenuHeader, ActionMenuItem, ActionMenuRadio }

--- a/react/ActionMenu/styles.styl
+++ b/react/ActionMenu/styles.styl
@@ -11,3 +11,7 @@
 
 .c-actionmenu-item
     @extends $actionmenu-item
+
+.c-actionmenu-radio
+    @extends $actionmenu-radio
+

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -17,9 +17,7 @@ exports[`ActionMenu should render examples: ActionMenu 1`] = `
             </svg></div>
         </div>
         <div class=\\"styles__media___cSJMp styles__media--top___K9w0I styles__c-actionmenu-item___gODqd\\">
-          <div class=\\"styles__img___3SHpG u-mh-1\\"><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
-              <use xlink:href=\\"#right\\"></use>
-            </svg></div>
+          <div class=\\"styles__img___3SHpG u-mh-1\\"><label class=\\"styles__c-input-radio___XJQt1 styles__c-actionmenu-radio___Km9uj\\"><input type=\\"radio\\" value=\\"\\"><span></span></label></div>
           <div class=\\"styles__bd___1Uv-F u-mr-1\\">Item 2</div>
         </div>
         <div class=\\"styles__media___cSJMp styles__media--top___K9w0I styles__c-actionmenu-item___gODqd\\">

--- a/react/index.js
+++ b/react/index.js
@@ -45,7 +45,8 @@ export { default as MidEllipsis } from './MidEllipsis'
 export {
   default as ActionMenu,
   ActionMenuItem,
-  ActionMenuHeader
+  ActionMenuHeader,
+  ActionMenuRadio
 } from './ActionMenu'
 export { default as Menu, MenuItem, MenuButton } from './Menu'
 export { default as Overlay } from './Overlay'

--- a/stylus/components/action-menu.styl
+++ b/stylus/components/action-menu.styl
@@ -23,3 +23,9 @@ $actionmenu-item
 
     &:hover
         background-color var(--paleGrey)
+
+$actionmenu-radio
+    height 1rem
+    width 1rem
+    margin-top .125rem
+    margin-bottom 0


### PR DESCRIPTION
To be able to put a Radio inside an ActionMenuItem, we need a
specific style.

https://ptbrowne.github.io/cozy-ui/react/#!/ActionMenu

<img width="265" alt="image" src="https://user-images.githubusercontent.com/465582/80725486-6f7f5500-8b03-11ea-9149-3b45e4b0beb6.png">
