### PR TITLE
Improve theme support for Breadcrumb / Figure

### DIFF
--- a/docs/ThemeChooser.jsx
+++ b/docs/ThemeChooser.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react'
+import CozyTheme from '../react/CozyTheme'
+
+const ThemeChooser = ({ children }) => {
+  const [theme, setTheme] = useState('normal')
+  const handleChange = ev => setTheme(ev.target.value)
+  return (
+    <>
+      theme:{' '}
+      <select onChange={handleChange}>
+        <option value="normal">normal</option>
+        <option value="inverted">inverted</option>
+      </select>
+      <CozyTheme variant={theme}>{children}</CozyTheme>
+    </>
+  )
+}
+
+export default ThemeChooser

--- a/docs/components/SectionsRenderer.jsx
+++ b/docs/components/SectionsRenderer.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import DefaultSectionsRenderer from 'react-styleguidist/lib/client/rsg-components/Sections/SectionsRenderer'
-import IconSprite from '../react/Icon/Sprite'
+import IconSprite from '../../react/Icon/Sprite'
 
-export default class IconSpriteInjector extends Component {
+export default class SectionsRenderer extends Component {
   render() {
     return (
       <>

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -185,7 +185,7 @@ module.exports = {
     }
   },
   styleguideComponents: {
-    SectionsRenderer: path.join(__dirname, 'IconSpriteInjector.jsx')
+    SectionsRenderer: path.join(__dirname, 'components/SectionsRenderer.jsx'),
   },
   theme: {
     fontFamily: {

--- a/react/Breadcrumbs/Readme.md
+++ b/react/Breadcrumbs/Readme.md
@@ -8,6 +8,7 @@ context.
 import { Component } from 'react'
 import Breadcrumbs from '.';
 import Icon from '../Icon'
+import ThemeChooser from '../../docs/ThemeChooser'
 
 const items = [
   { 
@@ -32,10 +33,10 @@ const items = [
 
 const Items = ({ items, onClickItem }) => {
   return items.map(item => (
-    <div style={{ height: '2rem', display: 'flex', alignItems: 'center'}} className={item.items ? 'u-c-pointer' : null } onClick={() => onClickItem(item)}>
+    <div style={{ color: 'var(--primaryTextColor)', height: '2rem', display: 'flex', alignItems: 'center'}} className={item.items ? 'u-c-pointer' : null } onClick={() => onClickItem(item)}>
       <Icon
         icon={!item.items ? 'file' : 'folder'}
-        className='u-mr-half' color='var(--primaryColor)' />
+        className='u-mr-half' color='var(--primaryTextColor)' />
       { item.name }
     </div>
   ))
@@ -71,12 +72,16 @@ class Example extends Component {
   render() {
     const { breadcrumbs } = this.state
     const last = breadcrumbs[breadcrumbs.length - 1]
-    return <div>
+    return <div className='u-p-1'>
       <Breadcrumbs items={breadcrumbs} />
       <Items items={last.items} onClickItem={this.handleGoDown} />
     </div>
   }
 }
 
-<Example />
+<>
+  <ThemeChooser>
+    <Example />
+  </ThemeChooser>
+</>
 ```

--- a/react/Breadcrumbs/index.jsx
+++ b/react/Breadcrumbs/index.jsx
@@ -47,20 +47,13 @@ BreadcrumbItem.propTypes = {
   showSeparator: PropTypes.bool
 }
 
-const Breadcrumbs = ({ items, className, theme, style }) => {
+const Breadcrumbs = ({ items, className, style }) => {
   const previousItems = items.slice(0, -1)
   const [lastPreviousItem] = previousItems.slice(-1)
   const [currentItem] = items.slice(-1)
 
   return (
-    <div
-      style={style}
-      className={cx(
-        styles.Breadcrumb,
-        className,
-        styles[`Breadcrumb--${theme}`]
-      )}
-    >
+    <div style={style} className={cx(styles.Breadcrumb, className)}>
       {items.length > 1 && (
         <Icon
           icon={'left'}
@@ -90,13 +83,8 @@ const Breadcrumbs = ({ items, className, theme, style }) => {
   )
 }
 
-Breadcrumbs.defaultProps = {
-  theme: 'default'
-}
-
 Breadcrumbs.propTypes = {
   className: PropTypes.string,
-  theme: PropTypes.oneOf(['default', 'primary']),
   items: PropTypes.arrayOf(PropTypes.shape(itemPropTypes))
 }
 

--- a/react/Breadcrumbs/styles.styl
+++ b/react/Breadcrumbs/styles.styl
@@ -4,25 +4,14 @@
 .Breadcrumb
     display flex
     align-items center
+    color var(--primaryTextColor)
 
 .Breadcrumb__previousButton
     margin-right (spacing_values.m)
     cursor pointer
 
-    .Breadcrumb--default &
-        color var(--charcoalGrey)
-
-    .Breadcrumb--primary &
-        color var(--primaryContrastTextColor)
-
 .Breadcrumb__items
     flex-grow 1
-
-    .Breadcrumb--default &
-        color var(--charcoalGrey)
-
-    .Breadcrumb--primary &
-        color var(--primaryContrastTextColor)
 
 .Breadcrumb__previousItems
     display flex

--- a/react/CozyTheme/Readme.md
+++ b/react/CozyTheme/Readme.md
@@ -1,7 +1,7 @@
 An area of a page can have a different CozyTheme and components inside
 will be automatically styled.
 
-- At the moment only some Buttons support this.
+- At the moment only a few components support this (Buttons / Breadcrumbs / Figure).
 
 
 ```

--- a/react/CozyTheme/Readme.md
+++ b/react/CozyTheme/Readme.md
@@ -29,6 +29,13 @@ const themesSupportingContext = [
   )}
   <SubTitle className='u-white'>BarButton</SubTitle>
   <BarButton icon='dots' />
+  <div className='u-bg-white u-p-1'>
+    We can always go back to normal theme if a child must "get out"
+    of the theme.
+    <CozyTheme variant='normal'>
+      <Button className='u-ml-0 u-mt-half' theme='primary' label='Primary button' />
+    </CozyTheme>
+  </div>
 </CozyTheme>
 ```
 

--- a/react/CozyTheme/index.jsx
+++ b/react/CozyTheme/index.jsx
@@ -1,14 +1,20 @@
 import React, { createContext, useContext } from 'react'
 import MuiCozyTheme from '../MuiCozyTheme'
 import styles from './styles.styl'
+import paletteStyles from '../../stylus/settings/palette.styl'
 import cx from 'classnames'
 
 export const CozyThemeContext = createContext()
 
+const allStyles = {
+  ...styles,
+  'CozyTheme--normal': paletteStyles['CozyTheme--normal']
+}
+
 const CozyTheme = ({ variant, children, className }) => (
   <CozyThemeContext.Provider value={variant}>
     <MuiCozyTheme variant={variant}>
-      <div className={cx(className, styles[`CozyTheme--${variant}`])}>
+      <div className={cx(className, allStyles[`CozyTheme--${variant}`])}>
         {children}
       </div>
     </MuiCozyTheme>

--- a/react/CozyTheme/styles.styl
+++ b/react/CozyTheme/styles.styl
@@ -3,6 +3,9 @@ $translucentWhite2=rgba(255, 255, 255, 0.88)
 
 .CozyTheme--inverted
     background: var(--primaryColor)
+
+    --primaryTextColor: var(--primaryContrastTextColor)
+    --secondaryTextColor: var(--primaryContrastTextColor)
     --barIconColor var(--primaryContrastTextColor)
     --barIconColorDisabled $translucentWhite2
 

--- a/react/Figure/Figure.jsx
+++ b/react/Figure/Figure.jsx
@@ -23,7 +23,6 @@ const Figure = props => {
     warningLimit,
     signed,
     className,
-    theme = 'default',
     total,
     totalClassName,
     currencyClassName,
@@ -50,7 +49,6 @@ const Figure = props => {
   return (
     <div
       className={cx(
-        styles[theme],
         {
           [stylePositive]: isTotalPositive && coloredPositive,
           [styleNegative]:

--- a/react/Figure/Figure.styl
+++ b/react/Figure/Figure.styl
@@ -1,29 +1,26 @@
 @require 'settings/breakpoints'
 
-.default
-    &.Figure-currency
-        color var(--coolGrey)
 
-    &.Figure-content--positive
+&.Figure-currency
+    color var(--secondaryTextColor)
+
+&.Figure-content--positive
+    color var(--emerald)
+
+    .Figure-currency
         color var(--emerald)
 
-        .Figure-currency
-            color var(--emerald)
+&.Figure-content--negative
+    color var(--pomegranate)
 
-    &.Figure-content--negative
+    .Figure-currency
         color var(--pomegranate)
 
-        .Figure-currency
-            color var(--pomegranate)
+&.Figure-content--warning
+    color var(--texasRose)
 
-    &.Figure-content--warning
+    .Figure-currency
         color var(--texasRose)
-
-        .Figure-currency
-            color var(--texasRose)
-
-.primary
-    color var(--white)
 
 .Figure-total
     font-weight    900

--- a/react/Figure/FigureBlock.md
+++ b/react/Figure/FigureBlock.md
@@ -1,24 +1,34 @@
 Pour montrer une KPI importante.
 
 ```jsx
-import { FigureBlock } from 'cozy-ui/transpiled/react/Figure';
-<div>
-  <FigureBlock
-    label='Balance totale'
-    total={1000}
-    symbol='€'
-    coloredPositive coloredNegative signed />
+import { FigureBlock } from 'cozy-ui/transpiled/react/Figure'
+import ThemeChooser from '../../docs/ThemeChooser'
 
-  <FigureBlock
-    label='Balance totale (negative number)'
-    total={-1000}
-    symbol='€'
-    coloredPositive coloredNegative signed />
+const Example = () => {
+  return (
+    <div>
+      <FigureBlock
+        label='Balance totale'
+        total={1000}
+        symbol='€'
+        coloredPositive coloredNegative signed />
 
-  <FigureBlock
-    label='Balance totale (no color)'
-    total={-1000}
-    symbol='€'
-    signed />
-</div>
+      <FigureBlock
+        label='Balance totale (negative number)'
+        total={-1000}
+        symbol='€'
+        coloredPositive coloredNegative signed />
+
+      <FigureBlock
+        label='Balance totale (no color)'
+        total={-1000}
+        symbol='€'
+        signed />
+    </div>
+  )
+}
+
+<ThemeChooser>
+  <Example />
+</ThemeChooser>
 ```

--- a/react/Figure/FigureBlock.styl
+++ b/react/Figure/FigureBlock.styl
@@ -1,7 +1,7 @@
 @require 'settings/breakpoints'
 
 .FigureBlock
-    color var(--charcoalGrey)
+    color var(--primaryTextColor)
 
 .FigureBlock-figure
     font-size 2rem

--- a/react/Figure/__snapshots__/Figure.spec.jsx.snap
+++ b/react/Figure/__snapshots__/Figure.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Figure should render correctly -100 coloredPositive: false, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -14,7 +14,7 @@ exports[`Figure should render correctly -100 coloredPositive: false, coloredNega
 
 exports[`Figure should render correctly -100 coloredPositive: false, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--warning___1Pn6n"
+  className="Figure__Figure-content--warning___1Pn6n"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -26,7 +26,7 @@ exports[`Figure should render correctly -100 coloredPositive: false, coloredNega
 
 exports[`Figure should render correctly -100 coloredPositive: false, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--negative___3ACbA"
+  className="Figure__Figure-content--negative___3ACbA"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -38,7 +38,7 @@ exports[`Figure should render correctly -100 coloredPositive: false, coloredNega
 
 exports[`Figure should render correctly -100 coloredPositive: false, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--warning___1Pn6n"
+  className="Figure__Figure-content--warning___1Pn6n"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -50,7 +50,7 @@ exports[`Figure should render correctly -100 coloredPositive: false, coloredNega
 
 exports[`Figure should render correctly -100 coloredPositive: true, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -62,7 +62,7 @@ exports[`Figure should render correctly -100 coloredPositive: true, coloredNegat
 
 exports[`Figure should render correctly -100 coloredPositive: true, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--warning___1Pn6n"
+  className="Figure__Figure-content--warning___1Pn6n"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -74,7 +74,7 @@ exports[`Figure should render correctly -100 coloredPositive: true, coloredNegat
 
 exports[`Figure should render correctly -100 coloredPositive: true, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--negative___3ACbA"
+  className="Figure__Figure-content--negative___3ACbA"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -86,7 +86,7 @@ exports[`Figure should render correctly -100 coloredPositive: true, coloredNegat
 
 exports[`Figure should render correctly -100 coloredPositive: true, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--warning___1Pn6n"
+  className="Figure__Figure-content--warning___1Pn6n"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -98,7 +98,7 @@ exports[`Figure should render correctly -100 coloredPositive: true, coloredNegat
 
 exports[`Figure should render correctly 4 coloredPositive: false, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -110,7 +110,7 @@ exports[`Figure should render correctly 4 coloredPositive: false, coloredNegativ
 
 exports[`Figure should render correctly 4 coloredPositive: false, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -122,7 +122,7 @@ exports[`Figure should render correctly 4 coloredPositive: false, coloredNegativ
 
 exports[`Figure should render correctly 4 coloredPositive: false, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -134,7 +134,7 @@ exports[`Figure should render correctly 4 coloredPositive: false, coloredNegativ
 
 exports[`Figure should render correctly 4 coloredPositive: false, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -146,7 +146,7 @@ exports[`Figure should render correctly 4 coloredPositive: false, coloredNegativ
 
 exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -158,7 +158,7 @@ exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative
 
 exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -170,7 +170,7 @@ exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative
 
 exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -182,7 +182,7 @@ exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative
 
 exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -194,7 +194,7 @@ exports[`Figure should render correctly 4 coloredPositive: true, coloredNegative
 
 exports[`Figure should render correctly 100 coloredPositive: false, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -206,7 +206,7 @@ exports[`Figure should render correctly 100 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 100 coloredPositive: false, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -218,7 +218,7 @@ exports[`Figure should render correctly 100 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 100 coloredPositive: false, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -230,7 +230,7 @@ exports[`Figure should render correctly 100 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 100 coloredPositive: false, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -242,7 +242,7 @@ exports[`Figure should render correctly 100 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 100 coloredPositive: true, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -254,7 +254,7 @@ exports[`Figure should render correctly 100 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 100 coloredPositive: true, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -266,7 +266,7 @@ exports[`Figure should render correctly 100 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 100 coloredPositive: true, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -278,7 +278,7 @@ exports[`Figure should render correctly 100 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 100 coloredPositive: true, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -290,7 +290,7 @@ exports[`Figure should render correctly 100 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 500 coloredPositive: false, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -302,7 +302,7 @@ exports[`Figure should render correctly 500 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 500 coloredPositive: false, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -314,7 +314,7 @@ exports[`Figure should render correctly 500 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 500 coloredPositive: false, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -326,7 +326,7 @@ exports[`Figure should render correctly 500 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 500 coloredPositive: false, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX"
+  className=""
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -338,7 +338,7 @@ exports[`Figure should render correctly 500 coloredPositive: false, coloredNegat
 
 exports[`Figure should render correctly 500 coloredPositive: true, coloredNegative: false, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -350,7 +350,7 @@ exports[`Figure should render correctly 500 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 500 coloredPositive: true, coloredNegative: false, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -362,7 +362,7 @@ exports[`Figure should render correctly 500 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 500 coloredPositive: true, coloredNegative: true, coloredWarning: false 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"
@@ -374,7 +374,7 @@ exports[`Figure should render correctly 500 coloredPositive: true, coloredNegati
 
 exports[`Figure should render correctly 500 coloredPositive: true, coloredNegative: true, coloredWarning: true 1`] = `
 <div
-  className="Figure__default___2A1eX Figure__Figure-content--positive___1qyd8"
+  className="Figure__Figure-content--positive___1qyd8"
 >
   <span
     className="Figure__Figure-total___MZ7Xt"

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -3,16 +3,7 @@
 @require '../utilities/text'
 @require '../tools/mixins'
 
-:root
-    --regularButtonPrimaryColor: var(--primaryColor)
-    --regularButtonSecondaryColor: var(--primaryColor)
-    --regularButtonActiveColor: var(--primaryColorDark)
-    --regularButtonConstrastColor: var(--primaryContrastTextColor)
 
-    --secondaryButtonPrimaryColor: var(--white)
-    --secondaryButtonSecondaryColor: var(--silver)
-    --secondaryButtonActiveColor: var(--silver)
-    --secondaryButtonContrastColor: var(--black)
 /*------------------------------------*\
   Variants
 \*------------------------------------*/

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -228,7 +228,7 @@ $form-progress
 // New styles
 $label
     text-transform uppercase
-    color var(--coolGrey)
+    color var(--secondaryTextColor)
     font-size rem(13)
     font-weight bold
     line-height rem(16)

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -156,5 +156,7 @@
     --primaryColorLight #5C9DF5 // lighten(dodgerBlue, 24)
     --primaryColorLighter #4B93F7
     --primaryColorLightest #9FC4FB
+    --primaryTextColor var(--charcoalGrey)
+    --secondaryTextColor var(--coolGrey)
     --primaryContrastTextColor var(--white)
 // @stylint on

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -151,6 +151,7 @@
 
     Styleguide Settings.theme.primary
     */
+:root, .CozyTheme--normal
     --primaryColor var(--dodgerBlue)
     --primaryColorDark var(--scienceBlue)
     --primaryColorLight #5C9DF5 // lighten(dodgerBlue, 24)
@@ -159,4 +160,14 @@
     --primaryTextColor var(--charcoalGrey)
     --secondaryTextColor var(--coolGrey)
     --primaryContrastTextColor var(--white)
+
+    --regularButtonPrimaryColor: var(--primaryColor)
+    --regularButtonSecondaryColor: var(--primaryColor)
+    --regularButtonActiveColor: var(--primaryColorDark)
+    --regularButtonConstrastColor: var(--primaryContrastTextColor)
+
+    --secondaryButtonPrimaryColor: var(--white)
+    --secondaryButtonSecondaryColor: var(--silver)
+    --secondaryButtonActiveColor: var(--silver)
+    --secondaryButtonContrastColor: var(--black)
 // @stylint on


### PR DESCRIPTION
- Use CSS variables for text color
- Breadcrumbs and Figure use those variables
- ThemeChooser component for easy switch between themes in styleguide
  (per component for now, would love to have it globally in the sidebar)

Preview: https://ptbrowne.github.io/cozy-ui/react/#!/Breadcrumbs

Edit: added the preview