### PR TITLE
feat: Rounder style for action menu in bottom drawer

### DIFF
--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -62,9 +62,9 @@ const ActionMenu = ({
   preventOverflow,
   anchorElRef,
   containerElRef,
-  breakpoints: { isDesktop }
+  breakpoints: { isMobile }
 }) => {
-  const shouldDisplayInline = isDesktop
+  const shouldDisplayInline = !isMobile
   const containerRef = React.createRef()
   return (
     <div
@@ -86,7 +86,7 @@ const ActionMenu = ({
           })}
         >
           {React.Children.map(children, child =>
-            child && child.type === ActionMenuHeader && isDesktop ? null : child
+            child && child.type === ActionMenuHeader && !isMobile ? null : child
           )}
         </div>
       </ActionMenuWrapper>

--- a/react/BottomDrawer/styles.styl
+++ b/react/BottomDrawer/styles.styl
@@ -1,6 +1,7 @@
 @require 'tools/mixins'
 @require 'settings/spaces'
 @require 'settings/z-index'
+@require 'settings/breakpoints'
 @require 'generic/animations'
 
 .with-transition
@@ -12,7 +13,7 @@
     bottom         rem(9)
     bottom         env(safe-area-inset-bottom) // @stylint ignore
     left           0
-    width          'calc(100% - %s)' % (spacing_values.m * 2)
-    margin         0 spacing_values.m
-    padding-bottom rem(5)
-    box-sizing border-box
+    right          0
+    width          100%
+    margin         0
+

--- a/stylus/components/action-menu.styl
+++ b/stylus/components/action-menu.styl
@@ -1,12 +1,21 @@
 @require './popover.styl'
 @require '../tools/mixins'
 @require '../settings/spaces.styl'
+@require '../settings/breakpoints.styl'
+
+$smallScreenPaddingTop=.5rem
 
 $actionmenu
     @extend $popover
     color var(--charcoalGrey)
     hr
         margin-top 0
+
+    +small-screen()
+        border 0
+        border-radius 1rem 1rem 0 0
+        padding-top $smallScreenPaddingTop
+        overflow hidden
 
 $actionmenu--inline
     width rem(256)
@@ -16,6 +25,7 @@ $actionmenu-header
     border-bottom rem(1) solid var(--silver)
     padding rem(16)
     min-height rem(64)
+    margin-top -($smallScreenPaddingTop)
 
 $actionmenu-item
     padding spacing_values.s 0


### PR DESCRIPTION
ActionMenu inside a BottomDrawer in latest designs is rounder and has no margin from the
screen.