### PR TITLE
Example with focus trap

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "enzyme-to-json": "3.4.0",
     "eslint": "4.19.1",
     "eslint-config-cozy-app": "0.5.1",
+    "focus-trap-react": "^6.0.0",
     "git-directory-deploy": "1.5.1",
     "http-server": "0.11.1",
     "husky": "0.14.3",

--- a/react/Modal/Readme.md
+++ b/react/Modal/Readme.md
@@ -403,9 +403,6 @@ const toggle = () => setState({ modalOpened: !state.modalOpened });
 
 ```
 
-
-
-
 ### Portal modals
 
 You can use the `into` prop to wrap the `Modal` in a `Portal`. This `prop` will be set to `"body"` in future versions so try to put it now to check if your Modal does not break when rendered in a Portal.
@@ -419,5 +416,42 @@ initialState = { modalOpened: false};
     Toggle modal
   </button>
   {state.modalOpened && <Modal into='body' title='Ada Lovelace' description={content.ada.short} dismissAction={() => setState({ modalOpened: false })} /> }
+</div>
+```
+
+### Focus trap
+
+FocusTrap can be useful used in conjuction with the Modal.
+
+```jsx
+import FocusTrap from 'focus-trap-react'
+import Modal, { ModalContent, ModalButtons } from 'cozy-ui/transpiled/react/Modal';
+import Button from 'cozy-ui/transpiled/react/Button';
+
+initialState = { modalOpened: false};
+
+const toggleModal = () => setState({ modalOpened: !state.modalOpened })
+const hideModal = () => setState({ modalOpened: false })
+
+const MyModal = ({ dismissAction }) => {
+  return <Modal dismissAction={dismissAction}>
+    <FocusTrap>
+      <ModalContent>
+        <p>
+          Buttons below can be cycled with Tab and focus will not escape
+          the modal.
+        </p>
+        <Button label="OK" onClick={dismissAction} />
+        <Button theme="secondary" label="Cancel" onClick={dismissAction} />
+      </ModalContent>
+    </FocusTrap>
+  </Modal>
+} ;
+
+<div>
+  <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  {state.modalOpened && <MyModal dismissAction={hideModal} />}
 </div>
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -6707,6 +6707,21 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap-react@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-6.0.0.tgz#3f5a9f68447dd374d22388fb4c50018be83e74a5"
+  integrity sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==
+  dependencies:
+    focus-trap "^4.0.2"
+
+focus-trap@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-4.0.2.tgz#4ee2b96547c9ea0e4252a2d4b2cca68944194663"
+  integrity sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==
+  dependencies:
+    tabbable "^3.1.2"
+    xtend "^4.0.1"
+
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -16041,6 +16056,11 @@ symbol@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/symbol/-/symbol-0.2.3.tgz#3b9873b8a901e47c6efe21526a3ac372ef28bbc7"
   integrity sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=
+
+tabbable@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.2.tgz#f2d16cccd01f400e38635c7181adfe0ad965a4a2"
+  integrity sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
We use focus trap in the cozy store. In the process of trying to
understand a crash, I developed an example and thought it could
be useful to keep it here. It could serve as a base to further
integrate focus trap so that it is automatically used by the
Modal buttons or content. What do you think ?

Info: The crash in question was in cozy-store where focus-trap
could not find any focusable element since the modal was loading
and a spinner was displayed. I have not found why it would not
crash bfore the update to cozy-ui 34 but I have seen that the
close button was focused by focus-trap-react before the update
to cozy-ui 34. After the update the close button was not
focused. Maybe the change to portal the content by default
was the triggerer for the error.

Edit: add link to example https://ptbrowne.github.io/cozy-ui/react/#!/Modal/35