### PR TITLE
feat: Make button textTransform and borderRadius overridable

### DIFF
--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -72,7 +72,7 @@ $button
     margin           0 rem(4)
     border-width     rem(1)
     border-style     solid
-    border-radius    rem(2)
+    border-radius    var(--buttonBorderRadius)
     min-height       rem(40)
     min-width        rem(112)
     padding          rem(3 16)
@@ -81,7 +81,7 @@ $button
     font-size        rem(14)
     font-weight      bold
     line-height      1
-    text-transform   uppercase
+    text-transform   var(--buttonTextTransform)
     text-decoration  none
     cursor           pointer
     align-items      center

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -1,3 +1,5 @@
+@require '../tools/mixins'
+
 // @stylint off
 /*------------------------------------*\
   Palette
@@ -177,4 +179,7 @@
     --errorColor: var(--pomegranate)
     --validColor: var(--emerald)
     --warnColor: var(--texasRose)
+
+    --buttonTextTransform uppercase
+    --buttonBorderRadius rem(2)
 // @stylint on


### PR DESCRIPTION
Use CSS custom properties to customize button's border radius
and text transform.