### PR TITLE
Use relative paths everywhere

### DIFF
--- a/react/AppIcon/Preloader.js
+++ b/react/AppIcon/Preloader.js
@@ -42,7 +42,7 @@ const _getAppIconURL = (app, domain, secure) => {
 }
 
 const _getInstalledIconPath = app => {
-  return app.links && app.links.icon
+  return app && app.links && app.links.icon
 }
 
 const _getRegistryIconPath = app => {
@@ -51,6 +51,7 @@ const _getRegistryIconPath = app => {
   }
 
   return (
+    app &&
     app.latest_version &&
     app.latest_version.version &&
     `/registry/${app.slug}/${app.latest_version.version}/icon`

--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -8,13 +8,13 @@ import {
   openDeeplinkOrRedirect,
   isAndroid
 } from 'cozy-device-helper'
+
 import {
   generateUniversalLink,
   generateWebLink,
   getUniversalLinkDomain
 } from './native'
-
-import { NATIVE_APP_INFOS } from 'cozy-ui/transpiled/react/AppLinker/native.config'
+import { NATIVE_APP_INFOS } from './native.config'
 import expiringMemoize from './expiringMemoize'
 
 const expirationDelay = 10 * 1000

--- a/react/AppSections/components/SmallAppItem.jsx
+++ b/react/AppSections/components/SmallAppItem.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import AppIcon from 'cozy-ui/react/AppIcon'
-import { translate } from 'cozy-ui/react/I18n'
-import styles from './SmallAppItem.styl'
-
+import AppIcon from '../../AppIcon'
+import { translate } from '../../I18n'
 import { getCurrentStatusLabel } from '../status'
 import { AppDoctype } from '../../proptypes'
+
+import styles from './SmallAppItem.styl'
 
 let dataset
 const getDataset = () => {

--- a/react/HistoryRow/index.jsx
+++ b/react/HistoryRow/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
-import { Caption, SubTitle, Bold } from 'cozy-ui/transpiled/react/Text'
-import { Icon, Circle } from 'cozy-ui/transpiled/react'
-import palette from 'cozy-ui/transpiled/react/palette'
+import Circle from './Circle'
+import { Media, Bd, Img } from '../Media'
+import { Caption, SubTitle, Bold } from '../Text'
+import Icon from '../Icon'
+import palette from '../palette'
 
 import styles from './styles.styl'
 

--- a/react/NestedSelect/Row.jsx
+++ b/react/NestedSelect/Row.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
-import { Media, Bd, Img, Icon } from 'cozy-ui/transpiled/react'
-import styles from './Row.styl'
 import cx from 'classnames'
+
+import { Media, Bd, Img } from '../Media'
+import Icon from '../Icon'
+import styles from './Row.styl'
 
 export const RowBody = ({ children }) => (
   <Bd className="u-ellipsis">{children}</Bd>

--- a/react/PushClientButton/index.jsx
+++ b/react/PushClientButton/index.jsx
@@ -3,7 +3,7 @@ import styles from './styles.styl'
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { Icon } from 'cozy-ui/transpiled/react'
+import Icon from '../react/Icon'
 
 const ButtonClient = props => {
   const { label, href, onClick, className } = props

--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -1,18 +1,19 @@
 import React, { Component } from 'react'
-import classNames from 'classnames'
-import { translate } from 'cozy-ui/react/I18n'
+import cx from 'classnames'
+import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
+import { splitFilename } from 'cozy-client/dist/models/file'
+
+import { translate } from '../I18n'
 import Icon from '../Icon'
 import Spinner from '../Spinner'
 import withLocales from '../I18n/withLocales'
 import { useI18n } from '../I18n'
 import ThresholdBar from '../ThresholdBar'
 import { Caption } from '../Text'
-import palette from '../../stylus/settings/palette.json'
-import styles from './styles.styl'
-import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
-import cx from 'classnames'
-import { splitFilename } from 'cozy-client/dist/models/file'
 import { Media, Bd, Img } from '../Media'
+import palette from '../../stylus/settings/palette.json'
+
+import styles from './styles.styl'
 import localeEn from './locales/en.json'
 import localeEs from './locales/es.json'
 import localeFr from './locales/fr.json'
@@ -126,7 +127,7 @@ const Item = translate()(
     return (
       <Media
         data-test-id="upload-queue-item"
-        className={classNames('u-ph-1', styles['upload-queue-item'], {
+        className={cx('u-ph-1', styles['upload-queue-item'], {
           [styles['upload-queue-item--done']]: done,
           [styles['upload-queue-item--error']]: error
         })}
@@ -179,7 +180,7 @@ class UploadQueue extends Component {
     return (
       <div
         data-test-id="upload-queue"
-        className={classNames(styles['upload-queue'], {
+        className={cx(styles['upload-queue'], {
           [styles['upload-queue--visible']]: queue.length !== 0,
           [styles['upload-queue--collapsed']]: collapsed,
           [styles['upload-queue--popover']]: popover
@@ -213,10 +214,7 @@ class UploadQueue extends Component {
                   total: queue.length
                 })}
               </span>
-              <button
-                className={classNames(styles['btn-close'])}
-                onClick={purgeQueue}
-              >
+              <button className={cx(styles['btn-close'])} onClick={purgeQueue}>
                 {t('close')}
               </button>
             </div>

--- a/react/Viewer/ShortcutViewer.jsx
+++ b/react/Viewer/ShortcutViewer.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
-import { useI18n } from '../I18n'
 import { useClient, useFetchShortcut } from 'cozy-client'
 import get from 'lodash/get'
+
+import { ButtonLink } from '../Button'
+import { useI18n } from '../I18n'
 import NoViewer from './NoViewer'
 import { FileDoctype } from '../proptypes'
 


### PR DESCRIPTION
An import was still using cozy-ui/react directly. We must use relative paths when importing other componetns. Those relative paths are expanded into `cozy-ui/transpiled/react` paths at transpile time. 