### PR TITLE
feat: Add missing WizardErrors that was lost during migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # General code owners
-* @ptbrowne @y-lohse
+* @ptbrowne @y-lohse @crash--

--- a/react/Wizard/Readme.md
+++ b/react/Wizard/Readme.md
@@ -7,7 +7,8 @@ import {
   WizardNextButton,
   WizardTitle,
   WizardMain,
-  WizardFooter
+  WizardFooter,
+  WizardErrors
 } from '.'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Field from 'cozy-ui/transpiled/react/Field'
@@ -39,6 +40,9 @@ const WizardExample = ({ onNext, onRegister }) => {
       <WizardMain>
         <Field label='Login' type='text' placeholder='dalailama@cozycloud.cc' />
         <Field label='Password' type='text' />
+        <WizardErrors tag='p'>
+          There is an error
+        </WizardErrors>
       </WizardMain>
       <WizardFooter className={isTiny ? 'u-mt-auto' : 'u-pb-2'}>
         <WizardNextButton

--- a/react/Wizard/index.jsx
+++ b/react/Wizard/index.jsx
@@ -130,7 +130,7 @@ export const WizardDualField = ({ children, hasFocus, hasError }) => {
   )
 }
 
-export const DualFieldWrapper = ({ children }) => {
+export const WizardDualFieldWrapper = ({ children }) => {
   return <div className={styles['wizard-dualfield-wrapper']}>{children}</div>
 }
 

--- a/react/Wizard/index.jsx
+++ b/react/Wizard/index.jsx
@@ -163,3 +163,19 @@ export const WizardNotice = ({
     </Component>
   )
 }
+
+export const WizardErrors = ({
+  children,
+  className,
+  tag: Component,
+  ...props
+}) => {
+  return (
+    <Component
+      className={cx(styles['wizard-errors'], 'u-error', className)}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}


### PR DESCRIPTION
Display errors in red in italic. Can be used with a custom Component with the `tag` prop, which can be used for example to use ReactMarkdown.

<img width="579" alt="image" src="https://user-images.githubusercontent.com/465582/87947005-0aecea00-caa3-11ea-8b46-b63813d7e830.png">
