### PR TITLE
fix: Import Intersection-observer polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "watch:doc:kss": "nodemon --ext styl,md --watch stylus --exec 'yarn build:doc:kss && http-server build/styleguide -p 4242'"
   },
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "intersection-observer"
   ],
   "devDependencies": {
     "@babel/cli": "7.7.4",
@@ -136,6 +137,7 @@
     "classnames": "^2.2.5",
     "date-fns": "^1.28.5",
     "hammerjs": "^2.0.8",
+    "intersection-observer": "0.11.0",
     "node-polyglot": "^2.2.2",
     "normalize.css": "^7.0.0",
     "react-hot-loader": "^4.3.11",

--- a/react/LoadMore/index.jsx
+++ b/react/LoadMore/index.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import Button from '../Button'
 import Spinner from '../Spinner'
 
+import 'intersection-observer' // polyfill for safari (mobile and desktop)
+
 const LoadMore = ({ fetchMore, label }) => {
   const [isLoading, setIsLoading] = useState(false)
   const elementRef = useRef()

--- a/yarn.lock
+++ b/yarn.lock
@@ -8048,6 +8048,11 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
+intersection-observer@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.11.0.tgz#f4ea067070326f68393ee161cc0a2ca4c0040c6f"
+  integrity sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ==
+
 into-stream@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-4.0.0.tgz#ef10ee2ffb6f78af34c93194bbdc36c35f7d8a9d"


### PR DESCRIPTION
Since LoadMore use Intersection Observer (and IO doesn't work on Safari), it seems to make sense that LoadMore requires the polyfill itself. 