### PR TITLE
Fix nav color text on mobile if hovered

### DIFF
--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -126,7 +126,7 @@ $nav-link
 
     // Prevent double tap on tablets
     @media not all and (pointer: fine)
-        &:hover
+        &:hover:not(.is-active)
             color var(--navTextColor)
 
 


### PR DESCRIPTION
A last :hover would make the text the normal color even
if the link was active.

Can be viewed here : https://ptbrowne.github.io/cozy-ui/react/#!/Sidebar

`--navTextActiveColor: red` can be set on body to check this behavior.

When the link is active, it should be red even with the mobile mode activated in the devtools, and with the pointer hovering the link.