### PR TITLE
chore: Update travis node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 matrix:
   fast_finish: true
 node_js:
-  - '8'
+  - '10'
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Travis is still using node 8.