### PR TITLE
feat: Use cozy-interapp to provide intents

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@popperjs/core": "^2.4.4",
     "body-scroll-lock": "^2.5.8",
     "classnames": "^2.2.5",
+    "cozy-interapp": "0.5.4",
     "date-fns": "^1.28.5",
     "hammerjs": "^2.0.8",
     "intersection-observer": "0.11.0",

--- a/react/IntentIframe/IntentIframe.jsx
+++ b/react/IntentIframe/IntentIframe.jsx
@@ -1,6 +1,8 @@
-/* global cozy */
 import React from 'react'
 import PropTypes from 'prop-types'
+import { Intents } from 'cozy-interapp'
+import { withClient } from 'cozy-client'
+
 import Spinner from '../Spinner'
 import styles from './styles.styl'
 
@@ -15,9 +17,23 @@ class IntentIframe extends React.Component {
   state = { loading: false }
 
   componentDidMount() {
-    const { action, data, type, onCancel, onError, onTerminate } = this.props
+    const {
+      action,
+      data,
+      type,
+      onCancel,
+      onError,
+      onTerminate,
+      client
+    } = this.props
 
-    const create = this.props.create || cozy.client.intents.create
+    let create
+    if (this.props.create) {
+      create = this.props.create
+    } else {
+      const intents = new Intents({ client })
+      create = intents.create
+    }
 
     this.setState({ loading: true })
     create(action, type, {
@@ -70,4 +86,4 @@ IntentIframe.defaultProps = {
   data: {}
 }
 
-export default IntentIframe
+export default withClient(IntentIframe)

--- a/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
+++ b/react/IntentModal/test/__snapshots__/intentModal.spec.js.snap
@@ -13,7 +13,7 @@ exports[`IntentModal component renders as expected 1`] = `
   secondaryType="secondary"
   size="small"
 >
-  <IntentIframe
+  <withClient(IntentIframe)
     action="ANY"
     create={[MockFunction createMock]}
     data={

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,6 +4715,11 @@ cozy-doctypes@^1.69.0:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
+cozy-interapp@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"
+  integrity sha512-f0UaKpBkRUnIKgAWND0e1IwfTTINjizlgDmfQwX3aMyWp8t9wX0xkNFn53TSyKUoBUnfovrclS3hm9fngjEp7A==
+
 cozy-logger@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.6.0.tgz#51675e081e0a40baae6c38c64718cfaee5ee66ff"


### PR DESCRIPTION
The IntentIframe now uses cozy-interapp and does not need
cozy-client-js to work.