### PR TITLE
fix: Show border even if item is not first and has 2ndary action

### DIFF
--- a/react/MuiCozyTheme/List/Readme.md
+++ b/react/MuiCozyTheme/List/Readme.md
@@ -54,6 +54,16 @@ import Button from 'cozy-ui/transpiled/react/Button';
     </ListItem>
     <ListItem>
       <ListItemText primaryText="I'm a primary text" />
+      <ListItemSecondaryAction>
+        <Button
+          label='Click for more !'
+          theme="text"
+          icon="dots"
+          extension="narrow"
+          iconOnly
+          className="u-m-0"
+        />
+      </ListItemSecondaryAction>
     </ListItem>
   </List>
 </MuiCozyTheme>

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -159,6 +159,11 @@ normalTheme.overrides = {
     }
   },
   MuiListItem: {
+    container: {
+      '&:not(:first-child)': {
+        borderTop: '1px solid var(--silver) !important'
+      }
+    },
     root: {
       minHeight: '4.25rem',
       paddingTop: '.5rem',


### PR DESCRIPTION
If the last child of a ListItem is a SecondaryAction, it is wrapped in a
`container`. This is why we have to have the border-top on the `container`
otherwise, when wrapped, the root is the first child, so the border is not
displayed.