### PR TITLE
feat: Ability to add classNames to primaryText and secondaryText

### DIFF
--- a/react/ListItemText/index.jsx
+++ b/react/ListItemText/index.jsx
@@ -9,14 +9,24 @@ const ListItemText = props => {
     primaryText,
     secondaryText,
     className,
+    primaryTextClassName,
+    secondaryTextClassName,
     ellipsis,
     children,
     ...rest
   } = props
   return (
     <div className={cx(styles['c-list-text'], className)} {...rest}>
-      {primaryText && <Text ellipsis={ellipsis}>{primaryText}</Text>}
-      {secondaryText && <Caption ellipsis={ellipsis}>{secondaryText}</Caption>}
+      {primaryText && (
+        <Text className={primaryTextClassName} ellipsis={ellipsis}>
+          {primaryText}
+        </Text>
+      )}
+      {secondaryText && (
+        <Caption className={secondaryTextClassName} ellipsis={ellipsis}>
+          {secondaryText}
+        </Caption>
+      )}
       {children}
     </div>
   )
@@ -25,7 +35,9 @@ const ListItemText = props => {
 ListItemText.propTypes = {
   children: PropTypes.node,
   primaryText: PropTypes.string,
+  primaryTextClassName: PropTypes.string,
   secondaryText: PropTypes.string,
+  secondaryTextClassName: PropTypes.string,
   className: PropTypes.string,
   ellipsis: PropTypes.bool
 }

--- a/react/MuiCozyTheme/List/Readme.md
+++ b/react/MuiCozyTheme/List/Readme.md
@@ -102,6 +102,7 @@ import Icon from 'cozy-ui/transpiled/react/Icon';
 ```
 
 ## Use cases
+
 ### List item selected
 Highlight a selected item from the list
 ```
@@ -132,35 +133,61 @@ import Icon from 'cozy-ui/transpiled/react/Icon';
   </List>
 </MuiCozyTheme>
 ```
-### List with sub header
-Adds a sub header as a list divider
+### Navigation menus
+
+When presenting a list of actions in a navigation menu, it can be useful to 
+group actions per sections.
+
+- `ListSubHeader` can be used to add a section header.
+- `ListItemSecondaryAction` can be used to show an arrow.
+
 ```
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List';
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem';
 import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon';
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction';
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader';
 import Icon from 'cozy-ui/transpiled/react/Icon';
 
 
 <MuiCozyTheme>
   <List>
+    <ListSubheader>General</ListSubheader>
     <ListItem>
       <ListItemIcon>
-        <Icon icon="folder" width="32" height="32" />
+        <Icon icon="gear" width="24" height="24" />
       </ListItemIcon>
-      <ListItemText primaryText="I'm a primary text"/>
+      <ListItemText primaryText="General settings"/>
+      <ListItemSecondaryAction>
+        <Icon icon="right" width="24" height="24" className='u-mr-1 u-coolGrey' />
+      </ListItemSecondaryAction>
     </ListItem>
     <ListItem>
       <ListItemIcon>
-        <Icon icon="file" width="32" height="32" />
+        <Icon icon="people" width="24" height="24" />
       </ListItemIcon>
-      <ListItemText primaryText="I'm a primary text" secondaryText="I'm a secondary text"/>
+      <ListItemText primaryText="User preferences" secondaryText="Notifications and theme"/>
+      <ListItemSecondaryAction>
+        <Icon icon="right" width="24" height="24" className='u-mr-1 u-coolGrey' />
+      </ListItemSecondaryAction>
     </ListItem>
-    <ListSubheader>I'm a subheader</ListSubheader>
     <ListItem>
-      <ListItemText primaryText="I'm a primary text" />
+      <ListItemIcon>
+        <Icon icon="trash" className='u-error' width="24" height="24" />
+      </ListItemIcon>
+      <ListItemText primaryText="Delete account" primaryTextClassName="u-error" secondaryTextClassName="u-error" secondaryText="Permanently delete all your data"/>
+    </ListItem>
+    <ListSubheader>Accounts</ListSubheader>
+    <ListItem>
+      <ListItemIcon>
+        <Icon icon="bank" width="24" height="24" />
+      </ListItemIcon>
+      <ListItemText primaryText="Bank accounts" />
+      <ListItemSecondaryAction>
+        <Icon icon="right" width="24" height="24" className='u-mr-1 u-coolGrey' />
+      </ListItemSecondaryAction>
     </ListItem>
   </List>
 </MuiCozyTheme>

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -5,13 +5,13 @@
 \*------------------------------------*/
 
 $error
-    color  var(--errorColor)
+    color  var(--errorColor) !important // @stylint ignore
 
 $valid
-    color  var(--validColor)
+    color  var(--validColor) !important // @stylint ignore
 
 $warn
-    color  var(--warnColor)
+    color  var(--warnColor) !important // @stylint ignore
 
 colors=json('../settings/palette.json', { hash: true })
 


### PR DESCRIPTION
It is useful to be able to add u-error on list item components.

In the usecase section, I tweaked the example to have a usecase
that is nearer to the real usecase of the navigation menu.