### PR TITLE
docs: Add doc on Divider

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -56,6 +56,7 @@ module.exports = {
       name: 'Layout components',
       components: () => [
         '../react/Circle/index.jsx',
+        '../react/MuiCozyTheme/Divider/index.jsx',
         '../react/Hero/index.jsx',
         '../react/hooks/useBreakpoints/index.jsx',
         '../react/Layout/Layout.jsx',

--- a/react/MuiCozyTheme/Divider/Readme.md
+++ b/react/MuiCozyTheme/Divider/Readme.md
@@ -1,0 +1,15 @@
+A divider can be used when you want to separate the content.
+
+```
+import Card from 'cozy-ui/transpiled/react/Card'
+import { CardDivider } from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
+
+<MuiCozyTheme>
+  <Card>
+    <p>Here is some content in a card.</p>
+    <CardDivider className='u-ml-0 u-maw-100' />
+    <p>Other content in a card, that is unrelated to the first paragraph.</p>
+  </Card>
+</MuiCozyTheme>
+```

--- a/react/MuiCozyTheme/Divider/index.jsx
+++ b/react/MuiCozyTheme/Divider/index.jsx
@@ -1,3 +1,10 @@
+import React from 'react'
 import Divider from '@material-ui/core/Divider'
 
 export default Divider
+
+export const CardDivider = () => {
+  // To circumvent a theme problem, we have to remove the margins
+  // https://github.com/cozy/cozy-ui/issues/1534 */
+  return <Divider className="u-ml-0 u-maw-100" />
+}


### PR DESCRIPTION
The Divider was not present in the doc.

I've reworkd the code as I realized I had not wrapped the example in a MuiCozyTheme. When wrapping the Divider in a MuiCozyTheme, it has a special behavior that works well for Dialogs (where the padding of the modal must be cancelled), but not so well in "normal situations". To deal with the problem, I created a CardDivider that cancels the bad behavior of the normal Divider.

I've created the issue in #1534. The idea behind CardDivider is that when we solve the problem with the normal Divider, it will be simple to convert CardDivider to Divider and Divider to DialogDivider.