### PR TITLE
feat: {primary,secondary}Text can be React nodes

### DIFF
--- a/react/ListItemText/index.jsx
+++ b/react/ListItemText/index.jsx
@@ -34,9 +34,9 @@ const ListItemText = props => {
 
 ListItemText.propTypes = {
   children: PropTypes.node,
-  primaryText: PropTypes.string,
+  primaryText: PropTypes.node,
   primaryTextClassName: PropTypes.string,
-  secondaryText: PropTypes.string,
+  secondaryText: PropTypes.node,
   secondaryTextClassName: PropTypes.string,
   className: PropTypes.string,
   ellipsis: PropTypes.bool


### PR DESCRIPTION
PropTypes.string is often too restrictive. Here for example, we
wanted to show an icon next to the text, hence we used a fragment
containing <Icon /> and the text string as secondaryText prop.