### PR TITLE
fix: Prevent badge warnings from MUI

### DIFF
--- a/react/Badge/index.jsx
+++ b/react/Badge/index.jsx
@@ -13,6 +13,8 @@ const MEDIUM_DOT = '.75rem'
 const SMALL_DOT = '.625rem'
 
 const customStyles = theme => ({
+  badge: {},
+  root: {},
   top: {
     top: '16%'
   },
@@ -102,9 +104,9 @@ const Badge = withStyles(customStyles)(
             badge,
             verticalClasses[anchorOrigin.vertical],
             horizontalClasses[anchorOrigin.horizontal],
-            sizeClasses[size],
-            customClasses
-          )
+            sizeClasses[size]
+          ),
+          ...customClasses
         }}
         {...props}
       />

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -183,18 +183,18 @@ exports[`Avatar should render examples: Avatar 4`] = `
 exports[`Badge should render examples: Badge 1`] = `
 "<div>
   <div class=\\"u-m-1\\">error: <input class=\\"u-mr-1\\" type=\\"checkbox\\">dot: <input class=\\"u-mr-1\\" type=\\"checkbox\\">large: <input class=\\"u-mr-1\\" type=\\"checkbox\\">small: <input class=\\"u-mr-1\\" type=\\"checkbox\\"></div>
-  <p><span class=\\"MuiBadge-root-12\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"24\\" height=\\"24\\"><use xlink:href=\\"#circle-filled\\"></use></svg><span class=\\"MuiBadge-badge-13 Component-top-1 Component-right-4 Component-medium-6 MuiBadge-colorPrimary-14 Component-colorPrimary-8\\">4</span></span></p>
+  <p><span class=\\"MuiBadge-root-14 Component-root-2\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"24\\" height=\\"24\\"><use xlink:href=\\"#circle-filled\\"></use></svg><span class=\\"MuiBadge-badge-15 Component-badge-1 Component-top-3 Component-right-6 Component-medium-8 MuiBadge-colorPrimary-16 Component-colorPrimary-10\\">4</span></span></p>
   <div class=\\"u-m-1\\">error: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">dot: <input class=\\"u-mr-1\\" type=\\"checkbox\\" checked=\\"\\">large: <input class=\\"u-mr-1\\" type=\\"checkbox\\">small: <input class=\\"u-mr-1\\" type=\\"checkbox\\"></div>
-  <p><span class=\\"MuiBadge-root-12\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"24\\" height=\\"24\\"><use xlink:href=\\"#circle-filled\\"></use></svg><span class=\\"MuiBadge-badge-13 Component-top-1 Component-right-4 Component-medium-6 MuiBadge-colorError-16 Component-colorError-10 MuiBadge-dot-18 Component-dot-11\\"></span></span></p>
+  <p><span class=\\"MuiBadge-root-14 Component-root-2\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"24\\" height=\\"24\\"><use xlink:href=\\"#circle-filled\\"></use></svg><span class=\\"MuiBadge-badge-15 Component-badge-1 Component-top-3 Component-right-6 Component-medium-8 MuiBadge-colorError-18 Component-colorError-12 MuiBadge-dot-20 Component-dot-13\\"></span></span></p>
   <div class=\\"u-m-1\\">error: <input class=\\"u-mr-1\\" type=\\"checkbox\\">dot: <input class=\\"u-mr-1\\" type=\\"checkbox\\">large: <input class=\\"u-mr-1\\" type=\\"checkbox\\">small: <input class=\\"u-mr-1\\" type=\\"checkbox\\"></div>
-  <p><span class=\\"MuiBadge-root-12\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"24\\" height=\\"24\\"><use xlink:href=\\"#circle-filled\\"></use></svg><span class=\\"MuiBadge-badge-13 Component-top-1 Component-right-4 Component-medium-6 MuiBadge-colorPrimary-14 Component-colorPrimary-8\\">4</span></span></p>
+  <p><span class=\\"MuiBadge-root-14 Component-root-2\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"24\\" height=\\"24\\"><use xlink:href=\\"#circle-filled\\"></use></svg><span class=\\"MuiBadge-badge-15 Component-badge-1 Component-top-3 Component-right-6 Component-medium-8 MuiBadge-colorPrimary-16 Component-colorPrimary-10\\">4</span></span></p>
 </div>"
 `;
 
 exports[`Badge should render examples: Badge 2`] = `
 "<div>
-  <p><span class=\\"MuiBadge-root-12\\"><div class=\\"styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv\\" style=\\"color: white;\\"><span class=\\"styles__c-avatar-initials___310qC\\">CD</span>
-</div><span class=\\"MuiBadge-badge-13 undefined Component-qualifier-19 Component-bottom-2 Component-right-4 Component-medium-6\\"><span class=\\"MuiBadge-root-12\\"><svg class=\\"styles__icon___23x3R\\" width=\\"10\\" height=\\"10\\"><use xlink:href=\\"#link\\"></use></svg><span class=\\"MuiBadge-badge-13 Component-top-1 Component-right-4 Component-small-7 MuiBadge-colorError-16 Component-colorError-10 MuiBadge-dot-18 Component-dot-11\\"></span></span></span></span></p>
+  <p><span class=\\"MuiBadge-root-14 Component-root-2\\"><div class=\\"styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv\\" style=\\"color: white;\\"><span class=\\"styles__c-avatar-initials___310qC\\">CD</span>
+</div><span class=\\"MuiBadge-badge-15 Component-badge-1 Component-qualifier-21 Component-bottom-4 Component-right-6 Component-medium-8\\"><span class=\\"MuiBadge-root-14 Component-root-2\\"><svg class=\\"styles__icon___23x3R\\" width=\\"10\\" height=\\"10\\"><use xlink:href=\\"#link\\"></use></svg><span class=\\"MuiBadge-badge-15 Component-badge-1 Component-top-3 Component-right-6 Component-small-9 MuiBadge-colorError-18 Component-colorError-12 MuiBadge-dot-20 Component-dot-13\\"></span></span></span></span></p>
 </div>"
 `;
 
@@ -435,7 +435,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
     <ol class=\\"styles__list-contact___8ztoP\\">
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">EMPTY</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">EMPTY</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"013a6414-9727-4a4e-8b35-d3b9946a17c6\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -451,7 +451,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">A</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">A</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"013a6413-9726-4a4d-8b34-d3b9946a17c5\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -467,7 +467,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">B</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">B</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"799b0f99-3ad7-4f07-a689-9765b4e239c9\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -560,7 +560,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">C</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">C</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"507fcc3d-1423-46da-b5f9-8fbcfd3f3fe4\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -609,7 +609,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">F</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">F</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"7acdab81-52cb-46f6-9e81-42032e9843ae\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -636,7 +636,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">G</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">G</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"8ba82505-25c3-4821-88df-2e11becc21e8\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -652,7 +652,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">H</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">H</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"307c4e16-70b8-4328-af1c-1d762f788e16\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -701,7 +701,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">J</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">J</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"3e540ae7-4605-4f05-82c9-8cb901a0c34d\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -717,7 +717,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">K</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">K</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"366f3eec-aaa0-4c82-9f27-80ad305ecec8\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -755,7 +755,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">L</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">L</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"3fe82c80-9da3-4a42-bab5-8274df1316e6\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -804,7 +804,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">M</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">M</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"d50b7eea-6e71-4348-ad75-fc791d7a82d4\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -875,7 +875,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">N</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">N</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"627ba975-1314-4813-8366-cea7ac4734bf\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -891,7 +891,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">O</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">O</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"3f6007f9-9284-4bfd-9350-1cbf294bd39b\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -907,7 +907,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">P</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">P</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"53c75e29-5c9b-4c4f-b802-e4a152551b23\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -956,7 +956,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">R</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">R</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"c55c831a-9869-4e14-b3aa-d004bced41b0\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -983,7 +983,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">S</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">S</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"814f6f67-bcc0-498f-bb91-cab5ed315a12\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1054,7 +1054,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">T</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">T</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"0ea42f4a-28f1-432e-934a-68f9c50fe38e\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1103,7 +1103,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">V</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">V</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"23d3d724-d869-4def-841f-c85b499aa6a6\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1141,7 +1141,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">W</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">W</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"b6f5fc43-4199-4cca-8372-d1fe4e75a168\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1212,7 +1212,7 @@ exports[`ContactsList should render examples: ContactsList 1`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">X</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">X</li>
           <li>
             <div class=\\"styles__contact___169nD\\" id=\\"71967809-8e54-4413-aa8e-35b2b945e816\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1238,7 +1238,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
     <ol class=\\"styles__list-contact___8ztoP\\">
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">EMPTY</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">EMPTY</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"013a6414-9727-4a4e-8b35-d3b9946a17c6\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1254,7 +1254,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">A</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">A</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"013a6413-9726-4a4d-8b34-d3b9946a17c5\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1270,7 +1270,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">B</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">B</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"799b0f99-3ad7-4f07-a689-9765b4e239c9\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1363,7 +1363,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">C</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">C</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"507fcc3d-1423-46da-b5f9-8fbcfd3f3fe4\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1412,7 +1412,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">F</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">F</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"7acdab81-52cb-46f6-9e81-42032e9843ae\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1439,7 +1439,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">G</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">G</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"8ba82505-25c3-4821-88df-2e11becc21e8\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1455,7 +1455,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">H</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">H</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"307c4e16-70b8-4328-af1c-1d762f788e16\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1504,7 +1504,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">J</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">J</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"3e540ae7-4605-4f05-82c9-8cb901a0c34d\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1520,7 +1520,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">K</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">K</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"366f3eec-aaa0-4c82-9f27-80ad305ecec8\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1558,7 +1558,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">L</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">L</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"3fe82c80-9da3-4a42-bab5-8274df1316e6\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1607,7 +1607,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">M</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">M</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"d50b7eea-6e71-4348-ad75-fc791d7a82d4\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1678,7 +1678,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">N</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">N</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"627ba975-1314-4813-8366-cea7ac4734bf\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1694,7 +1694,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">O</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">O</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"3f6007f9-9284-4bfd-9350-1cbf294bd39b\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1710,7 +1710,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">P</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">P</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"53c75e29-5c9b-4c4f-b802-e4a152551b23\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1759,7 +1759,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">R</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">R</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"c55c831a-9869-4e14-b3aa-d004bced41b0\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1786,7 +1786,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">S</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">S</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"814f6f67-bcc0-498f-bb91-cab5ed315a12\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1857,7 +1857,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">T</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">T</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"0ea42f4a-28f1-432e-934a-68f9c50fe38e\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1906,7 +1906,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">V</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">V</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"23d3d724-d869-4def-841f-c85b499aa6a6\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -1944,7 +1944,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">W</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">W</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"b6f5fc43-4199-4cca-8372-d1fe4e75a168\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -2015,7 +2015,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
       </li>
       <li>
         <ol class=\\"styles__sublist-contact___NBitx\\">
-          <li class=\\"MuiListSubheader-root-20 MuiListSubheader-sticky-25 MuiListSubheader-gutters-23\\">X</li>
+          <li class=\\"MuiListSubheader-root-22 MuiListSubheader-sticky-27 MuiListSubheader-gutters-25\\">X</li>
           <li>
             <div class=\\"styles__contact___169nD styles__contact--clickable___1GLTM\\" id=\\"71967809-8e54-4413-aa8e-35b2b945e816\\">
               <div class=\\"styles__contact-identity___mL3IJ\\">
@@ -5543,19 +5543,19 @@ exports[`MuiCozyTheme/Switch should render examples: MuiCozyTheme/Switch 1`] = `
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Primary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-80\\"><span class=\\"MuiButtonBase-root-99 MuiIconButton-root-93 MuiPrivateSwitchBase-root-89 MuiSwitch-switchBase-83 MuiSwitch-colorPrimary-85 MuiPrivateSwitchBase-checked-90 MuiSwitch-checked-84\\"><span class=\\"MuiIconButton-label-98\\"><span class=\\"MuiSwitch-icon-81 MuiSwitch-iconChecked-82\\"></span><input class=\\"MuiPrivateSwitchBase-input-92\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-124\\"></span></span><span class=\\"MuiSwitch-bar-88\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-82\\"><span class=\\"MuiButtonBase-root-101 MuiIconButton-root-95 MuiPrivateSwitchBase-root-91 MuiSwitch-switchBase-85 MuiSwitch-colorPrimary-87 MuiPrivateSwitchBase-checked-92 MuiSwitch-checked-86\\"><span class=\\"MuiIconButton-label-100\\"><span class=\\"MuiSwitch-icon-83 MuiSwitch-iconChecked-84\\"></span><input class=\\"MuiPrivateSwitchBase-input-94\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-126\\"></span></span><span class=\\"MuiSwitch-bar-90\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Secondary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-80\\"><span class=\\"MuiButtonBase-root-99 MuiIconButton-root-93 MuiPrivateSwitchBase-root-89 MuiSwitch-switchBase-83 MuiSwitch-colorSecondary-86 MuiPrivateSwitchBase-checked-90 MuiSwitch-checked-84\\"><span class=\\"MuiIconButton-label-98\\"><span class=\\"MuiSwitch-icon-81 MuiSwitch-iconChecked-82\\"></span><input class=\\"MuiPrivateSwitchBase-input-92\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-124\\"></span></span><span class=\\"MuiSwitch-bar-88\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-82\\"><span class=\\"MuiButtonBase-root-101 MuiIconButton-root-95 MuiPrivateSwitchBase-root-91 MuiSwitch-switchBase-85 MuiSwitch-colorSecondary-88 MuiPrivateSwitchBase-checked-92 MuiSwitch-checked-86\\"><span class=\\"MuiIconButton-label-100\\"><span class=\\"MuiSwitch-icon-83 MuiSwitch-iconChecked-84\\"></span><input class=\\"MuiPrivateSwitchBase-input-94\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-126\\"></span></span><span class=\\"MuiSwitch-bar-90\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Disabled</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-80\\"><span class=\\"MuiButtonBase-root-99 MuiButtonBase-disabled-100 MuiIconButton-root-93 MuiIconButton-disabled-97 MuiPrivateSwitchBase-root-89 MuiSwitch-switchBase-83 MuiSwitch-colorSecondary-86 MuiPrivateSwitchBase-disabled-91 MuiSwitch-disabled-87\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-98\\"><span class=\\"MuiSwitch-icon-81\\"></span><input class=\\"MuiPrivateSwitchBase-input-92\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-88\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-82\\"><span class=\\"MuiButtonBase-root-101 MuiButtonBase-disabled-102 MuiIconButton-root-95 MuiIconButton-disabled-99 MuiPrivateSwitchBase-root-91 MuiSwitch-switchBase-85 MuiSwitch-colorSecondary-88 MuiPrivateSwitchBase-disabled-93 MuiSwitch-disabled-89\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-100\\"><span class=\\"MuiSwitch-icon-83\\"></span><input class=\\"MuiPrivateSwitchBase-input-94\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-90\\"></span></span></div>
       </div>
     </div>
     <div class=\\"u-title-h2 u-mt-1\\">Inverted theme</div>
@@ -5564,19 +5564,19 @@ exports[`MuiCozyTheme/Switch should render examples: MuiCozyTheme/Switch 1`] = `
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Primary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-102\\"><span class=\\"MuiButtonBase-root-121 MuiIconButton-root-115 MuiPrivateSwitchBase-root-111 MuiSwitch-switchBase-105 MuiSwitch-colorPrimary-107 MuiPrivateSwitchBase-checked-112 MuiSwitch-checked-106\\"><span class=\\"MuiIconButton-label-120\\"><span class=\\"MuiSwitch-icon-103 MuiSwitch-iconChecked-104\\"></span><input class=\\"MuiPrivateSwitchBase-input-114\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-131\\"></span></span><span class=\\"MuiSwitch-bar-110\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-104\\"><span class=\\"MuiButtonBase-root-123 MuiIconButton-root-117 MuiPrivateSwitchBase-root-113 MuiSwitch-switchBase-107 MuiSwitch-colorPrimary-109 MuiPrivateSwitchBase-checked-114 MuiSwitch-checked-108\\"><span class=\\"MuiIconButton-label-122\\"><span class=\\"MuiSwitch-icon-105 MuiSwitch-iconChecked-106\\"></span><input class=\\"MuiPrivateSwitchBase-input-116\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-133\\"></span></span><span class=\\"MuiSwitch-bar-112\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Secondary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-102\\"><span class=\\"MuiButtonBase-root-121 MuiIconButton-root-115 MuiPrivateSwitchBase-root-111 MuiSwitch-switchBase-105 MuiSwitch-colorSecondary-108 MuiPrivateSwitchBase-checked-112 MuiSwitch-checked-106\\"><span class=\\"MuiIconButton-label-120\\"><span class=\\"MuiSwitch-icon-103 MuiSwitch-iconChecked-104\\"></span><input class=\\"MuiPrivateSwitchBase-input-114\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-131\\"></span></span><span class=\\"MuiSwitch-bar-110\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-104\\"><span class=\\"MuiButtonBase-root-123 MuiIconButton-root-117 MuiPrivateSwitchBase-root-113 MuiSwitch-switchBase-107 MuiSwitch-colorSecondary-110 MuiPrivateSwitchBase-checked-114 MuiSwitch-checked-108\\"><span class=\\"MuiIconButton-label-122\\"><span class=\\"MuiSwitch-icon-105 MuiSwitch-iconChecked-106\\"></span><input class=\\"MuiPrivateSwitchBase-input-116\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-133\\"></span></span><span class=\\"MuiSwitch-bar-112\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Disabled</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-102\\"><span class=\\"MuiButtonBase-root-121 MuiButtonBase-disabled-122 MuiIconButton-root-115 MuiIconButton-disabled-119 MuiPrivateSwitchBase-root-111 MuiSwitch-switchBase-105 MuiSwitch-colorSecondary-108 MuiPrivateSwitchBase-disabled-113 MuiSwitch-disabled-109\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-120\\"><span class=\\"MuiSwitch-icon-103\\"></span><input class=\\"MuiPrivateSwitchBase-input-114\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-110\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-104\\"><span class=\\"MuiButtonBase-root-123 MuiButtonBase-disabled-124 MuiIconButton-root-117 MuiIconButton-disabled-121 MuiPrivateSwitchBase-root-113 MuiSwitch-switchBase-107 MuiSwitch-colorSecondary-110 MuiPrivateSwitchBase-disabled-115 MuiSwitch-disabled-111\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-122\\"><span class=\\"MuiSwitch-icon-105\\"></span><input class=\\"MuiPrivateSwitchBase-input-116\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-112\\"></span></span></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
When using `InfosBadge` or `Ghostbadge`, we got a warning `Material-UI: the key `badge` provided to the classes property is not implemented in Component.`. This is because even though `badge` is a valid class name for [MUI Badge](https://v3.material-ui.com/api/badge/), it wasn't declared in the cozy-ui export.

I also fixed a problem where custom classes where not spread in the right place.