### PR TITLE
fix: Use correct variable for error background

### DIFF
--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -18,7 +18,7 @@
         background-color var(--neutralBackground)
 
     &.Infos--danger
-        background-color var(--errorLightBackground)
+        background-color var(--errorBackgroundLight)
 
 .Infos-description
     max-width 32rem


### PR DESCRIPTION
Typo making the background "white" on Infos--danger