### PR TITLE
Typography components

### DIFF
--- a/codemods/transform-typography.js
+++ b/codemods/transform-typography.js
@@ -4,25 +4,25 @@ const mappings = {
   MainTitle: {
     componentName: 'Typography',
     props: {
-      variant: 'h1'
+      variant: 'h3'
     }
   },
   Title: {
     componentName: 'Typography',
     props: {
-      variant: 'h2'
+      variant: 'h4'
     }
   },
   SubTitle: {
     componentName: 'Typography',
     props: {
-      variant: 'h3'
+      variant: 'h5'
     }
   },
   Bold: {
     componentName: 'Typography',
     props: {
-      variant: 'h4'
+      variant: 'h6'
     }
   },
   Caption: {

--- a/codemods/transform-typography.js
+++ b/codemods/transform-typography.js
@@ -4,7 +4,8 @@ const mappings = {
   MainTitle: {
     componentName: 'Typography',
     props: {
-      variant: 'h3'
+      variant: 'h3',
+      component: 'h1'
     }
   },
   Title: {

--- a/codemods/transform-typography.js
+++ b/codemods/transform-typography.js
@@ -1,0 +1,111 @@
+const makeUtils = require('@cozy/codemods/src/utils')
+
+const mappings = {
+  MainTitle: {
+    componentName: 'Typography',
+    props: {
+      variant: 'h1'
+    }
+  },
+  Title: {
+    componentName: 'Typography',
+    props: {
+      variant: 'h2'
+    }
+  },
+  SubTitle: {
+    componentName: 'Typography',
+    props: {
+      variant: 'h3'
+    }
+  },
+  Bold: {
+    componentName: 'Typography',
+    props: {
+      variant: 'h4'
+    }
+  },
+  Caption: {
+    componentName: 'Typography',
+    props: {
+      variant: 'caption',
+      color: 'textSecondary'
+    }
+  },
+  Text: {
+    componentName: 'Typography',
+    props: {
+      variant: 'body1'
+    }
+  }
+}
+
+const ensureImport = (j, root, options) => {
+  const existingImport = root.find(
+    options.defaultImport ? j.ImportDefaultSpecifier : j.ImportSpecifier,
+    { local: { name: options.localName } }
+  )
+  if (existingImport.length > 0) {
+    return
+  } else {
+    const paths = root.find(j.ImportDeclaration)
+    paths
+      .at(-1)
+      .insertAfter(
+        j.importDeclaration(
+          [
+            (options.defaultImport
+              ? j.importDefaultSpecifier
+              : j.importSpecifier)(j.identifier(options.localName))
+          ],
+          j.literal(options.source)
+        )
+      )
+  }
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift
+  const utils = makeUtils(j)
+  const root = j(file.source)
+  let hasFound = false
+
+  Object.entries(mappings).forEach(([oldComponent, newSpec]) => {
+    // Replace JSX opening elements
+    root
+      .find(j.JSXOpeningElement, { name: { name: oldComponent } })
+      .forEach(path => {
+        hasFound = true
+        path.node.name = j.jsxIdentifier(newSpec.componentName)
+
+        for (let [propName, propValue] of Object.entries(newSpec.props)) {
+          path.node.attributes.push(
+            j.jsxAttribute(j.jsxIdentifier(propName), j.literal(propValue))
+          )
+        }
+      })
+
+    // Replace JSX closing elements
+    root
+      .find(j.JSXClosingElement, { name: { name: oldComponent } })
+      .forEach(path => {
+        path.node.name = j.jsxIdentifier(newSpec.componentName)
+      })
+  })
+
+  utils.imports.removeUnused(root)
+
+  // Ensures Typography is imported
+  if (hasFound) {
+    console.log('ensure import')
+    utils.imports.add(
+      root,
+      {
+        default: 'Typography'
+      },
+      'cozy-ui/transpiled/react/Typography'
+    )
+  }
+
+  return root.toSource()
+}

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -91,6 +91,7 @@ module.exports = {
         '../react/OrderedList/index.jsx',
         '../react/Table/index.jsx',
         '../react/Text/index.jsx',
+        '../react/Typography/index.jsx',
         '../react/Tooltip/index.jsx',
         '../react/UnorderedList/index.jsx',
         '../react/Well/index.jsx',

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -22,9 +22,54 @@ const SWITCH_BUTTON_WIDTH = 46
 export const normalTheme = createMuiTheme({
   typography: {
     useNextVariants: true,
-    fontFamily: getCssVariableValue('primaryFont'),
-    h6: {
-      color: 'white'
+    fontFamily: getCssVariableValue('primaryFont') || 'Lato',
+    h1: {
+      fontSize: 40,
+      fontWeight: 'bold',
+      lineHeight: 1.313
+    },
+    h2: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      lineHeight: 1.313
+    },
+    h3: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      lineHeight: 1.313
+    },
+    h4: {
+      fontSize: 18,
+      fontWeight: 'bold',
+      lineHeight: 1.313
+    },
+    h5: {
+      fontSize: 16,
+      fontWeight: 'bold',
+      lineHeight: 1.313
+    },
+    subtitle1: {
+      fontWeight: 'bold',
+      fontSize: 12,
+      lineHeight: 1.313,
+      textTransform: 'uppercase'
+    },
+    body1: {
+      fontSize: 16,
+      lineHeight: 1.313
+    },
+    body2: {
+      fontSize: 14,
+      lineHeight: 1.313
+    },
+    button: {
+      fontWeight: 'bold',
+      fontSize: 14,
+      lineHeight: 1.313
+    },
+    caption: {
+      fontSize: 12,
+      lineHeight: 1.313
     }
   },
   shape: {

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -24,26 +24,33 @@ export const normalTheme = createMuiTheme({
     useNextVariants: true,
     fontFamily: getCssVariableValue('primaryFont') || 'Lato',
     h1: {
-      fontSize: 40,
+      fontSize: 48,
       fontWeight: 'bold',
-      lineHeight: 1.313
+      lineHeight: 1.087,
+      letterSpacing: -0.8
     },
     h2: {
-      fontSize: 24,
+      fontSize: 32,
       fontWeight: 'bold',
-      lineHeight: 1.313
+      lineHeight: 1.313,
+      letterSpacing: -0.4
     },
     h3: {
-      fontSize: 20,
+      fontSize: 24,
       fontWeight: 'bold',
-      lineHeight: 1.313
+      lineHeight: 1.167
     },
     h4: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      lineHeight: 1.167
+    },
+    h5: {
       fontSize: 18,
       fontWeight: 'bold',
       lineHeight: 1.313
     },
-    h5: {
+    h6: {
       fontSize: 16,
       fontWeight: 'bold',
       lineHeight: 1.313

--- a/react/Text/Readme.md
+++ b/react/Text/Readme.md
@@ -1,3 +1,5 @@
+⚠️ Those components are deprecated, instead please use the Typography component.
+
 #### Standard text
 
 ```

--- a/react/Typography/Readme.md
+++ b/react/Typography/Readme.md
@@ -1,48 +1,87 @@
-Divider: { 
-  importPath: 'cozy-ui/transpiled/react/Divider',
-  defaultImport: true
-},
-ExpansionPanel: { 
-  importPath: 'cozy-ui/transpiled/react/ExpansionPanel',
-  defaultImport: true
-},
-ExpansionPanelDetails: { 
-  importPath: 'cozy-ui/transpiled/react/ExpansionPanelDetails',
-  defaultImport: true
-},
-ExpansionPanelSummary: { 
-  importPath: 'cozy-ui/transpiled/react/ExpansionPanelSummary',
-  defaultImport: true
-},
-Grid: { 
-  importPath: 'cozy-ui/transpiled/react/Grid',
-  defaultImport: true
-},
-List: { 
-  importPath: 'cozy-ui/transpiled/react/List',
-  defaultImport: true
-},
-ListItem: { 
-  importPath: 'cozy-ui/transpiled/react/ListItem',
-  defaultImport: true
-},
-ListItemIcon: { 
-  importPath: 'cozy-ui/transpiled/react/ListItemIcon',
-  defaultImport: true
-},
-ListItemSecondaryAction: { 
-  importPath: 'cozy-ui/transpiled/react/ListItemSecondaryAction',
-  defaultImport: true
-},
-ListSubheader: { 
-  importPath: 'cozy-ui/transpiled/react/ListSubheader',
-  defaultImport: true
-},
-Switch: { 
-  importPath: 'cozy-ui/transpiled/react/Switch',
-  defaultImport: true
-},
-TextField: { 
-  importPath: 'cozy-ui/transpiled/react/TextField',
-  defaultImport: true
-}
+Use typographic components to have sensible defaults for text
+content. The typography variants naming is based on material design.
+
+🆕 The Typography component should be used instead of Text components.
+
+<details>
+<summary>⤵️ A codemod can be used to help you migrate the code (click here for more information).</summary>
+
+```bash
+npm install -g jscodeshift
+jscodeshift -t node_modules/cozy-ui/codemods/transform-typography.js --parser babel src/
+```
+
+</details>
+
+
+```
+import Typography from '.'
+import MuiCozyTheme from '../MuiCozyTheme'
+import Stack from '../Stack'
+
+const variants = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'button',
+  'subtitle1',
+  'body1',
+  'body2',
+  'caption',
+];
+
+<MuiCozyTheme>
+  <Stack spacing='s'>
+    { variants.map(variant => (
+      <Typography variant={variant}>{variant}</Typography>
+    )) }
+  </Stack>
+</MuiCozyTheme>
+```
+
+From old to new :
+
+```
+import { Text, Caption, MainTitle, SubTitle, Title, Bold, ErrorMessage } from '../Text'
+import MuiCozyTheme from '../MuiCozyTheme'
+import Typography from '.';
+
+const trStyle = { borderBottom: '1px solid gray'}
+const tdStyle = { borderRight: '1px solid gray'};
+
+<MuiCozyTheme>
+  <table className='u-w-100'>
+    <tbody>
+      <tr style={trStyle}>
+        <td style={tdStyle}><MainTitle>MainTitle</MainTitle></td>
+        <td><Typography variant='h2'>is replaced by &lt;Typography variant="h2" &gt;</Typography></td>
+      </tr>
+      <tr style={trStyle}>
+        <td style={tdStyle}><Title>Title</Title></td>
+        <td><Typography variant='h3'>is replaced by &lt;Typography variant="h3" &gt;</Typography></td>
+      </tr>
+      <tr style={trStyle}>
+        <td style={tdStyle}><SubTitle>SubTitle</SubTitle></td>
+        <td><Typography variant='h4'>is replaced by &lt;Typography variant="h4" &gt;</Typography></td>
+      </tr>
+      <tr style={trStyle}>
+        <td style={tdStyle}><Bold>Bold</Bold></td>
+        <td><Typography variant='h5'>is replaced by &lt;Typography variant="h5" &gt;</Typography></td>
+      </tr>
+      <tr style={trStyle}>
+        <td style={tdStyle}><Caption>Caption</Caption></td>
+        <td><Typography variant='caption' color='textSecondary'>is replaced by &lt;Typography variant="caption" color="textSecondary" /&gt; </Typography></td>
+      </tr>
+      <tr style={trStyle}>
+        <td style={tdStyle}><ErrorMessage>ErrorMessage</ErrorMessage></td>
+        <td><Typography variant='body1' color='error'>is replaced by &lt;Typography color="error"  variant='body1' /&gt; </Typography></td>
+      </tr>
+    </tbody>
+  </table>
+</MuiCozyTheme>
+
+```
+
+

--- a/react/Typography/Readme.md
+++ b/react/Typography/Readme.md
@@ -56,19 +56,19 @@ const tdStyle = { borderRight: '1px solid gray'};
     <tbody>
       <tr style={trStyle}>
         <td style={tdStyle}><MainTitle>MainTitle</MainTitle></td>
-        <td><Typography variant='h2'>is replaced by &lt;Typography variant="h2" &gt;</Typography></td>
-      </tr>
-      <tr style={trStyle}>
-        <td style={tdStyle}><Title>Title</Title></td>
         <td><Typography variant='h3'>is replaced by &lt;Typography variant="h3" &gt;</Typography></td>
       </tr>
       <tr style={trStyle}>
-        <td style={tdStyle}><SubTitle>SubTitle</SubTitle></td>
+        <td style={tdStyle}><Title>Title</Title></td>
         <td><Typography variant='h4'>is replaced by &lt;Typography variant="h4" &gt;</Typography></td>
       </tr>
       <tr style={trStyle}>
-        <td style={tdStyle}><Bold>Bold</Bold></td>
+        <td style={tdStyle}><SubTitle>SubTitle</SubTitle></td>
         <td><Typography variant='h5'>is replaced by &lt;Typography variant="h5" &gt;</Typography></td>
+      </tr>
+      <tr style={trStyle}>
+        <td style={tdStyle}><Bold>Bold</Bold></td>
+        <td><Typography variant='h6'>is replaced by &lt;Typography variant="h6" &gt;</Typography></td>
       </tr>
       <tr style={trStyle}>
         <td style={tdStyle}><Caption>Caption</Caption></td>

--- a/react/Typography/Readme.md
+++ b/react/Typography/Readme.md
@@ -1,6 +1,9 @@
 Use typographic components to have sensible defaults for text
 content. The typography variants naming is based on material design.
 
+Read the original [Typography component](https://material-ui.com/components/typography/)
+documentation for more information.
+
 🆕 The Typography component should be used instead of Text components.
 
 <details>

--- a/react/Typography/Readme.md
+++ b/react/Typography/Readme.md
@@ -1,0 +1,48 @@
+Divider: { 
+  importPath: 'cozy-ui/transpiled/react/Divider',
+  defaultImport: true
+},
+ExpansionPanel: { 
+  importPath: 'cozy-ui/transpiled/react/ExpansionPanel',
+  defaultImport: true
+},
+ExpansionPanelDetails: { 
+  importPath: 'cozy-ui/transpiled/react/ExpansionPanelDetails',
+  defaultImport: true
+},
+ExpansionPanelSummary: { 
+  importPath: 'cozy-ui/transpiled/react/ExpansionPanelSummary',
+  defaultImport: true
+},
+Grid: { 
+  importPath: 'cozy-ui/transpiled/react/Grid',
+  defaultImport: true
+},
+List: { 
+  importPath: 'cozy-ui/transpiled/react/List',
+  defaultImport: true
+},
+ListItem: { 
+  importPath: 'cozy-ui/transpiled/react/ListItem',
+  defaultImport: true
+},
+ListItemIcon: { 
+  importPath: 'cozy-ui/transpiled/react/ListItemIcon',
+  defaultImport: true
+},
+ListItemSecondaryAction: { 
+  importPath: 'cozy-ui/transpiled/react/ListItemSecondaryAction',
+  defaultImport: true
+},
+ListSubheader: { 
+  importPath: 'cozy-ui/transpiled/react/ListSubheader',
+  defaultImport: true
+},
+Switch: { 
+  importPath: 'cozy-ui/transpiled/react/Switch',
+  defaultImport: true
+},
+TextField: { 
+  importPath: 'cozy-ui/transpiled/react/TextField',
+  defaultImport: true
+}

--- a/react/Typography/index.jsx
+++ b/react/Typography/index.jsx
@@ -1,0 +1,3 @@
+import Typography from '@material-ui/core/Typography'
+
+export default Typography


### PR DESCRIPTION
To better follow the design specs, and to remove discrepancies
between cozy-ui and material-ui, I added the theme for our
text specs into the MUI theme.

🔧 We can now use Typography components in our apps, instead of the Text components.

An example in the styleguide is there to show how to migrate
and a codemod is also there to facilitate the transition.

https://ptbrowne.github.io/cozy-ui/react/#!/Typography

⚠️ Styles for `Typography variant=h1,h2` are not similar to `u-title-h1`, `u-title-h2` since u-title-h1 is now `Typography variant=h3`. A second pass to take care of utility classes would be necessary, maybe adding first u-typo-h1 and others, and then removing u-title classes ?