### PR TITLE
fix: ListItemIcon size is fixed

### DIFF
--- a/react/MuiCozyTheme/ListItemIcon/index.js
+++ b/react/MuiCozyTheme/ListItemIcon/index.js
@@ -1,3 +1,9 @@
+import { withStyles } from '@material-ui/core/styles'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 
-export default ListItemIcon
+export default withStyles({
+  root: {
+    width: 32,
+    justifyContent: 'center'
+  }
+})(ListItemIcon)

--- a/react/NavigationList/Readme.md
+++ b/react/NavigationList/Readme.md
@@ -26,9 +26,9 @@ const NavigationListExample = ({ style }) => {
         <NavigationListSection>
         <ListItem>
           <ListItemIcon>
-            <Icon icon="gear" width="16" height="16" />
+            <Icon icon="gear" width="32" height="32" />
           </ListItemIcon>
-          <ListItemText primaryText="General settings" />
+          <ListItemText primaryText="General settings (large icon does not change size of icon area)" />
           <ListItemSecondaryAction>
             <Icon
               icon="right"


### PR DESCRIPTION
Our ListItemIcon must have a fixed width of 32px with horizontal padding
of 16px.

- Fixes https://github.com/cozy/cozy-ui/issues/1541
- See result at https://ptbrowne.github.io/cozy-ui/react/#!/NavigationList