### PR TITLE
Better behavior for CollectionField

### DIFF
--- a/react/ContactPicker/index.jsx
+++ b/react/ContactPicker/index.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ContactsListModal from '../ContactsListModal'
 import styles from './styles.styl'
 import cx from 'classnames'
@@ -18,39 +19,65 @@ const SelectControl = props => {
   )
 }
 
-const ContactPicker = props => {
-  const {
-    placeholder,
-    onChange,
-    value,
-    listPlaceholder,
-    listEmptyMessage,
-    addContactLabel,
-    ...rest
-  } = props
-
-  const [showContactsList, setShowContactsList] = useState(false)
-
-  const handleChange = contact => {
-    onChange(contact)
+class ContactPicker extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+    this.state = {
+      opened: this.props.initialOpen
+    }
+    this.open = this.open.bind(this)
+    this.close = this.close.bind(this)
   }
 
-  return (
-    <>
-      <SelectControl {...rest} onClick={() => setShowContactsList(true)}>
-        {value ? Contact.getDisplayName(value) : placeholder}
-      </SelectControl>
-      {showContactsList && (
-        <ContactsListModal
-          dismissAction={() => setShowContactsList(false)}
-          onItemClick={handleChange}
-          placeholder={listPlaceholder}
-          emptyMessage={listEmptyMessage}
-          addContactLabel={addContactLabel}
-        />
-      )}
-    </>
-  )
+  open() {
+    this.setState({ opened: true })
+  }
+
+  close() {
+    this.setState({ opened: false })
+  }
+
+  render() {
+    const {
+      placeholder,
+      onChange,
+      value,
+      listPlaceholder,
+      listEmptyMessage,
+      addContactLabel,
+      ...rest
+    } = this.props
+    const { opened } = this.state
+
+    const handleChange = contact => {
+      onChange(contact)
+    }
+
+    return (
+      <>
+        <SelectControl {...rest} onClick={this.open}>
+          {value ? Contact.getDisplayName(value) : placeholder}
+        </SelectControl>
+        {opened && (
+          <ContactsListModal
+            dismissAction={this.close}
+            onItemClick={handleChange}
+            placeholder={listPlaceholder}
+            emptyMessage={listEmptyMessage}
+            addContactLabel={addContactLabel}
+          />
+        )}
+      </>
+    )
+  }
+}
+
+ContactPicker.defaultProps = {
+  initialOpen: false
+}
+
+ContactPicker.propTypes = {
+  initialOpen: PropTypes.bool
 }
 
 export default ContactPicker

--- a/react/Labs/CollectionField/Readme.md
+++ b/react/Labs/CollectionField/Readme.md
@@ -1,41 +1,39 @@
-```jsx
-import CollectionField from 'cozy-ui/transpiled/react/Labs/CollectionField';
-import ContactPicker from 'cozy-ui/transpiled/react/ContactPicker';
-import DemoProvider from '../../ContactsListModal/DemoProvider';
-import contacts from '../../ContactsList/data.json';
-initialState = { contacts: [contacts[0]] };
-
-<DemoProvider>
-  <CollectionField
-    values={state.contacts}
-    component={ContactPicker}
-    onChange={contacts => setState({ contacts })}
-    onAddField={fieldInstance => fieldInstance.open()}
-    label="Contacts"
-    addButtonLabel="Add a contact"
-    removeButtonLabel="Remove this contact"
-    placeholder="Select a contact"
-  />
-</DemoProvider>
-```
+If the initial data is empty, the button is shown. If it contains
+only `null`, the button will not be shown, and the underlying component
+will receive `null` as its value, which can be handy for example for
+the ContactPicker to remove one click.
 
 ```jsx
 import CollectionField from 'cozy-ui/transpiled/react/Labs/CollectionField';
 import ContactPicker from 'cozy-ui/transpiled/react/ContactPicker';
 import DemoProvider from '../../ContactsListModal/DemoProvider';
 import contacts from '../../ContactsList/data.json';
+import Variants from 'cozy-ui/docs/components/Variants';
+
 initialState = { contacts: [contacts[0]] };
 
-<DemoProvider>
-  <CollectionField
-    values={state.contacts}
-    component={ContactPicker}
-    onChange={contacts => setState({ contacts })}
-    label="Contacts"
-    addButtonLabel="Add a contact"
-    removeButtonLabel="Remove this contact"
-    placeholder="Select a contact"
-    variant="inline"
-  />
-</DemoProvider>
+const initialVariants = [{
+  inline: false,
+  emptyData: false,
+  nullData: false
+}];
+
+<Variants initialVariants={initialVariants}>{
+  variant => (
+    <DemoProvider>
+      <CollectionField
+        values={variant.emptyData ? [] : variant.nullData ? [null] : state.contacts}
+        component={ContactPicker}
+        onChange={contacts => setState({ contacts })}
+        onAddField={fieldInstance => fieldInstance.open()}
+        label="Contacts"
+        addButtonLabel="Add a contact"
+        removeButtonLabel="Remove this contact"
+        placeholder="Select a contact"
+        variant={variant.inline ? "inline" : null}
+      />
+    </DemoProvider>
+  )
+}
+</Variants>
 ```

--- a/react/Labs/CollectionField/Readme.md
+++ b/react/Labs/CollectionField/Readme.md
@@ -10,6 +10,7 @@ initialState = { contacts: [contacts[0]] };
     values={state.contacts}
     component={ContactPicker}
     onChange={contacts => setState({ contacts })}
+    onAddField={fieldInstance => fieldInstance.open()}
     label="Contacts"
     addButtonLabel="Add a contact"
     removeButtonLabel="Remove this contact"

--- a/react/Labs/CollectionField/index.jsx
+++ b/react/Labs/CollectionField/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import Button from '../../Button'
 import Label from '../../Label'
 import styles from './styles.styl'
@@ -20,8 +20,16 @@ const CollectionField = props => {
     addButtonLabel,
     removeButtonLabel,
     onChange,
+    onAddField,
     ...rest
   } = props
+
+  // This ref is used to support the onAddField props.
+  // It contains the index of the field that has been
+  // added and is used when handling refs to pass the
+  // instance of the component that was added to the
+  // onAddField prop of the parent.
+  const justAddedFieldIndex = useRef()
 
   const handleChange = index => contact => {
     const data = [...values]
@@ -33,11 +41,22 @@ const CollectionField = props => {
   const handleAdd = () => {
     const data = [...values, null]
     onChange(data)
+    justAddedFieldIndex.current = data.length - 1
   }
 
   const handleRemove = index => {
     const data = [...values.slice(0, index), ...values.slice(index + 1)]
     onChange(data)
+  }
+
+  const handleFieldRef = (index, componentInstance) => {
+    if (!onAddField) {
+      return
+    }
+    if (index === justAddedFieldIndex.current && componentInstance) {
+      justAddedFieldIndex.current = null
+      onAddField(componentInstance)
+    }
   }
 
   return (
@@ -50,6 +69,7 @@ const CollectionField = props => {
               return (
                 <div key={index} className={styles.CollectionField__row}>
                   <Component
+                    ref={value => handleFieldRef(index, value)}
                     value={value}
                     onChange={handleChange(index)}
                     placeholder={placeholder}

--- a/react/Labs/CollectionField/index.jsx
+++ b/react/Labs/CollectionField/index.jsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react'
+import PropTypes from 'prop-types'
 import Button from '../../Button'
 import Label from '../../Label'
 import styles from './styles.styl'
@@ -10,6 +11,10 @@ import { FieldContainer } from '../../Field'
  * Handles a collection of form fields.
  * This is a controlled component. You have to give it some values and handle
  * changes via the onChange prop. See examples in readme.
+ *
+ * When a field is added, the underlying component receives `null` as
+ * its value.
+ * When a field is being added, the "Add" button is not shown.
  */
 const CollectionField = props => {
   const {
@@ -106,6 +111,25 @@ const CollectionField = props => {
       </Stack>
     </FieldContainer>
   )
+}
+
+CollectionField.propTypes = {
+  /** @type {Array} Individual values will be passed through `value` to the underlying Component */
+  values: PropTypes.array.isRequired,
+  /** @type {Element} Component used to render a field */
+  component: PropTypes.element.isRequired,
+  /** @type {String} Label of the field */
+  label: PropTypes.node.isRequired,
+  /** @type {Function} Callback called when a value is added / updated / removed */
+  onChange: PropTypes.func.isRequired,
+  /** @type {String} Label of the "Add" button */
+  addButtonLabel: PropTypes.node.isRequired,
+  /** @type {String} Label of the "Remove" button */
+  removeButtonLabel: PropTypes.node.isRequired,
+  /** @type {String} Placeholder passed to the Component */
+  placeholder: PropTypes.string,
+  /** @type {String} Callback called with the instance of the Component when a field is being added */
+  onAddField: PropTypes.func
 }
 
 export default CollectionField

--- a/react/Labs/CollectionField/index.jsx
+++ b/react/Labs/CollectionField/index.jsx
@@ -68,16 +68,21 @@ const CollectionField = props => {
             })}
           </Stack>
         ) : null}
-        <Button
-          label={addButtonLabel}
-          type="button"
-          theme="text"
-          icon={
-            <Icon icon="plus" className={styles.CollectionField__addBtnIcon} />
-          }
-          onClick={handleAdd}
-          className={styles.CollectionField__addBtn}
-        />
+        {values[values.length - 1] !== null ? (
+          <Button
+            label={addButtonLabel}
+            type="button"
+            theme="text"
+            icon={
+              <Icon
+                icon="plus"
+                className={styles.CollectionField__addBtnIcon}
+              />
+            }
+            onClick={handleAdd}
+            className={styles.CollectionField__addBtn}
+          />
+        ) : null}
       </Stack>
     </FieldContainer>
   )

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -5395,19 +5395,8 @@ exports[`Label should render examples: Label 3`] = `
 
 exports[`Labs/CollectionField should render examples: Labs/CollectionField 1`] = `
 "<div>
+  <div class=\\"u-m-1\\">inline: <input class=\\"u-mr-1\\" type=\\"checkbox\\">emptyData: <input class=\\"u-mr-1\\" type=\\"checkbox\\">nullData: <input class=\\"u-mr-1\\" type=\\"checkbox\\"></div>
   <div class=\\"styles__o-field___3n5HM\\"><label class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">Contacts</label>
-    <div class=\\"styles__Stack--m___1tSpV\\">
-      <div class=\\"styles__Stack--s___22WMg\\">
-        <div class=\\"styles__CollectionField__row___Z7bbf\\"><button type=\\"button\\" class=\\"styles__SelectControl___2OxoO\\">isabelle.durand@cozycloud.cc</button><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--center___16_Xh styles__c-btn--round___1Lkyl\\" title=\\"Remove this contact\\"><span><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#cross-small\\"></use></svg><span class=\\"u-visuallyhidden\\">Remove this contact</span></span></button></div>
-      </div><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--text___2Vp-2 styles__c-btn--center___16_Xh styles__CollectionField__addBtn___Z0FO-\\"><span><svg class=\\"styles__CollectionField__addBtnIcon___1hA5b styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#plus\\"></use></svg><span>Add a contact</span></span></button>
-    </div>
-  </div>
-</div>"
-`;
-
-exports[`Labs/CollectionField should render examples: Labs/CollectionField 2`] = `
-"<div>
-  <div class=\\"styles__o-field___3n5HM styles__o-field--inline___7JWZ8\\"><label class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">Contacts</label>
     <div class=\\"styles__Stack--m___1tSpV\\">
       <div class=\\"styles__Stack--s___22WMg\\">
         <div class=\\"styles__CollectionField__row___Z7bbf\\"><button type=\\"button\\" class=\\"styles__SelectControl___2OxoO\\">isabelle.durand@cozycloud.cc</button><button type=\\"button\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--center___16_Xh styles__c-btn--round___1Lkyl\\" title=\\"Remove this contact\\"><span><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--slateGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#cross-small\\"></use></svg><span class=\\"u-visuallyhidden\\">Remove this contact</span></span></button></div>


### PR DESCRIPTION
Following @joel-costa's remarks during validation phase, the
CollectionField now supports the use of an imperative callback called when
a component is added. This is useful for example for the contact picker that should be
shown directly just after clicking "Add".

See the CollectionField/Readme.md for more information (see the onAddField prop).

[new behavior](https://ptbrowne.github.io/cozy-ui/react/#!/CollectionField) to compare with [current behavior](https://docs.cozy.io/cozy-ui/react/#!/CollectionField)
