### PR TITLE
chore: Remove unused fast_finish from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
-matrix:
-  fast_finish: true
 node_js:
-  - '10'
+  - 10
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Fast finish is used during matrix jobs and we do not use the matrix
feature from Travis here.