### PR TITLE
fix: Allow custom stylesheet to override global custom properties

### DIFF
--- a/stylus/settings/fontstack.styl
+++ b/stylus/settings/fontstack.styl
@@ -13,7 +13,7 @@
 
     Styleguide Settings.fonts
 */
-:root
+html
     --primaryFont Lato, sans-serif
 
 $font-labor

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -20,7 +20,7 @@
 
     Styleguide Settings.colors
 */
-:root
+html
     /*
     Grey
 
@@ -153,7 +153,7 @@
 
     Styleguide Settings.theme.primary
     */
-:root, .CozyTheme--normal
+html, .CozyTheme--normal
     --primaryColor var(--dodgerBlue)
     --primaryColorDark var(--scienceBlue)
     --primaryColorLight #5C9DF5 // lighten(dodgerBlue, 24)

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -47,7 +47,8 @@ $drawer-index       = 60
 $modal-index        = 70
 $alert-index        = 80
 
-:root
+// @stylint off
+html
     --zIndex-below $below-index
     --zIndex-app $app-index
     --zIndex-low $low-index
@@ -61,3 +62,5 @@ $alert-index        = 80
     --zIndex-drawer $drawer-index
     --zIndex-modal $modal-index
     --zindex-alert $alert-index
+// @stylint on
+


### PR DESCRIPTION
### Problem

Custom stylesheet lost the ability to override button colors after
the introduction of CSS properties relying on others (for example
regularButtonPrimaryColor relying on primaryColor).

For the button color to be correctly overriden, the stack must be
able to override the --primaryColor, so that it is correctly
picked up when using regularButtonPrimaryColor.

### Solution

html targets the same element as :root but its specificity is lower.
This allows us to use html to define our CSS custom properties inside
cozy-ui, and use :root in the custom CSS injected by the stack for
context that have a theme. This way, the :root selector can override
CSS custom properties, without relying on CSS order.