### PR TITLE
Add possibility to pass props to SelectBox options icon

### DIFF
--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -200,6 +200,7 @@ const ActionsOption = ({ actions, ...props }) => (
     <span className={withPrefix(props.cx, styles['select-option__actions'])}>
       {actions.map((action, index) => (
         <Icon
+          {...action.iconProps}
           key={index}
           icon={action.icon}
           color={props.isFocused ? coolGrey : silver}
@@ -218,7 +219,8 @@ ActionsOption.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       icon: PropTypes.string,
-      onClick: PropTypes.func
+      onClick: PropTypes.func,
+      iconProps: PropTypes.object
     })
   )
 }


### PR DESCRIPTION
Used in contact to pass data-testid on Icon


If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

```
yarn build:doc:react
yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
```

- [x] Deployed the styleguidist
- [x] Did you think of ARIA attributes if you are coding new components ?