### PR TITLE
Fix/alerter mobile

### DIFF
--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -12,7 +12,7 @@ alert-width = rem(640)
 
 $alert
     position fixed
-    z-index $alert-index-mobile
+    z-index $alert-index
     right 0
     bottom calc(3rem + env(safe-area-inset-bottom))
     left 0

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -14,7 +14,7 @@ $alert
     position fixed
     z-index $alert-index
     right 0
-    bottom calc(3rem + env(safe-area-inset-bottom))
+    bottom 0
     left 0
     color var(--white)
     opacity 1
@@ -46,7 +46,8 @@ $alert-wrapper
     background-color var(--validColor)
     padding rem(13 16)
     pointer-events auto
-
+    padding-bottom 3rem
+    padding-bottom env(safe-area-inset-bottom)
     p
         margin 0
         line-height 1.5

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -58,7 +58,7 @@ html
     --zIndex-fileActionMenu $file-action-menu
     --zIndex-drawer $drawer-index
     --zIndex-modal $modal-index
-    --zindex-alert $alert-index
+    --zIndex-alert $alert-index
     //@deprecated Use --zIndex-alert
     --zIndex-alertMobile $alert-index
 

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -20,7 +20,6 @@
     $below-index        - **index -1** Layer below the app, mostly for hiding purpose
     $app-index          - **index 0** App index, the ground zero.
     $low-index          - **index 1** Low level index, to make sure a positionned element goes over elements with z-index 0.
-    $alert-index-mobile - **index 10** Alert index like success, errors, infos *mobile only*
     $nav-index          - **index 20** Nav index
     $bar-index          - **index 21** Bar index equals Nav index + 1, not actually used, just as reference.
     $selection-index    - **index 30** Selection bar index, with actions for selected items
@@ -36,7 +35,6 @@
 $below-index        = -1
 $app-index          = 0
 $low-index          = 1
-$alert-index-mobile = 10
 $nav-index          = 20
 $bar-index          = $nav-index + 1 // Not actually used, just as reference
 $selection-index    = 30
@@ -52,7 +50,6 @@ html
     --zIndex-below $below-index
     --zIndex-app $app-index
     --zIndex-low $low-index
-    --zIndex-alertMobile $alert-index-mobile
     --zIndex-nav $nav-index
     --zIndex-bar $bar-index
     --zIndex-selection $selection-index
@@ -62,5 +59,8 @@ html
     --zIndex-drawer $drawer-index
     --zIndex-modal $modal-index
     --zindex-alert $alert-index
+    //@deprecated Use --zIndex-alert
+    --zIndex-alertMobile $alert-index
+
 // @stylint on
 


### PR DESCRIPTION
Two issues resolved in this PR : 

- alerter's zIndex was too low on mobile. I don't know why we had a different value on mobile or desktop
- alerter now handles correctly the safe area. Same as we have done for action menu (#1573) 

I fixed a case issue on a CSS var. It's a breaking change... 

let's see what argos tells me