### PR TITLE
feat: Add withNoAction on SelectBox ActionsOption

### DIFF
--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -215,6 +215,7 @@ import SelectBox, { ActionsOption } from 'cozy-ui/transpiled/react/SelectBox';
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
+  { value: 'withNoAction', label: 'withNoAction', withNoAction: true },
   { value: 'vanilla', label: 'Vanilla' },
   { value: 'long', label: 'Salt and vinegar crisps with vegamite and brussel sprouts, double chai latte sauce' }
 ];

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -195,23 +195,25 @@ const CheckboxOption = ({ ...props }) => <Option {...props} withCheckbox />
 
 CheckboxOption.propTypes = {}
 
-const ActionsOption = ({ actions, ...props }) => (
+const ActionsOption = ({ actions, withNoAction, ...props }) => (
   <Option {...props} labelComponent={props.children}>
-    <span className={withPrefix(props.cx, styles['select-option__actions'])}>
-      {actions.map((action, index) => (
-        <Icon
-          {...action.iconProps}
-          key={index}
-          icon={action.icon}
-          color={props.isFocused ? coolGrey : silver}
-          className={withPrefix(props.cx, 'u-ph-half')}
-          onClick={e => {
-            e.stopPropagation()
-            action.onClick(props)
-          }}
-        />
-      ))}
-    </span>
+    {withNoAction ? null : (
+      <span className={withPrefix(props.cx, styles['select-option__actions'])}>
+        {actions.map((action, index) => (
+          <Icon
+            {...action.iconProps}
+            key={index}
+            icon={action.icon}
+            color={props.isFocused ? coolGrey : silver}
+            className={withPrefix(props.cx, 'u-ph-half')}
+            onClick={e => {
+              e.stopPropagation()
+              action.onClick(props)
+            }}
+          />
+        ))}
+      </span>
+    )}
   </Option>
 )
 


### PR DESCRIPTION
We may need to have actions only on some options, not all of them. To do this, simply add `withNoAction: true` in the option.

I think it's better to go through cozy-ui rather than in the app, doing something like `actions={withNoAction ? [] : [{icon: '', ...}]}`

---

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

```
yarn build:doc:react
yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
```

- [x] Deployed the styleguidist
- [x] Did you think of ARIA attributes if you are coding new components ?