### PR TITLE
feat: Tabs switch to fullWidth variant on small viewports

### DIFF
--- a/react/MuiTabs.js
+++ b/react/MuiTabs.js
@@ -1,4 +1,0 @@
-import Tabs from '@material-ui/core/Tabs'
-import Tab from '@material-ui/core/Tab'
-
-export { Tabs, Tab }

--- a/react/MuiTabs.jsx
+++ b/react/MuiTabs.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import MuiTabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
+import useBreakpoints from './hooks/useBreakpoints'
+
+const Tabs = props => {
+  const { isMobile } = useBreakpoints()
+  return <MuiTabs variant={isMobile ? 'fullWidth' : undefined} {...props} />
+}
+
+export { Tabs, Tab }

--- a/react/Tabs/Readme.md
+++ b/react/Tabs/Readme.md
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { Tabs, Tab } from 'cozy-ui/transpiled/react/MuiTabs'
 import { CardDivider } from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider';
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 function a11yProps(index) {
   return {
@@ -36,7 +37,7 @@ const Example = () => {
   )
 };
 
-<>
+<BreakpointsProvider>
   <MuiCozyTheme variant='normal'>
     <Example />
   </MuiCozyTheme>
@@ -44,7 +45,7 @@ const Example = () => {
   <MuiCozyTheme variant='inverted'>
     <Example />
   </MuiCozyTheme>
-</>
+</BreakpointsProvider>
 ```
 
 ### Old tabs


### PR DESCRIPTION
We want tabs to be in fullWidth variant on mobile. To achieve
this we must export a component wrapping the material-ui tabs.