### PR TITLE
fix: Default Control works now on mobile

### DIFF
--- a/react/SelectBox/ControlDefault.jsx
+++ b/react/SelectBox/ControlDefault.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { components } from 'react-select'
+
+const ControlDefault = ({
+  selectProps: { onControlClicked },
+  innerProps,
+  ...props
+}) => {
+  // onTouchStart is necessary on mobile
+  // see https://github.com/JedWatson/react-select/issues/3806#issuecomment-541325710
+
+  const enhancedInnerProps = {
+    ...innerProps,
+    onClick: onControlClicked,
+    onTouchStart: onControlClicked
+  }
+  return <components.Control {...props} innerProps={enhancedInnerProps} />
+}
+
+ControlDefault.propTypes = {
+  selectProps: PropTypes.object.isRequired
+}
+
+export default ControlDefault

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -10,6 +10,8 @@ import Icon from '../Icon'
 import { dodgerBlue, silver, coolGrey, paleGrey } from '../palette'
 import withBreakpoints from '../helpers/withBreakpoints'
 
+import ControlDefault from './ControlDefault'
+
 const heights = {
   tiny: '2rem',
   medium: '2.5rem',
@@ -236,6 +238,7 @@ const getNodeFromRef = ref => {
 }
 
 const customComponents = {
+  Control: ControlDefault,
   DropdownIndicator,
   Option
 }

--- a/react/SelectBox/index.jsx
+++ b/react/SelectBox/index.jsx
@@ -11,3 +11,5 @@ export {
 export {
   default as SelectBoxWithFixedOptions
 } from './SelectBoxWithFixedOptions'
+
+export { default as ControlDefault } from './ControlDefault'


### PR DESCRIPTION
We have now a default react-select control that works on mobile in the case we want to use an onClick function on the control, specially to manage the isMenuOpen prop.

Fix https://github.com/cozy/cozy-ui/issues/1593


If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

```
yarn build:doc:react
yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
```

- [x] Deployed the styleguidist
- [x] Did you think of ARIA attributes if you are coding new components ?
