### PR TITLE
feat: Better formatting for numbers

### DIFF
--- a/react/Figure/Figure.md
+++ b/react/Figure/Figure.md
@@ -1,19 +1,30 @@
 ```jsx
 import { Figure } from 'cozy-ui/transpiled/react/Figure';
-<div>
-  <Figure
-    total={1000}
-    symbol='€'
-    coloredPositive coloredNegative signed />
+import I18n from 'cozy-ui/transpiled/react/I18n';
+import Button from 'cozy-ui/transpiled/react/Button';
 
-  <Figure
-    total={-1000}
-    symbol='€'
-    coloredPositive coloredNegative signed />
+initialState = { locale: 'fr' };
 
-  <Figure
-    total={-1000}
-    symbol='€'
-    signed />
-</div>
+<I18n lang={state.locale} dictRequire={() => {}}>
+  <Button label='en locale' onClick={() => setState({ locale: 'en' })} />
+  <Button label='fr locale' onClick={() => setState({ locale: 'fr' })} />
+  locale: { state.locale }<br/>
+  <p>
+    <Figure
+      total={100000}
+      symbol='€'
+      signed
+      coloredPositive coloredNegative signed />
+    <Figure
+      total={-100000}
+      symbol='€'
+      signed
+      coloredPositive coloredNegative signed />
+
+    <Figure
+      total={-100000}
+      symbol='€'
+      signed />
+  </p>
+</I18n>
 ```

--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -18,17 +18,18 @@ export const I18nContext = React.createContext()
 export class I18n extends Component {
   constructor(props) {
     super(props)
-    this.init(this.props)
+    this.init()
+    this.state = {
+      contextValue: this.getContextValue()
+    }
   }
 
-  init(props) {
-    const { polyglot, lang, dictRequire, context, defaultLang } = props
-
+  init() {
+    const { polyglot, lang, dictRequire, context, defaultLang } = this.props
     this.translator =
       polyglot || initTranslation(lang, dictRequire, context, defaultLang)
     this.format = initFormat(lang, defaultLang)
     this.t = this.translator.t.bind(this.translator)
-    this.contextValue = this.getContextValue()
   }
 
   getContextValue() {
@@ -40,18 +41,19 @@ export class I18n extends Component {
   }
 
   getChildContext() {
-    return this.contextValue
+    return this.state.contextValue
   }
 
-  UNSAFE_componentWillReceiveProps = nextProps => {
-    if (nextProps.lang !== this.props.lang) {
-      this.init(nextProps)
+  componentDidUpdate(prevProps) {
+    if (prevProps.lang !== this.props.lang) {
+      this.init()
+      this.setState({ contextValue: this.getContextValue() })
     }
   }
 
   render() {
     return (
-      <I18nContext.Provider value={this.contextValue}>
+      <I18nContext.Provider value={this.state.contextValue}>
         {this.props.children}
       </I18nContext.Provider>
     )


### PR DESCRIPTION
- We rely on a custom function instead of the localization function
    from the browser since some browsers like safari can lack this
    library
   - Doing the formatting ourselves opens up opportunities to format the
    decimal part and normal part differently (for example the decimal part in a smaller font, as seen in some designs from joel)

See https://ptbrowne.github.io/cozy-ui/react/#!/Figure