### PR TITLE
Fix/selection bar

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -65,6 +65,7 @@ module.exports = {
         '../react/NarrowContent/index.jsx',
         '../react/Page/index.jsx',
         '../react/SectionHeader/index.jsx',
+        '../react/SelectionBar/index.jsx',
         '../react/Sidebar/index.jsx',
         '../react/ViewStack/index.jsx'
       ]

--- a/react/SelectionBar/Readme.md
+++ b/react/SelectionBar/Readme.md
@@ -1,0 +1,49 @@
+SelectionBar 
+
+### Usage
+
+```jsx
+import SelectionBar from 'cozy-ui/transpiled/react/SelectionBar';
+import I18n from 'cozy-ui/transpiled/react/I18n';
+initialState = { selected: [] };
+const selectedItem = {
+    _id: 1,
+    type: 'file'
+}
+const addSelected = () => setState(previousState => {
+    const arr = previousState.selected
+    arr.push(selectedItem)
+    return {selected: arr}
+});
+const removeSelected = () => setState(previousState => {
+    const arr = previousState.selected
+    arr.pop()
+    return {selected: arr}
+});
+const dictRequire = x => ({})
+
+const actions = {
+  trash: {
+    action: selections => alert(JSON.stringify(selections)),
+    icon: 'trash'
+  },
+  rename: {
+    action: selections => alert(JSON.stringify(selections)),
+    displayCondition: selections => selections.length > 1
+  }
+};
+<I18n dictRequire={dictRequire} lang='en'>
+    {state.selected.length > 0 &&
+    <div style={{backgroundColor: 'var(--slateGrey)'}}>
+        <SelectionBar
+        actions={actions}
+        selected={state.selected}
+        hideSelectionBar={() => setState({selected: []})}
+        />
+    </div>
+    }
+    <button onClick={addSelected}>Add a selected document</button>
+    <button onClick={removeSelected}>Remove a selected document</button>
+</I18n>
+
+```

--- a/react/SelectionBar/Readme.md
+++ b/react/SelectionBar/Readme.md
@@ -5,21 +5,27 @@ SelectionBar
 ```jsx
 import SelectionBar from 'cozy-ui/transpiled/react/SelectionBar';
 import I18n from 'cozy-ui/transpiled/react/I18n';
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints';
+
 initialState = { selected: [] };
+
 const selectedItem = {
     _id: 1,
     type: 'file'
 }
+
 const addSelected = () => setState(previousState => {
     const arr = previousState.selected
     arr.push(selectedItem)
     return {selected: arr}
 });
+
 const removeSelected = () => setState(previousState => {
     const arr = previousState.selected
     arr.pop()
     return {selected: arr}
 });
+
 const dictRequire = x => ({})
 
 const actions = {
@@ -32,7 +38,10 @@ const actions = {
     displayCondition: selections => selections.length > 1
   }
 };
+
 <I18n dictRequire={dictRequire} lang='en'>
+  <BreakpointsProvider>
+
     {state.selected.length > 0 &&
     <div style={{backgroundColor: 'var(--slateGrey)'}}>
         <SelectionBar
@@ -44,6 +53,7 @@ const actions = {
     }
     <button onClick={addSelected}>Add a selected document</button>
     <button onClick={removeSelected}>Remove a selected document</button>
+  </BreakpointsProvider>
 </I18n>
 
 ```

--- a/react/SelectionBar/Readme.md
+++ b/react/SelectionBar/Readme.md
@@ -7,12 +7,14 @@ import SelectionBar from 'cozy-ui/transpiled/react/SelectionBar';
 import I18n from 'cozy-ui/transpiled/react/I18n';
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints';
 
-initialState = { selected: [] };
 
 const selectedItem = {
     _id: 1,
     type: 'file'
-}
+};
+
+initialState = { selected: isTesting() ? [selectedItem, selectedItem] : [] };
+
 
 const addSelected = () => setState(previousState => {
     const arr = previousState.selected

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -12,7 +12,8 @@ If you want use SelectionBar component, you must have `actions` parameter, like 
 
 actions = {
   trash: {
-    action: selections => dispatch(trashFiles(selections)))
+    action: selections => dispatch(trashFiles(selections))),
+    icon: 'trash'
   },
   rename: {
     action: selections => dispatch(startRenamingAsync(selected[0])),
@@ -52,7 +53,7 @@ const SelectionBar = ({
           key={index}
           disabled={selectedCount < 1}
           onClick={() => actions[actionName].action(selected)}
-          icon={actionName.toLowerCase()}
+          icon={actions[actionName].icon || actionName.toLowerCase()}
           label={t('SelectionBar.' + actionName)}
           iconOnly={isMobile || isTablet ? true : false}
           subtle
@@ -80,4 +81,4 @@ SelectionBar.propTypes = {
   hideSelectionBar: PropTypes.func.isRequired // function to close SelectionBar.
 }
 
-export default withBreakpoints()(translate()(SelectionBar))
+export default translate()(withBreakpoints()(SelectionBar))

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -38,15 +38,15 @@ const SelectionBar = ({
     )
   })
   return (
-    <div className={styles['coz-selectionbar']} role="toolbar">
-      <span className={styles['coz-selectionbar-count']}>
+    <div className={styles['SelectionBar']} role="toolbar">
+      <span className={styles['SelectionBar-count']}>
         {selectedCount}
         <span>
           {' '}
           {t('SelectionBar.selected_count', { smart_count: selectedCount })}
         </span>
       </span>
-      <span className={styles['coz-selectionbar-separator']} />
+      <span className={styles['SelectionBar-separator']} />
       {actionNames.map((actionName, index) => (
         <Button
           type="button"
@@ -64,7 +64,7 @@ const SelectionBar = ({
         label={t('SelectionBar.close')}
         type="button"
         theme="close"
-        className={styles['coz-action-close']}
+        className={styles['SelectionBar-action-close']}
         onClick={hideSelectionBar}
         extension="narrow"
       >

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { translate } from '../I18n'
+import { useI18n } from '../I18n'
 import { Button, Icon } from '../index'
-import withBreakpoints from '../helpers/withBreakpoints'
+import useBreakpoints from '../hooks/useBreakpoints'
 
 import styles from './styles.styl'
 
@@ -23,13 +23,9 @@ actions = {
 
 */
 
-const SelectionBar = ({
-  t,
-  actions,
-  selected,
-  hideSelectionBar,
-  breakpoints: { isMobile, isTablet }
-}) => {
+const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
+  const { t } = useI18n()
+  const { isMobile, isTablet } = useBreakpoints()
   const selectedCount = selected.length
   const actionNames = Object.keys(actions).filter(actionName => {
     const action = actions[actionName]
@@ -75,10 +71,9 @@ const SelectionBar = ({
 }
 
 SelectionBar.propTypes = {
-  t: PropTypes.func.isRequired, // translate action name.
   actions: PropTypes.object.isRequired, // An object with actions
   selected: PropTypes.array.isRequired, // selected items id.
   hideSelectionBar: PropTypes.func.isRequired // function to close SelectionBar.
 }
 
-export default translate()(withBreakpoints()(SelectionBar))
+export default SelectionBar

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -60,7 +60,7 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
         label={t('SelectionBar.close')}
         type="button"
         theme="close"
-        className={styles['SelectionBar-action-close']}
+        className={styles['SelectionBar-actionClose']}
         onClick={hideSelectionBar}
         extension="narrow"
       >

--- a/react/SelectionBar/styles.styl
+++ b/react/SelectionBar/styles.styl
@@ -3,5 +3,5 @@
 @require '../../stylus/components/button'
 @require '../../stylus/components/selectionbar'
 
-[role=application]
+.SelectionBar
   @extend $selectionbar

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -3,53 +3,44 @@
 @require '../utilities/display'
 @require '../tools/mixins'
 
-
-/*------------------------------------*\
-  Selection Bar
-  ======
-
-  This file contains all needs for Selection Bar
-\*------------------------------------*/
-
 $selectionbar
-    .coz-selectionbar
-        position          fixed
-        z-index           $selection-index
-        top               0
-        left              0
-        box-sizing        border-box
-        display           flex
-        justify-content   center
-        align-items       center
-        width             100%
-        height            rem(52)
-        color             var(--white)
-        background-color  var(--slateGrey)
-        font-weight       bold
+    position          fixed
+    z-index           $selection-index
+    top               0
+    left              0
+    box-sizing        border-box
+    display           flex
+    justify-content   center
+    align-items       center
+    width             100%
+    height            rem(52)
+    color             var(--white)
+    background-color  var(--slateGrey)
+    font-weight       bold
 
-        .coz-selectionbar-separator
-            margin            rem(0 8 0 32)
-            width             rem(4)
-            height            rem(4)
-            border-radius     50%
-            background-color  var(--black)
+    .SelectionBar-separator
+        margin            rem(0 8 0 32)
+        width             rem(4)
+        height            rem(4)
+        border-radius     50%
+        background-color  var(--black)
 
-        button
-            padding 0 rem(16)
-            color   var(--white)
+    button
+        padding 0 rem(16)
+        color   var(--white)
 
-        .coz-action-extra
-            display none
+    .SelectionBar-action-extra
+        display none
 
-        .coz-action-close
-            position          absolute
-            top               50%
-            right             0
-            transform         translateY(-50%)
+    .SelectionBar-action-close
+        position          absolute
+        top               50%
+        right             0
+        transform         translateY(-50%)
 
 
     +medium-screen()
-        .coz-selectionbar
+        &
             top              auto
             bottom           0
             justify-content  flex-start
@@ -61,16 +52,16 @@ $selectionbar
             // iPhone X environment tweak
             padding-bottom env(safe-area-inset-bottom)
 
-            .coz-selectionbar-count span
-            .coz-action-moveto
+            .SelectionBar-count span
+            .SelectionBar-action-moveto
                 display none
 
-            .coz-action-extra
+            .SelectionBar-action-extra
                 display block
 
-            .coz-selectionbar-separator
+            .SelectionBar-separator
                 margin   0 0 0 rem(16)
 
-            .coz-action-close
+            .SelectionBar-action-close
                 top auto
                 transform none

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -62,6 +62,6 @@ $selectionbar
             .SelectionBar-separator
                 margin   0 0 0 rem(16)
 
-            .SelectionBar-action-close
+            .SelectionBar-actionClose
                 top auto
                 transform none

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -29,9 +29,6 @@ $selectionbar
         padding 0 rem(16)
         color   var(--white)
 
-    .SelectionBar-action-extra
-        display none
-
     .SelectionBar-action-close
         position          absolute
         top               50%
@@ -53,11 +50,6 @@ $selectionbar
             padding-bottom env(safe-area-inset-bottom)
 
             .SelectionBar-count span
-            .SelectionBar-action-moveto
-                display none
-
-            .SelectionBar-action-extra
-                display block
 
             .SelectionBar-separator
                 margin   0 0 0 rem(16)

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -29,7 +29,7 @@ $selectionbar
         padding 0 rem(16)
         color   var(--white)
 
-    .SelectionBar-action-close
+    .SelectionBar-actionClose
         position          absolute
         top               50%
         right             0


### PR DESCRIPTION
There is a lot to be done for the SelectionBar component, but let's do it gradually.

First: SelectionBar action can now have an icon attribute to use instead of relying only on the Action name
Second: Added an example on the Styleguidist 


https://crash--.github.io/cozy-ui/react/#/Layout%20components?id=selectionbar

@ptbrowne it seems that the style for the SelectionBar is not exported / imported in the styleguidist. Do you know how I can add it? 
