### PR TITLE
feat: Add u-danger color

### DIFF
--- a/stylus/settings/palette.json
+++ b/stylus/settings/palette.json
@@ -41,6 +41,7 @@
   "valid": "var(--validColor)",
   "warn": "var(--warnColor)",
   "error": "var(--errorColor)",
+  "danger": "var(--dangerColor)",
   "errorBackgroundLight": "var(--errorBackgroundLight)",
   "primaryBackgroundLight": "var(--primaryBackgroundLight)",
   "neutralBackground": "var(--neutralBackground)"

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -189,6 +189,7 @@ html, .CozyTheme--normal
 
     --validColor: var(--emerald)
     --warnColor: var(--texasRose)
+    --dangerColor: var(--pomegranate)
 
     --neutralBackground: var(--paleGrey)
 


### PR DESCRIPTION
I needed a semantic color to indicate a "danger zone" like destroying a document. This is currently the same as an error since its value is `pomegranate` but now its semantically correct ;) 