### PR TITLE
docs: Add Example for ActionMenu in a Dialog

### DIFF
--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -279,3 +279,82 @@ const options = [
 
 <SelectBox options={options} menuIsOpen classNamePrefix='needsclick cz' />
 ```
+
+### Fixed SelectBox
+
+When you use a SelectBox within a Modal / Dialog, you can want to have 
+a custom CSS position for your SelectBox's options. `fixed` position makes
+the options to be displayed on top of all the layers. 
+
+```jsx
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs';
+import {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+import SelectBox from 'cozy-ui/transpiled/react/SelectBox';
+const options = [
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'strawberry', label: 'Strawberry', isDisabled: true },
+  { value: 'vanilla', label: 'Vanilla' },
+  { value: 'long', label: 'Salt and vinegar crisps with vegamite and brussel sprouts, double chai latte sauce' },
+];
+
+const handleClose = () => setState({ modalOpened: false })
+
+initialState = { modalOpened: isTesting()  }
+
+const ExampleDialog = ({ open, onClose }) => {
+  return (
+    <Dialog 
+      open={open} 
+      onClose={onClose} 
+      title='Ada Lovelace'
+      content={
+        <>
+          <span>Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
+          – 27 November 1852) was an English mathematician and writer, chiefly
+          known for her work on Charles Babbage's proposed mechanical
+          general-purpose computer, the Analytical Engine. She was the first to
+          recognise that the machine had applications beyond pure calculation, and
+          published the first algorithm intended to be carried out by such a
+          machine. As a result, she is often regarded as the first to recognise
+          the full potential of a "computing machine" and the first computer
+          programmer.</span>
+          <SelectBox options={options} menuIsOpen  menuPosition='fixed'/>
+        </>
+      }
+      actions={
+        <>
+          <Button
+            theme="secondary"
+            onClick={() => onClose()}
+            label={'Close Modal'}
+          />
+          <Button
+            theme="primary"
+            label={'Touch Me'}
+            onClick={() => alert('click')}
+          />
+        </>
+      }
+    />
+    
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog open={state.modalOpened} onClose={handleClose} />
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -7143,6 +7143,8 @@ exports[`SelectBox should render examples: SelectBox 13`] = `
 </div>"
 `;
 
+exports[`SelectBox should render examples: SelectBox 14`] = `"<div><button>Toggle modal</button></div>"`;
+
 exports[`Sidebar should render examples: Sidebar 1`] = `
 "<div>
   <aside class=\\"styles__o-sidebar___1295j\\" id=\\"sidebar\\">

--- a/rsgscreenshots.json
+++ b/rsgscreenshots.json
@@ -12,5 +12,8 @@
   },
   "Dialog": {
     "perExampleScreenshot": true
+  },
+  "SelectBox": {
+    "perExampleScreenshot": true
   }
 }


### PR DESCRIPTION
In a few cases, a SelectBox can be displayed in a Dialog. By default, in that case, the content of the SelectBox will be inside the ModalContent. Using `fixed` resolves this issue. I'm not setting it by default since the Select is now fixed, it doesn't follow the scroll 

see: https://crash--.github.io/cozy-ui/react/#/Forms?id=selectbox


<img width="745" alt="Capture d’écran 2020-10-16 à 14 33 45" src="https://user-images.githubusercontent.com/1107936/96259624-2aba7e00-0fbe-11eb-9c8f-f94befa87b2b.png">



<img width="673" alt="Capture d’écran 2020-10-16 à 14 34 06" src="https://user-images.githubusercontent.com/1107936/96259636-2c844180-0fbe-11eb-8649-e55ef2dc2460.png">

