### PR TITLE
docs: Add mention of developing inside the styleguidist

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,19 +60,39 @@ The entire library is also available as a good ol’ CSS library. You can simply
 
 ## Develop on Cozy UI
 
-If you want to customize or improve a Cozy UI Component, you need to clone a local version of the library, and declare it as a local symlink with `yarn link`.
+If you want to develop inside cozy-ui, you need a local version cozy-ui.
 
-```
+```bash
 git clone git@github.com:cozy/cozy-ui.git
+```
+
+### Develop inside the styleguidist
+
+It is convenient when modifying a component to use the styleguide site.
+
+```bash
+yarn watch:doc:react # Run the styleguide in watch mode
+```
+
+### Develop inside an app
+
+Sometimes, you want to develop on a component, from the context of an app.
+Then you need to link cozy-ui with `yarn link`.
+
+```bash
 cd cozy-ui
 yarn link
 yarn transpile --watch # Launch transpilation
 ```
 
-Then in your application folder, you can link to your local Cozy UI
+Then in your application folder, you can link to your local Cozy UI.
+You can use [rlink](https://gist.github.com/ptbrowne/add609bdcf4396d32072acc4674fff23)
+instead of `yarn link`. It will prevent common build problems due
+to module resolution inside symlinked folders.
 
-```
-yarn link cozy-ui
+```bash
+cd my-app
+rlink cozy-ui # Prefer rlink to yarn link
 yarn watch
 ```
 
@@ -81,7 +101,7 @@ All your modifications in your local Cozy UI will now be visible in your applica
 When sending a PR, if your changes have graphic impacts, it is useful for the reviewers if
 you have deployed a version of the styleguidist containing your changes to your repository.
 
-```
+```bash
 yarn build:doc:react
 yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
 ```
@@ -96,12 +116,12 @@ If your app uses [React Styleguidist][], `cozy-ui` provides `rsg-screenshots`, a
 screenshots of your components (uses Puppeteer under the hood).
 
 ```bash
-$ yarn add cozy-ui
-$ # The rsg-screenshots binary is now installed
-$ yarn build:doc:react # Build our styleguide, the output directory is docs/react
-$ rsg-screenshots --screenshot-dir screenshots/ --styleguide-dir docs/react
+yarn add cozy-ui
+# The rsg-screenshots binary is now installed
+yarn build:doc:react # Build our styleguide, the output directory is docs/react
+rsg-screenshots --screenshot-dir screenshots/ --styleguide-dir docs/react
 # Each component in the styleguide will be screenshotted and saved inside the
-# screenshots/ directory
+screenshots/ directory
 ```
 
 See our [travis configuration](./travis.yml) for more information.


### PR DESCRIPTION
Developing a component from the styleguidist was not mentioned in the README.