### PR TITLE
Change tabs font size to match subtitle1

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -83,16 +83,6 @@ export const normalTheme = createMuiTheme({
     borderRadius: defaultValues.borderRadius
   },
   breakpoints: {
-    // Define custom breakpoint values.
-    // These will apply to Material-UI components that use responsive
-    // breakpoints, such as `Grid` and `Hidden`. You can also use the
-    // theme breakpoint functions `up`, `down`, and `between` to create
-    // media queries for these breakpoints
-    // xs = all
-    // sm = tiny
-    // md = small
-    // lg = medium
-    // xl = large
     values: {
       xs: 0,
       sm: 480,

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -153,6 +153,12 @@ normalTheme.overrides = {
     },
     textColorSecondary: {
       color: 'var(--coolGrey)'
+    },
+    root: {
+      fontSize: normalTheme.typography.subtitle1.fontSize,
+      [normalTheme.breakpoints.up('md')]: {
+        fontSize: normalTheme.typography.subtitle1.fontSize
+      }
     }
   },
   MuiExpansionPanel: {


### PR DESCRIPTION
We had a small discrepancy between our tabs font-size and the one that
we should use (the fontsize from subtitle1).

https://ptbrowne.github.io/cozy-ui/react/#!/Tab