### PR TITLE
refactor: Dialog and add Dialog usecases

### DIFF
--- a/react/Dialog/DialogActions.jsx
+++ b/react/Dialog/DialogActions.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import MUIDialogActions from '@material-ui/core/DialogActions'
 
-const DialogActions = ({ layout, children }) => {
-  const className = layout === 'row' ? { className: 'modal_actions_row' } : {}
+const DialogActions = ({ below, children }) => {
+  const className = below ? { className: 'modal_actions_below' } : {}
+
   return <MUIDialogActions {...className}>{children}</MUIDialogActions>
 }
 

--- a/react/Dialog/DialogBackButton.jsx
+++ b/react/Dialog/DialogBackButton.jsx
@@ -5,7 +5,7 @@ const DialogBackButton = ({ onClick }) => {
   return (
     <Icon
       onClick={onClick}
-      icon="left"
+      icon="previous"
       className="u-c-pointer u-coolGrey u-mr-1"
     />
   )

--- a/react/Dialog/DialogContent.jsx
+++ b/react/Dialog/DialogContent.jsx
@@ -1,3 +1,15 @@
-import DialogContent from '@material-ui/core/DialogContent'
+import React from 'react'
+import MUIDialogContent from '@material-ui/core/DialogContent'
+
+const DialogContent = ({ unfixed, withDividers, children, ...props }) => {
+  const style = unfixed ? { style: { overflowY: 'initial' } } : {}
+  const className = withDividers ? { className: 'modal_content_dividers' } : {}
+
+  return (
+    <MUIDialogContent {...props} {...style} {...className}>
+      {children}
+    </MUIDialogContent>
+  )
+}
 
 export default DialogContent

--- a/react/Dialog/DialogTitle.jsx
+++ b/react/Dialog/DialogTitle.jsx
@@ -1,26 +1,14 @@
 import React from 'react'
 import MUIDialogTitle from '@material-ui/core/DialogTitle'
-import { withStyles } from '@material-ui/core/styles'
-import AppTitle from '../AppTitle'
-import styles from './styles.styl'
 
-const DialogTitle = ({ children, classes }) => {
+const DialogTitle = ({ children, classes, ellipsis }) => {
+  const className = ellipsis ? { className: 'u-ellipsis' } : {}
+
   return (
-    <MUIDialogTitle disableTypography classes={classes}>
-      {/*
-        The h6 tag is used here since the modal title is always deeply nested in the DOM.
-        This is what MuiDialogTitle originally uses for its inner Typography component.
-      */}
-      <AppTitle className={styles.DialogTitle} tag="h6" id="dialog-title">
-        {children}
-      </AppTitle>
+    <MUIDialogTitle disableTypography classes={classes} {...className}>
+      {children}
     </MUIDialogTitle>
   )
 }
 
-export default withStyles({
-  root: {
-    paddingTop: 0,
-    paddingBottom: 0
-  }
-})(DialogTitle)
+export default DialogTitle

--- a/react/Dialog/Readme.md
+++ b/react/Dialog/Readme.md
@@ -1,10 +1,14 @@
 ## Dialog
 
+* Default behavior : header/footer fixed, no dividers, no ellipsis on title
 * Dialogs have no close button, but Cozy-UI exposes `DialogCloseButton` that can be included as a child of `<Dialog />`.
 * Use `<Dialog scroll="body" />` to make the whole Dialog scrollable, instead of only the `DialogContent`.
-* Use [Divider components](https://v3.material-ui.com/api/divider/) when you need to materialize the separation between `DialogTitle`, `DialogContent` and `DialogActions`.
+* `Divider` : Use [Divider components](https://v3.material-ui.com/api/divider/) when you need to materialize the separation between `DialogTitle`, `DialogContent` and `DialogActions`. Needs to come with `withDividers` on `<DialogContent />`
+* `DialogTitle` may accept `ellipsis` prop to add ellipsis on title
+* `DialogActions` may accept `below` prop to show actions in column
+* `DialogContent` may accept `unfixed` prop to unfixed header and footer
 
-### With default Actions (mobile and desktop)
+### With default Actions (with dividers)
 
 ```jsx
 import Dialog, {
@@ -36,7 +40,7 @@ const ExampleDialog = ({ opened, onClose }) => {
         {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Ada Lovelace
       </DialogTitle>
       <Divider />
-      <DialogContent>
+      <DialogContent withDividers>
         Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
         – 27 November 1852) was an English mathematician and writer, chiefly
         known for her work on Charles Babbage's proposed mechanical
@@ -47,6 +51,7 @@ const ExampleDialog = ({ opened, onClose }) => {
         the full potential of a "computing machine" and the first computer
         programmer.
       </DialogContent>
+      <Divider />
       <DialogActions>
         <Button
           theme="secondary"
@@ -75,7 +80,7 @@ const ExampleDialog = ({ opened, onClose }) => {
 </>
 ```
 
-### With "below" Actions (mobile)
+### With "below" Actions (on mobile)
 
 ```jsx
 import Dialog, {
@@ -115,7 +120,183 @@ initialState = { modalOpened: isTesting() }
           the full potential of a "computing machine" and the first computer
           programmer.
         </DialogContent>
-        <DialogActions layout="row">
+        <DialogActions below>
+          <Button
+            theme="secondary"
+            onClick={() => onClose()}
+            label={'This button to close the modal'}
+          />
+          <Button
+            theme="primary"
+            label={'This button to, well, why not ?'}
+            onClick={() => alert('click')}
+          />
+        </DialogActions>
+      </Dialog>
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```
+
+### With long content (with dividers)
+
+```jsx
+import Dialog, {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogCloseButton,
+  DialogBackButton
+} from 'cozy-ui/transpiled/react/Dialog';
+import useBreakpoints, {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const handleClose = () => setState({ modalOpened: !state.modalOpened })
+
+initialState = { modalOpened: isTesting() }
+
+const ExampleDialog = ({ opened, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  return (
+    <Dialog open={opened} onClose={onClose}>
+      <DialogCloseButton onClick={onClose} />
+      <DialogTitle>
+        {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Ada Lovelace
+      </DialogTitle>
+      <Divider />
+      <DialogContent withDividers>
+        { new Array(100).fill('Augusta Ada King-Noel was an English mathematician and writer.').join('\n') }
+      </DialogContent>
+      <Divider />
+      <DialogActions>
+        <Button
+          theme="secondary"
+          onClick={() => onClose()}
+          label={'Close Modal'}
+        />
+        <Button
+          theme="primary"
+          label={'Touch Me'}
+          onClick={() => alert('click')}
+        />
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog opened={state.modalOpened} onClose={handleClose} />
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```
+
+### With long content (header/footer not fixed)
+
+```jsx
+import Dialog, {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogCloseButton,
+  DialogBackButton
+} from 'cozy-ui/transpiled/react/Dialog';
+import useBreakpoints, {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const handleClose = () => setState({ modalOpened: !state.modalOpened })
+
+initialState = { modalOpened: isTesting() }
+
+const ExampleDialog = ({ opened, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  return (
+    <Dialog open={opened} onClose={onClose}>
+      <DialogCloseButton onClick={onClose} />
+      <DialogTitle>
+        {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Ada Lovelace
+      </DialogTitle>
+      <DialogContent unfixed>
+        { new Array(100).fill('Augusta Ada King-Noel was an English mathematician and writer.').join('\n') }
+      </DialogContent>
+      <DialogActions>
+        <Button
+          theme="secondary"
+          onClick={() => onClose()}
+          label={'Close Modal'}
+        />
+        <Button
+          theme="primary"
+          label={'Touch Me'}
+          onClick={() => alert('click')}
+        />
+      </DialogActions>
+      <div className="u-pb-1" />
+    </Dialog>
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog opened={state.modalOpened} onClose={handleClose} />
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```
+
+### With long content (header fixed only)
+
+```jsx
+import Dialog, {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogCloseButton,
+  DialogBackButton
+} from 'cozy-ui/transpiled/react/Dialog';
+import useBreakpoints, {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const handleClose = () => setState({ modalOpened: !state.modalOpened })
+
+initialState = { modalOpened: isTesting() }
+
+const ExampleDialog = ({ opened, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  return (
+    <Dialog open={opened} onClose={onClose}>
+      <DialogCloseButton onClick={onClose} />
+      <DialogTitle>
+        {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Ada Lovelace
+      </DialogTitle>
+      <DialogContent>
+        { new Array(100).fill('Augusta Ada King-Noel was an English mathematician and writer.').join('\n') }
+        <DialogActions>
           <Button
             theme="secondary"
             onClick={() => onClose()}
@@ -127,7 +308,229 @@ initialState = { modalOpened: isTesting() }
             onClick={() => alert('click')}
           />
         </DialogActions>
-      </Dialog>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog opened={state.modalOpened} onClose={handleClose} />
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```
+
+### With long title
+
+```jsx
+import Dialog, {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogCloseButton,
+  DialogBackButton
+} from 'cozy-ui/transpiled/react/Dialog';
+import useBreakpoints, {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const handleClose = () => setState({ modalOpened: !state.modalOpened })
+
+initialState = { modalOpened: isTesting() }
+
+const ExampleDialog = ({ opened, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  return (
+    <Dialog open={opened} onClose={onClose}>
+      <DialogCloseButton onClick={onClose} />
+      <DialogTitle>
+        {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
+          – 27 November 1852) was an English mathematician and writer, chiefly
+          known for her work on Charles Babbage's proposed mechanical
+          general-purpose computer, the Analytical Engine.
+      </DialogTitle>
+      <DialogContent>
+          Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
+          – 27 November 1852) was an English mathematician and writer, chiefly
+          known for her work on Charles Babbage's proposed mechanical
+          general-purpose computer, the Analytical Engine. She was the first to
+          recognise that the machine had applications beyond pure calculation, and
+          published the first algorithm intended to be carried out by such a
+          machine. As a result, she is often regarded as the first to recognise
+          the full potential of a "computing machine" and the first computer
+          programmer.
+      </DialogContent>
+      <DialogActions>
+        <Button
+          theme="secondary"
+          onClick={() => onClose()}
+          label={'Close Modal'}
+        />
+        <Button
+          theme="primary"
+          label={'Touch Me'}
+          onClick={() => alert('click')}
+        />
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog opened={state.modalOpened} onClose={handleClose} />
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```
+
+### With long title (with ellipsis)
+
+```jsx
+import Dialog, {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogCloseButton,
+  DialogBackButton
+} from 'cozy-ui/transpiled/react/Dialog';
+import useBreakpoints, {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const handleClose = () => setState({ modalOpened: !state.modalOpened })
+
+initialState = { modalOpened: isTesting() }
+
+const ExampleDialog = ({ opened, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  return (
+    <Dialog open={opened} onClose={onClose}>
+      <DialogCloseButton onClick={onClose} />
+      <DialogTitle ellipsis>
+        {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
+          – 27 November 1852) was an English mathematician and writer, chiefly
+          known for her work on Charles Babbage's proposed mechanical
+          general-purpose computer, the Analytical Engine.
+      </DialogTitle>
+      <DialogContent>
+          Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
+          – 27 November 1852) was an English mathematician and writer, chiefly
+          known for her work on Charles Babbage's proposed mechanical
+          general-purpose computer, the Analytical Engine. She was the first to
+          recognise that the machine had applications beyond pure calculation, and
+          published the first algorithm intended to be carried out by such a
+          machine. As a result, she is often regarded as the first to recognise
+          the full potential of a "computing machine" and the first computer
+          programmer.
+      </DialogContent>
+      <DialogActions>
+        <Button
+          theme="secondary"
+          onClick={() => onClose()}
+          label={'Close Modal'}
+        />
+        <Button
+          theme="primary"
+          label={'Touch Me'}
+          onClick={() => alert('click')}
+        />
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog opened={state.modalOpened} onClose={handleClose} />
+    </MuiCozyTheme>
+  </BreakpointsProvider>
+</>
+```
+
+### With long title and long content (with ellipsis and dividers)
+
+```jsx
+import Dialog, {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogCloseButton,
+  DialogBackButton
+} from 'cozy-ui/transpiled/react/Dialog';
+import useBreakpoints, {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const handleClose = () => setState({ modalOpened: !state.modalOpened })
+
+initialState = { modalOpened: isTesting() }
+
+const ExampleDialog = ({ opened, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  return (
+    <Dialog open={opened} onClose={onClose}>
+      <DialogCloseButton onClick={onClose} />
+      <DialogTitle ellipsis>
+        {isMobile ? <DialogBackButton onClick={onClose} /> :  null } Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815
+          – 27 November 1852) was an English mathematician and writer, chiefly
+          known for her work on Charles Babbage's proposed mechanical
+          general-purpose computer, the Analytical Engine.
+      </DialogTitle>
+      <Divider />
+      <DialogContent withDividers>
+          { new Array(100).fill('Augusta Ada King-Noel was an English mathematician and writer.').join('\n') }
+      </DialogContent>
+      <Divider />
+      <DialogActions>
+        <Button
+          theme="secondary"
+          onClick={() => onClose()}
+          label={'Close Modal'}
+        />
+        <Button
+          theme="primary"
+          label={'Touch Me'}
+          onClick={() => alert('click')}
+        />
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+;<>
+  <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
+    Toggle modal
+  </button>
+  <BreakpointsProvider>
+    <MuiCozyTheme>
+      <ExampleDialog opened={state.modalOpened} onClose={handleClose} />
     </MuiCozyTheme>
   </BreakpointsProvider>
 </>

--- a/react/Dialog/styles.styl
+++ b/react/Dialog/styles.styl
@@ -1,7 +1,7 @@
 @require 'settings/breakpoints.styl'
 
 .DialogCloseButton
-    top 0.8125rem
+    top 0.83rem
     right 1.5rem
     background-color transparent
     margin 0
@@ -14,14 +14,5 @@
 
 +small-screen()
     .DialogCloseButton
-        top 0rem
+        top 0.35rem
         right 0.5rem
-
-.DialogTitle
-    margin-top -1.5rem // Cancels padding of the dialog
-    height 4rem // Should match with the DialogCloseButton size so that cross and title are centered
-
-+small-screen()
-    .DialogTitle
-        margin-top -1rem
-        height 3rem

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -347,10 +347,10 @@ normalTheme.overrides = {
     paper: {
       'box-sizing': 'border-box',
       [normalTheme.breakpoints.down('md')]: {
-        padding: `${defaultValues.dialog.sm.padding}px`
+        padding: `12px ${defaultValues.dialog.sm.padding}px`
       },
       [normalTheme.breakpoints.up('md')]: {
-        padding: `${defaultValues.dialog.md.padding}px`
+        padding: `16px ${defaultValues.dialog.md.padding}px`
       }
     },
     paperWidthSm: {
@@ -366,21 +366,26 @@ normalTheme.overrides = {
   },
   MuiDialogContent: {
     root: {
+      '&.modal_content_dividers': {
+        padding: '1.5rem 0'
+      },
       [normalTheme.breakpoints.up('md')]: {
-        padding: `${defaultValues.dialog.md.padding}px 0`
+        padding: '0 0 0.75rem'
       },
       [normalTheme.breakpoints.down('sm')]: {
-        padding: `${defaultValues.dialog.sm.padding}px 0`
-      },
-
-      overflowY: 'initial'
+        padding: '0',
+        '&.modal_content_dividers': {
+          padding: '1rem 0'
+        }
+      }
     }
   },
   MuiDialogActions: {
     root: {
       padding: '0',
+      margin: '12px 0 0',
       [normalTheme.breakpoints.down('sm')]: {
-        margin: 0,
+        margin: '8px 0 0',
         '& button': {
           '&:only-child': {
             width: '100%'
@@ -402,9 +407,13 @@ normalTheme.overrides = {
   },
   MuiDialogTitle: {
     root: {
-      padding: '0 0 16px 0',
+      ...normalTheme.typography.h3,
+      padding: '4px 0 0',
+      marginBottom: '20px',
+      width: '90%', // to not recover DialogCloseButton
       [normalTheme.breakpoints.down('sm')]: {
-        padding: '14px 0 16px 0'
+        ...normalTheme.typography.h4,
+        marginBottom: '12px'
       }
     }
   },

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2087,6 +2087,18 @@ exports[`Dialog should render examples: Dialog 3`] = `
 </div>"
 `;
 
+exports[`Dialog should render examples: Dialog 3`] = `"<div><button>Toggle modal</button></div>"`;
+
+exports[`Dialog should render examples: Dialog 4`] = `"<div><button>Toggle modal</button></div>"`;
+
+exports[`Dialog should render examples: Dialog 5`] = `"<div><button>Toggle modal</button></div>"`;
+
+exports[`Dialog should render examples: Dialog 6`] = `"<div><button>Toggle modal</button></div>"`;
+
+exports[`Dialog should render examples: Dialog 7`] = `"<div><button>Toggle modal</button></div>"`;
+
+exports[`Dialog should render examples: Dialog 8`] = `"<div><button>Toggle modal</button></div>"`;
+
 exports[`Empty should render examples: Empty 1`] = `
 "<div>
   <div style=\\"position: relative; transform: translateZ(0); height: 500px; display: flex;\\">
@@ -5459,19 +5471,19 @@ exports[`Labs/CollectionField should render examples: Labs/CollectionField 1`] =
 
 exports[`ListItemText should render examples: ListItemText 1`] = `
 "<div>
-  <div class=\\"MuiListItemText-root-83\\"><span class=\\"MuiTypography-root-89 u-db u-ellipsis MuiTypography-subheading-96 MuiListItemText-primary-86\\">I'm a list item text</span></div>
+  <div class=\\"MuiListItemText-root-82\\"><span class=\\"MuiTypography-root-88 u-db u-ellipsis MuiTypography-subheading-95 MuiListItemText-primary-85\\">I'm a list item text</span></div>
 </div>"
 `;
 
 exports[`ListItemText should render examples: ListItemText 2`] = `
 "<div>
-  <div class=\\"MuiListItemText-root-83\\"><span class=\\"MuiTypography-root-89 u-db u-ellipsis MuiTypography-subheading-96 MuiListItemText-primary-86\\">I'm a primary text</span><span class=\\"MuiTypography-root-89 u-db u-ellipsis MuiTypography-caption-99 MuiTypography-colorTextSecondary-122 MuiListItemText-secondary-87\\">I'm a secondary text</span></div>
+  <div class=\\"MuiListItemText-root-82\\"><span class=\\"MuiTypography-root-88 u-db u-ellipsis MuiTypography-subheading-95 MuiListItemText-primary-85\\">I'm a primary text</span><span class=\\"MuiTypography-root-88 u-db u-ellipsis MuiTypography-caption-98 MuiTypography-colorTextSecondary-121 MuiListItemText-secondary-86\\">I'm a secondary text</span></div>
 </div>"
 `;
 
 exports[`ListItemText should render examples: ListItemText 3`] = `
 "<div>
-  <div class=\\"MuiListItemText-root-83\\"><span class=\\"MuiTypography-root-89 u-db u-ellipsis MuiTypography-subheading-96 MuiListItemText-primary-86\\"><div class=\\"u-text\\">I'm a primary text</div><a class=\\"u-caption\\" href=\\"http://cozy.io\\"><div class=\\"u-midellipsis\\"><span>Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815 – 27 November 1852) was an English mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical general-purpose computer, the Analytical Engine. She was the first to recognis</span><span>e that the machine had applications beyond pure calculation, and published the first algorithm intended to be carried out by such a machine. As a result, she is often regarded as the first to recognise the full potential of a \\"computing machine\\" and the first computer programmer.</span></div></a></span>
+  <div class=\\"MuiListItemText-root-82\\"><span class=\\"MuiTypography-root-88 u-db u-ellipsis MuiTypography-subheading-95 MuiListItemText-primary-85\\"><div class=\\"u-text\\">I'm a primary text</div><a class=\\"u-caption\\" href=\\"http://cozy.io\\"><div class=\\"u-midellipsis\\"><span>Augusta Ada King-Noel, Countess of Lovelace (née Byron; 10 December 1815 – 27 November 1852) was an English mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical general-purpose computer, the Analytical Engine. She was the first to recognis</span><span>e that the machine had applications beyond pure calculation, and published the first algorithm intended to be carried out by such a machine. As a result, she is often regarded as the first to recognise the full potential of a \\"computing machine\\" and the first computer programmer.</span></div></a></span>
 </div>
 </div>"
 `;
@@ -5571,19 +5583,19 @@ exports[`MuiCozyTheme/Switch should render examples: MuiCozyTheme/Switch 1`] = `
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Primary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-125\\"><span class=\\"MuiButtonBase-root-144 MuiIconButton-root-138 MuiPrivateSwitchBase-root-134 MuiSwitch-switchBase-128 MuiSwitch-colorPrimary-130 MuiPrivateSwitchBase-checked-135 MuiSwitch-checked-129\\"><span class=\\"MuiIconButton-label-143\\"><span class=\\"MuiSwitch-icon-126 MuiSwitch-iconChecked-127\\"></span><input class=\\"MuiPrivateSwitchBase-input-137\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-169\\"></span></span><span class=\\"MuiSwitch-bar-133\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-124\\"><span class=\\"MuiButtonBase-root-143 MuiIconButton-root-137 MuiPrivateSwitchBase-root-133 MuiSwitch-switchBase-127 MuiSwitch-colorPrimary-129 MuiPrivateSwitchBase-checked-134 MuiSwitch-checked-128\\"><span class=\\"MuiIconButton-label-142\\"><span class=\\"MuiSwitch-icon-125 MuiSwitch-iconChecked-126\\"></span><input class=\\"MuiPrivateSwitchBase-input-136\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-168\\"></span></span><span class=\\"MuiSwitch-bar-132\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Secondary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-125\\"><span class=\\"MuiButtonBase-root-144 MuiIconButton-root-138 MuiPrivateSwitchBase-root-134 MuiSwitch-switchBase-128 MuiSwitch-colorSecondary-131 MuiPrivateSwitchBase-checked-135 MuiSwitch-checked-129\\"><span class=\\"MuiIconButton-label-143\\"><span class=\\"MuiSwitch-icon-126 MuiSwitch-iconChecked-127\\"></span><input class=\\"MuiPrivateSwitchBase-input-137\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-169\\"></span></span><span class=\\"MuiSwitch-bar-133\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-124\\"><span class=\\"MuiButtonBase-root-143 MuiIconButton-root-137 MuiPrivateSwitchBase-root-133 MuiSwitch-switchBase-127 MuiSwitch-colorSecondary-130 MuiPrivateSwitchBase-checked-134 MuiSwitch-checked-128\\"><span class=\\"MuiIconButton-label-142\\"><span class=\\"MuiSwitch-icon-125 MuiSwitch-iconChecked-126\\"></span><input class=\\"MuiPrivateSwitchBase-input-136\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-168\\"></span></span><span class=\\"MuiSwitch-bar-132\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Disabled</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-125\\"><span class=\\"MuiButtonBase-root-144 MuiButtonBase-disabled-145 MuiIconButton-root-138 MuiIconButton-disabled-142 MuiPrivateSwitchBase-root-134 MuiSwitch-switchBase-128 MuiSwitch-colorSecondary-131 MuiPrivateSwitchBase-disabled-136 MuiSwitch-disabled-132\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-143\\"><span class=\\"MuiSwitch-icon-126\\"></span><input class=\\"MuiPrivateSwitchBase-input-137\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-133\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-124\\"><span class=\\"MuiButtonBase-root-143 MuiButtonBase-disabled-144 MuiIconButton-root-137 MuiIconButton-disabled-141 MuiPrivateSwitchBase-root-133 MuiSwitch-switchBase-127 MuiSwitch-colorSecondary-130 MuiPrivateSwitchBase-disabled-135 MuiSwitch-disabled-131\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-142\\"><span class=\\"MuiSwitch-icon-125\\"></span><input class=\\"MuiPrivateSwitchBase-input-136\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-132\\"></span></span></div>
       </div>
     </div>
     <div class=\\"u-title-h2 u-mt-1\\">Inverted theme</div>
@@ -5592,19 +5604,19 @@ exports[`MuiCozyTheme/Switch should render examples: MuiCozyTheme/Switch 1`] = `
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Primary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-147\\"><span class=\\"MuiButtonBase-root-166 MuiIconButton-root-160 MuiPrivateSwitchBase-root-156 MuiSwitch-switchBase-150 MuiSwitch-colorPrimary-152 MuiPrivateSwitchBase-checked-157 MuiSwitch-checked-151\\"><span class=\\"MuiIconButton-label-165\\"><span class=\\"MuiSwitch-icon-148 MuiSwitch-iconChecked-149\\"></span><input class=\\"MuiPrivateSwitchBase-input-159\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-176\\"></span></span><span class=\\"MuiSwitch-bar-155\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-146\\"><span class=\\"MuiButtonBase-root-165 MuiIconButton-root-159 MuiPrivateSwitchBase-root-155 MuiSwitch-switchBase-149 MuiSwitch-colorPrimary-151 MuiPrivateSwitchBase-checked-156 MuiSwitch-checked-150\\"><span class=\\"MuiIconButton-label-164\\"><span class=\\"MuiSwitch-icon-147 MuiSwitch-iconChecked-148\\"></span><input class=\\"MuiPrivateSwitchBase-input-158\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-175\\"></span></span><span class=\\"MuiSwitch-bar-154\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Secondary</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-147\\"><span class=\\"MuiButtonBase-root-166 MuiIconButton-root-160 MuiPrivateSwitchBase-root-156 MuiSwitch-switchBase-150 MuiSwitch-colorSecondary-153 MuiPrivateSwitchBase-checked-157 MuiSwitch-checked-151\\"><span class=\\"MuiIconButton-label-165\\"><span class=\\"MuiSwitch-icon-148 MuiSwitch-iconChecked-149\\"></span><input class=\\"MuiPrivateSwitchBase-input-159\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-176\\"></span></span><span class=\\"MuiSwitch-bar-155\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-146\\"><span class=\\"MuiButtonBase-root-165 MuiIconButton-root-159 MuiPrivateSwitchBase-root-155 MuiSwitch-switchBase-149 MuiSwitch-colorSecondary-152 MuiPrivateSwitchBase-checked-156 MuiSwitch-checked-150\\"><span class=\\"MuiIconButton-label-164\\"><span class=\\"MuiSwitch-icon-147 MuiSwitch-iconChecked-148\\"></span><input class=\\"MuiPrivateSwitchBase-input-158\\" type=\\"checkbox\\" value=\\"\\" checked=\\"\\"></span><span class=\\"MuiTouchRipple-root-175\\"></span></span><span class=\\"MuiSwitch-bar-154\\"></span></span></div>
       </div>
       <div class=\\"styles__media___cSJMp\\">
         <div class=\\"styles__img___3SHpG\\">
           <div class=\\"u-text\\">Disabled</div>
         </div>
-        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-147\\"><span class=\\"MuiButtonBase-root-166 MuiButtonBase-disabled-167 MuiIconButton-root-160 MuiIconButton-disabled-164 MuiPrivateSwitchBase-root-156 MuiSwitch-switchBase-150 MuiSwitch-colorSecondary-153 MuiPrivateSwitchBase-disabled-158 MuiSwitch-disabled-154\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-165\\"><span class=\\"MuiSwitch-icon-148\\"></span><input class=\\"MuiPrivateSwitchBase-input-159\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-155\\"></span></span></div>
+        <div class=\\"styles__img___3SHpG\\"><span class=\\"MuiSwitch-root-146\\"><span class=\\"MuiButtonBase-root-165 MuiButtonBase-disabled-166 MuiIconButton-root-159 MuiIconButton-disabled-163 MuiPrivateSwitchBase-root-155 MuiSwitch-switchBase-149 MuiSwitch-colorSecondary-152 MuiPrivateSwitchBase-disabled-157 MuiSwitch-disabled-153\\" tabindex=\\"-1\\"><span class=\\"MuiIconButton-label-164\\"><span class=\\"MuiSwitch-icon-147\\"></span><input class=\\"MuiPrivateSwitchBase-input-158\\" disabled=\\"\\" type=\\"checkbox\\" value=\\"\\"></span></span><span class=\\"MuiSwitch-bar-154\\"></span></span></div>
       </div>
     </div>
   </div>
@@ -6167,22 +6179,30 @@ exports[`Table should render examples: Table 1`] = `
 
 exports[`Tabs should render examples: Tabs 1`] = `
 "<div>
-  <div class=\\"MuiTabs-root-183\\" aria-label=\\"simple tabs example\\">
-    <div class=\\"MuiTabs-flexContainer-184\\">
-      <div class=\\"MuiTabs-scroller-186 MuiTabs-fixed-187\\" style=\\"margin-bottom: 0px;\\" role=\\"tablist\\">
-        <div class=\\"MuiTabs-flexContainer-184\\"><button class=\\"MuiButtonBase-root-204 MuiTab-root-192 MuiTab-textColorPrimary-195 MuiTab-selected-197\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"true\\" id=\\"simple-tab-0\\" aria-controls=\\"simple-tabpanel-0\\"><span class=\\"MuiTab-wrapper-200\\"><span class=\\"MuiTab-labelContainer-201\\"><span class=\\"MuiTab-label-202\\">Item One</span></span></span><span class=\\"MuiTouchRipple-root-242\\"></span></button><button class=\\"MuiButtonBase-root-204 MuiTab-root-192 MuiTab-textColorPrimary-195\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-1\\" aria-controls=\\"simple-tabpanel-1\\"><span class=\\"MuiTab-wrapper-200\\"><span class=\\"MuiTab-labelContainer-201\\"><span class=\\"MuiTab-label-202\\">Item Two</span></span></span><span class=\\"MuiTouchRipple-root-242\\"></span></button><button class=\\"MuiButtonBase-root-204 MuiTab-root-192 MuiTab-textColorPrimary-195\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-2\\" aria-controls=\\"simple-tabpanel-2\\"><span class=\\"MuiTab-wrapper-200\\"><span class=\\"MuiTab-labelContainer-201\\"><span class=\\"MuiTab-label-202\\">Item Three</span></span></span><span class=\\"MuiTouchRipple-root-242\\"></span></button></div><span class=\\"MuiPrivateTabIndicator-root-207 MuiPrivateTabIndicator-colorPrimary-208 MuiTabs-indicator-191\\" style=\\"left: 0px; width: 0px;\\"></span>
+  <div class=\\"MuiTabs-root-182\\" aria-label=\\"simple tabs example\\">
+    <div class=\\"MuiTabs-flexContainer-183\\">
+      <div class=\\"MuiTabs-scroller-185 MuiTabs-fixed-186\\" style=\\"margin-bottom: 0px;\\" role=\\"tablist\\">
+        <div class=\\"MuiTabs-flexContainer-183\\"><button class=\\"MuiButtonBase-root-203 MuiTab-root-191 MuiTab-textColorPrimary-194 MuiTab-selected-196\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"true\\" id=\\"simple-tab-0\\" aria-controls=\\"simple-tabpanel-0\\"><span class=\\"MuiTab-wrapper-199\\"><span class=\\"MuiTab-labelContainer-200\\"><span class=\\"MuiTab-label-201\\">Item One</span></span></span><span class=\\"MuiTouchRipple-root-241\\"></span></button><button class=\\"MuiButtonBase-root-203 MuiTab-root-191 MuiTab-textColorPrimary-194\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-1\\" aria-controls=\\"simple-tabpanel-1\\"><span class=\\"MuiTab-wrapper-199\\"><span class=\\"MuiTab-labelContainer-200\\"><span class=\\"MuiTab-label-201\\">Item Two</span></span></span><span class=\\"MuiTouchRipple-root-241\\"></span></button><button class=\\"MuiButtonBase-root-203 MuiTab-root-191 MuiTab-textColorPrimary-194\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-2\\" aria-controls=\\"simple-tabpanel-2\\"><span class=\\"MuiTab-wrapper-199\\"><span class=\\"MuiTab-labelContainer-200\\"><span class=\\"MuiTab-label-201\\">Item Three</span></span></span><span class=\\"MuiTouchRipple-root-241\\"></span></button></div><span class=\\"MuiPrivateTabIndicator-root-206 MuiPrivateTabIndicator-colorPrimary-207 MuiTabs-indicator-190\\" style=\\"left: 0px; width: 0px;\\"></span>
       </div>
     </div>
   </div>
+<<<<<<< master
   <hr class=\\"MuiDivider-root-78 u-ml-0 u-maw-100\\"><br>
   <div class=\\"MuiTabs-root-210\\" aria-label=\\"simple tabs example\\">
     <div class=\\"MuiTabs-flexContainer-211\\">
       <div class=\\"MuiTabs-scroller-213 MuiTabs-fixed-214\\" style=\\"margin-bottom: 0px;\\" role=\\"tablist\\">
         <div class=\\"MuiTabs-flexContainer-211\\"><button class=\\"MuiButtonBase-root-231 MuiTab-root-219 MuiTab-textColorPrimary-222 MuiTab-selected-224\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"true\\" id=\\"simple-tab-0\\" aria-controls=\\"simple-tabpanel-0\\"><span class=\\"MuiTab-wrapper-227\\"><span class=\\"MuiTab-labelContainer-228\\"><span class=\\"MuiTab-label-229\\">Item One</span></span></span><span class=\\"MuiTouchRipple-root-249\\"></span></button><button class=\\"MuiButtonBase-root-231 MuiTab-root-219 MuiTab-textColorPrimary-222\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-1\\" aria-controls=\\"simple-tabpanel-1\\"><span class=\\"MuiTab-wrapper-227\\"><span class=\\"MuiTab-labelContainer-228\\"><span class=\\"MuiTab-label-229\\">Item Two</span></span></span><span class=\\"MuiTouchRipple-root-249\\"></span></button><button class=\\"MuiButtonBase-root-231 MuiTab-root-219 MuiTab-textColorPrimary-222\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-2\\" aria-controls=\\"simple-tabpanel-2\\"><span class=\\"MuiTab-wrapper-227\\"><span class=\\"MuiTab-labelContainer-228\\"><span class=\\"MuiTab-label-229\\">Item Three</span></span></span><span class=\\"MuiTouchRipple-root-249\\"></span></button></div><span class=\\"MuiPrivateTabIndicator-root-234 MuiPrivateTabIndicator-colorPrimary-235 MuiTabs-indicator-218\\" style=\\"left: 0px; width: 0px;\\"></span>
+=======
+  <hr class=\\"MuiDivider-root-74 u-ml-0 u-maw-100\\"><br>
+  <div class=\\"MuiTabs-root-209\\" aria-label=\\"simple tabs example\\">
+    <div class=\\"MuiTabs-flexContainer-210\\">
+      <div class=\\"MuiTabs-scroller-212 MuiTabs-fixed-213\\" style=\\"margin-bottom: 0px;\\" role=\\"tablist\\">
+        <div class=\\"MuiTabs-flexContainer-210\\"><button class=\\"MuiButtonBase-root-230 MuiTab-root-218 MuiTab-textColorPrimary-221 MuiTab-selected-223\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"true\\" id=\\"simple-tab-0\\" aria-controls=\\"simple-tabpanel-0\\"><span class=\\"MuiTab-wrapper-226\\"><span class=\\"MuiTab-labelContainer-227\\"><span class=\\"MuiTab-label-228\\">Item One</span></span></span><span class=\\"MuiTouchRipple-root-248\\"></span></button><button class=\\"MuiButtonBase-root-230 MuiTab-root-218 MuiTab-textColorPrimary-221\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-1\\" aria-controls=\\"simple-tabpanel-1\\"><span class=\\"MuiTab-wrapper-226\\"><span class=\\"MuiTab-labelContainer-227\\"><span class=\\"MuiTab-label-228\\">Item Two</span></span></span><span class=\\"MuiTouchRipple-root-248\\"></span></button><button class=\\"MuiButtonBase-root-230 MuiTab-root-218 MuiTab-textColorPrimary-221\\" tabindex=\\"0\\" type=\\"button\\" role=\\"tab\\" aria-selected=\\"false\\" id=\\"simple-tab-2\\" aria-controls=\\"simple-tabpanel-2\\"><span class=\\"MuiTab-wrapper-226\\"><span class=\\"MuiTab-labelContainer-227\\"><span class=\\"MuiTab-label-228\\">Item Three</span></span></span><span class=\\"MuiTouchRipple-root-248\\"></span></button></div><span class=\\"MuiPrivateTabIndicator-root-233 MuiPrivateTabIndicator-colorPrimary-234 MuiTabs-indicator-217\\" style=\\"left: 0px; width: 0px;\\"></span>
+>>>>>>> refactor: Dialog and add Dialog usecases in docs
       </div>
     </div>
   </div>
-  <hr class=\\"MuiDivider-root-237 u-ml-0 u-maw-100\\">
+  <hr class=\\"MuiDivider-root-236 u-ml-0 u-maw-100\\">
 </div>"
 `;
 


### PR DESCRIPTION
This is a **breaking change** : default behavior is now with header/footer fixed, as MUI does

This is still not the last version. There are still some behaviors that are not suitable (wrong title margin in not fixed header, scroller badly positioned etc.).

We discussed it again with @joel-costa , who will take a little more time on it, starting this time from the MUI component.

But it is a suitable compromise to start the subject of sharing in Drive.

See exemples here : https://jf-cozy.github.io/cozy-ui/react/#!/Dialog

Scrollers are fixed here : https://github.com/cozy/cozy-ui/pull/1597

Closed, replaced by https://github.com/cozy/cozy-ui/pull/1624