### PR TITLE
feat: Set dialogTitle width to 90%

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -402,6 +402,7 @@ normalTheme.overrides = {
   },
   MuiDialogTitle: {
     root: {
+      width: '90%',
       padding: '0 0 16px 0',
       [normalTheme.breakpoints.down('sm')]: {
         padding: '14px 0 16px 0'


### PR DESCRIPTION
- useful to manage ellipsis
- 90% is not arbitrary, it's @joel-costa 's specs