### PR TITLE
fix: Remove translateY -50% on Empty

### DIFF
--- a/react/Empty/index.jsx
+++ b/react/Empty/index.jsx
@@ -11,10 +11,22 @@ export const Empty = ({
   text,
   children,
   className,
+  noTransform,
   ...restProps
 }) => {
+  let withTransform = null
+  if (!noTransform) {
+    console.warn(
+      "Empty shouldn't have css transformation on it, but should be managed by the application. Please put the css of withTransform class into the application and set noTransform to true."
+    )
+    withTransform = 'withTransform'
+  }
+
   return (
-    <div className={cx(styles['c-empty'], className)} {...restProps}>
+    <div
+      className={cx(styles['c-empty'], styles[withTransform], className)}
+      {...restProps}
+    >
       <Icon
         className={styles['c-empty-img']}
         icon={icon}
@@ -36,7 +48,12 @@ Empty.propTypes = {
   icon: iconPropType.isRequired,
   title: PropTypes.node.isRequired,
   text: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  noTransform: PropTypes.bool
+}
+
+Empty.defaultProps = {
+  noTransform: false
 }
 
 export const EmptySubTitle = ({ ...restProps }) => (

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2147,7 +2147,7 @@ exports[`Dialog should render examples: Dialog 1`] = `"<div><button>Toggle modal
 exports[`Empty should render examples: Empty 1`] = `
 "<div>
   <div style=\\"position: relative; transform: translateZ(0); height: 500px; display: flex;\\">
-    <div class=\\"styles__c-empty___3w5oV\\"><svg class=\\"styles__c-empty-img___2GC4d styles__icon___23x3R\\" width=\\"100%\\" height=\\"100%\\">
+    <div class=\\"styles__c-empty___3w5oV styles__withTransform___15iRC\\"><svg class=\\"styles__c-empty-img___2GC4d styles__icon___23x3R\\" width=\\"100%\\" height=\\"100%\\">
         <use xlink:href=\\"#cozy\\"></use>
       </svg>
       <h2 class=\\"u-title-h1 styles__c-empty-title___2HduE\\">This list is empty</h2>
@@ -2161,7 +2161,7 @@ exports[`Empty should render examples: Empty 1`] = `
 exports[`Empty should render examples: Empty 2`] = `
 "<div>
   <div style=\\"position: relative; transform: translateZ(0); height: 500px; display: flex;\\">
-    <div class=\\"styles__c-empty___3w5oV\\" id=\\"empty\\"><svg class=\\"styles__c-empty-img___2GC4d styles__icon___23x3R\\" width=\\"100%\\" height=\\"100%\\">
+    <div class=\\"styles__c-empty___3w5oV styles__withTransform___15iRC\\" id=\\"empty\\"><svg class=\\"styles__c-empty-img___2GC4d styles__icon___23x3R\\" width=\\"100%\\" height=\\"100%\\">
         <use xlink:href=\\"#cozy\\"></use>
       </svg>
       <h2 class=\\"u-title-h1 styles__c-empty-title___2HduE\\">An error occured</h2>

--- a/stylus/components/empty.styl
+++ b/stylus/components/empty.styl
@@ -14,9 +14,10 @@ $empty
     text-align       center
     max-width        100%
 
-    +medium-screen()
-        margin-top 'calc(50vh - %s)' % contentHeight
-        transform translateY(-50%)
+    &.withTransform
+        +medium-screen()
+            margin-top 'calc(50vh - %s)' % contentHeight
+            transform translateY(-50%)
 
 $empty-img
     display              block


### PR DESCRIPTION
Contacts : this moved the block under the cozyBar., so we need a way to deactivated the translateY
I don't think that putting a translate here in this way is relevant here.