### PR TITLE
Fix/dialog z index

### DIFF
--- a/react/Dialog/Readme.md
+++ b/react/Dialog/Readme.md
@@ -22,6 +22,7 @@ import {
 import useBreakpoints, {
   BreakpointsProvider
 } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Alerter from 'cozy-ui/transpiled/react/Alerter';
 
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme/'
 import { CardDivider } from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
@@ -121,7 +122,7 @@ const ExampleDialog = ({ open, onClose }) => {
         <Button
           theme="primary"
           label='Click Me'
-          onClick={() => alert('click')}
+          onClick={() => Alerter.info("This is an info alert!")}
         />
       </DialogActions>
     </Dialog>
@@ -134,6 +135,7 @@ const ExampleDialog = ({ open, onClose }) => {
   </button>
   <BreakpointsProvider>
     <MuiCozyTheme>
+      <Alerter />
       <ExampleDialog open={state.modalOpened} onClose={handleClose} />
     </MuiCozyTheme>
   </BreakpointsProvider>

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -345,6 +345,9 @@ normalTheme.overrides = {
     }
   },
   MuiDialog: {
+    root: {
+      zIndex: getCssVariableValue('zIndex-modal')
+    },
     paper: {
       '&.small': {
         width: '480px',


### PR DESCRIPTION
MUi's dialog comes with a 1300 zIndex. We need to fix it back to 70 as our previous modal. Like that, Alerter are displayed on top of Dialog...


We already done that on https://github.com/cozy/cozy-ui/pull/1408 but it was removed in https://github.com/cozy/cozy-ui/commit/391704c5e7ee74c75ef1b78b597199a8b9ad1367#diff-68934137b7c3b9a38678727aa3dbd31f8cb5fe366b4e3f31a30a675856010841


https://crash--.github.io/cozy-ui/react/#!/Dialog/1

