### PR TITLE
fix: Clear Timeout when reseting

### DIFF
--- a/react/Viewer/withFileUrl.jsx
+++ b/react/Viewer/withFileUrl.jsx
@@ -62,6 +62,7 @@ const withFileUrl = BaseComponent =>
     }
 
     reset = () => {
+      this.clearTimeout()
       this.setState({ status: LOADING, downloadUrl: null })
     }
 


### PR DESCRIPTION
We need to reset the timeout when reseting. Without, the call in the didUpdate is not done since timeout is setted.

It's a quick fix, I'm working on a refacto on this HOC to convert it to hooks. But I need to rewrite the tests, so let's go for this fix first, and later the refacto 👍 