### PR TITLE
fix: Use a precise selector for SelectionBar button hover

### DIFF
--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -28,7 +28,8 @@ $selectionbar
     button
         padding 0 rem(16)
         color   var(--white)
-
+        &:hover
+            color   var(--white)
     .SelectionBar-actionClose
         position          absolute
         top               50%


### PR DESCRIPTION
In https://github.com/cozy/cozy-ui/commit/9c543922553fe8d193ba6c38e3f0521f26c88e9e#r43258678 we wondered why the selector was on role=application. It was to be more precise than the style on the button and on the hover button of Cozy-UI (we have by default blue hover on a subtle button). Let's use a slightly more precise selector by manually specifying the hover to make sure we use the right color.

With this fix, the hover on the SelectionBar item is now white and not blue 
