### PR TITLE
feat: Avatar accepts IconComponent

### DIFF
--- a/react/Avatar/Readme.md
+++ b/react/Avatar/Readme.md
@@ -3,6 +3,7 @@
 ```jsx
 import cozyLogo from '../../docs/cozy-logo_white_128.png'
 import Avatar from 'cozy-ui/transpiled/react/Avatar';
+import Icon from 'cozy-ui/transpiled/react/Icon'; 
 
 <div className="u-flex">
   <Avatar />
@@ -10,6 +11,7 @@ import Avatar from 'cozy-ui/transpiled/react/Avatar';
   <Avatar image={cozyLogo} />
   <Avatar icon="link" />
   <Avatar text="CD" style={{color: 'black', backgroundColor: 'var(--seafoamGreen)' }} />
+  <Avatar icon={<Icon icon='warning' />} />
 </div>
 ```
 

--- a/react/Avatar/index.jsx
+++ b/react/Avatar/index.jsx
@@ -5,7 +5,7 @@ import assign from 'lodash/assign'
 
 import palette from '../palette'
 import styles from './styles.styl'
-import Icon from '../Icon'
+import Icon, { iconPropType } from '../Icon'
 import { createSizeStyle } from '../Circle'
 
 const nameToColor = (name = '') => {
@@ -50,7 +50,7 @@ export const Avatar = ({
   const sizeStyle = createSizeStyle(size)
   const bgColorStyle = createBgColorStyle({ text, textId })
   const avatarStyle = assign(bgColorStyle, sizeStyle, style)
-
+  const IconToRender = Icon.isProperIcon(icon) ? <Icon icon={icon} /> : icon
   return (
     <div
       className={cx(
@@ -66,7 +66,7 @@ export const Avatar = ({
       {!image && text && (
         <span className={styles['c-avatar-initials']}>{text}</span>
       )}
-      {!image && !text && <Icon icon={icon} />}
+      {!image && !text && IconToRender}
     </div>
   )
 }
@@ -80,7 +80,7 @@ Avatar.propTypes = {
   ]),
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  icon: PropTypes.string,
+  icon: PropTypes.oneOfType([PropTypes.node, iconPropType]),
   style: PropTypes.object
 }
 

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -151,6 +151,9 @@ exports[`Avatar should render examples: Avatar 1`] = `
         <use xlink:href=\\"#link\\"></use>
       </svg></div>
     <div class=\\"styles__c-avatar___PpDI- styles__c-avatar--text___2dvna\\" style=\\"color: black;\\"><span class=\\"styles__c-avatar-initials___310qC\\">CD</span></div>
+    <div class=\\"styles__c-avatar___PpDI-\\"><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+        <use xlink:href=\\"#warning\\"></use>
+      </svg></div>
   </div>
 </div>"
 `;


### PR DESCRIPTION
Avatar can accept `<Icon>` directly from icon props. Like that, we can import the IconComponent directly without importing the Sprite. 

with: https://github.com/cozy/cozy-libs/pull/1149