### PR TITLE
Fix/banner

### DIFF
--- a/react/Banner/Readme.md
+++ b/react/Banner/Readme.md
@@ -1,30 +1,34 @@
 ### Banner
 
 ```jsx
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
-import Variants from 'docs/components/Variants';
-import palette from 'cozy-ui/transpiled/react/palette';
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+import Variants from 'docs/components/Variants'
+import palette from 'cozy-ui/transpiled/react/palette'
 
-import Banner from 'cozy-ui/transpiled/react/Banner';
-import Button from 'cozy-ui/transpiled/react/Button';
-import Icon from '../Icon';
-import Circle from 'cozy-ui/transpiled/react/Circle';
+import Banner from 'cozy-ui/transpiled/react/Banner'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import CalendarIcon from 'cozy-ui/transpiled/react/Icons/Calendar'
+import DeviceLaptopIcon from 'cozy-ui/transpiled/react/Icons/DeviceLaptop'
+import Avatar from 'cozy-ui/transpiled/react/Avatar'
 
-const text = "You have lost connection to the internet. This app is offline. And this is a long text to show how it reacts, with, well, a long text.";
-const buttonOne = <Button theme="text" label="Turn on wifi" />;
-const buttonTwo = <Button theme="text" label="Close" />;
-const icon = <Circle><Icon icon="calendar" /></Circle>;
+const shortText = "You have lost connection to the internet."
+const longText = "You have lost connection to the internet. This app is offline. And this is a long text to show how it reacts, with, well, a long text. You have lost connection to the internet. This app is offline. And this is a long text to show how it reacts, with, well, a long text. You have lost connection to the internet. This app is offline. And this is a long text to show how it reacts, with, well, a long text. You have lost connection to the internet. This app is offline. And this is a long text to show how it reacts, with, well, a long text."
+const buttonOne = <Button theme="text" label="Turn on wifi" />
+const buttonTwo = <Button theme="text" label="No, thanks!" />
+const icon = <Avatar icon={CalendarIcon} />
 
 const initialVariants = [
-  { icon: true, buttonOne: true, buttonTwo: true, inline: false }
+  { icon: true, longText: true, buttonOne: true, buttonTwo: true, inline: false, backgroundColor: false }
 ];
 
 <MuiCozyTheme>
   <Variants initialVariants={initialVariants}>{
     variant => (
       <Banner
+        bgcolor={variant.backgroundColor ? palette['paleGrey'] : 'transparent'}
         icon={variant.icon && icon}
-        text={text}
+        text={variant.longText ? longText : shortText }
         buttonOne={variant.buttonOne && buttonOne}
         buttonTwo={variant.buttonTwo && buttonTwo}
         inline={variant.inline}
@@ -33,11 +37,11 @@ const initialVariants = [
   }</Variants>
   <hr />
   <Banner
-    icon={<Icon icon="device-laptop" size="100%" />}
+    icon={<Icon icon={DeviceLaptopIcon} />}
     text="Get Cozy Drive for Desktop and synchronise your files safely to make them accessible at all times"
     bgcolor={palette['paleGrey']}
     buttonOne={<Button theme="text" icon='download' label="Download" onClick={() => alert("Clicked!")} />}
-    buttonTwo={<Button theme="text" label="Close" />}
+    buttonTwo={<Button theme="text" label="No, thanks!" />}
     inline
   />
 </MuiCozyTheme>

--- a/react/Banner/index.jsx
+++ b/react/Banner/index.jsx
@@ -31,7 +31,6 @@ const Banner = ({ icon, bgcolor, text, buttonOne, buttonTwo, inline }) => {
               item
               xs={12}
               lg={size[0]}
-              spacing={16}
               alignItems="center"
               wrap="nowrap"
             >
@@ -40,8 +39,8 @@ const Banner = ({ icon, bgcolor, text, buttonOne, buttonTwo, inline }) => {
                   <div className={styles['c-banner-icon']}>{icon}</div>
                 </Grid>
               )}
-              <Grid item>
-                <Typography variant="body1">{text}</Typography>
+              <Grid item className={styles['c-banner-text']}>
+                <Typography variant="body2">{text}</Typography>
               </Grid>
             </Grid>
             {(buttonOne || buttonTwo) && (
@@ -51,9 +50,9 @@ const Banner = ({ icon, bgcolor, text, buttonOne, buttonTwo, inline }) => {
                 xs={12}
                 lg={size[1]}
                 justify="flex-end"
-                spacing={8}
+                alignItems="center"
               >
-                <Grid item>
+                <Grid item className={styles['c-banner-buttons']}>
                   {buttonOne && buttonOne}
                   {buttonTwo && buttonTwo}
                 </Grid>

--- a/react/Banner/styles.styl
+++ b/react/Banner/styles.styl
@@ -1,12 +1,35 @@
+@require 'settings/breakpoints.styl'
 @require 'tools/mixins'
 
 .c-banner
     &-wrapper
-        padding rem(16) rem(8) rem(16)
+        display flex
+        align-items 'center'
+        min-height rem(56)
+        padding 0 rem(16)
+
+        +small-screen()
+            padding 0
 
     &-icon
-        width rem(40)
-        height rem(40)
-        svg
-            width 100%
-            height 100%
+        width rem(32)
+        height rem(32)
+        margin-left rem(16)
+
+        & > svg // force Icon to be 32x32px
+            width rem(32)
+            height rem(32)
+
+        div // force Avatar/Circle to be 32x32px
+            width rem(32)
+            height rem(32)
+            min-width rem(32)
+            min-height rem(32)
+
+    &-text
+        padding rem(12) rem(16)
+
+    &-buttons
+        button
+            margin 0
+            min-width 3rem

--- a/react/Icon/index.jsx
+++ b/react/Icon/index.jsx
@@ -24,7 +24,7 @@ function getSvgObject(icon) {
   )
 }
 
-function isReactComponent(obj) {
+function isFunction(obj) {
   return obj instanceof Function
 }
 
@@ -42,10 +42,9 @@ function Icon(props) {
     ...restProps
   } = props
 
-  const Svg = useMemo(
-    () => (isReactComponent(icon) ? icon : getSvgObject(icon)),
-    [icon]
-  )
+  const Svg = useMemo(() => (isFunction(icon) ? icon : getSvgObject(icon)), [
+    icon
+  ])
 
   let style = props.style
   style = Object.assign({}, style)
@@ -75,7 +74,8 @@ function Icon(props) {
 Icon.isProperIcon = icon => {
   const isSvgSymbol = icon && !!icon.id
   const isIconIdentifier = typeof icon === 'string'
-  return isSvgSymbol || isIconIdentifier
+  const isSvgr = isFunction(icon)
+  return isSvgSymbol || isIconIdentifier || isSvgr
 }
 
 export const iconPropType = PropTypes.oneOfType([


### PR DESCRIPTION
This is the correction of the banner : fix https://github.com/cozy/cozy-ui/issues/1629

**This PR is based on https://github.com/cozy/cozy-ui/pull/1658 because of Banner refactoring.**

This PR is approved by @joel-costa 

Icon.isProperIcon did not take into account the svgr, this caused a problem especially for the Avatars: in the case where we passed a svgr to the prop icon, the icon was not displayed. Note : it still works for `<Icon />` passed as prop.

Icon size is voluntarily forced to 32x32px. As the default size of Avatar/Icon/Circle is 40px, this way we don't need to have to specify the size.

https://jf-cozy.github.io/cozy-ui/react/#!/Banner