### PR TITLE
Add npm publication with semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@material-ui/core": "3.9.4",
     "@material-ui/styles": "4.10.0",
     "@oskarer/enzyme-wait": "^1.5.0",
-    "@semantic-release/changelog": "3.0.6",
+    "@semantic-release/changelog": "5.0.1",
     "@semantic-release/git": "7.0.18",
     "@semantic-release/npm": "5.3.4",
     "@svgr/cli": "^5.4.0",

--- a/release.config.js
+++ b/release.config.js
@@ -7,6 +7,7 @@ module.exports = {
       "assets": ["CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
+    "@semantic-release/npm",
     "@semantic-release/github"
   ]
 }

--- a/release.config.js
+++ b/release.config.js
@@ -3,6 +3,9 @@ module.exports = {
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
     ["@semantic-release/git", {
       "assets": ["CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,14 +2102,14 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
-"@semantic-release/changelog@3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-3.0.6.tgz#9d68d68bf732cbba1034c028bb6720091f783b2a"
-  integrity sha512-9TqPL/VarLLj6WkUqbIqFiY3nwPmLuKFHy9fe/LamAW5s4MEW/ig9zW9vzYGOUVtWdErGJ1J62E3Edkamh3xaQ==
+"@semantic-release/changelog@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-5.0.1.tgz#50a84b63e5d391b7debfe021421589fa2bcdafe4"
+  integrity sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==
   dependencies:
     "@semantic-release/error" "^2.1.0"
     aggregate-error "^3.0.0"
-    fs-extra "^8.0.0"
+    fs-extra "^9.0.0"
     lodash "^4.17.4"
 
 "@semantic-release/commit-analyzer@^8.0.0":


### PR DESCRIPTION
The npm plugin had been forgotten, leading to non publication of the
release on npm.

Added the semantic-release/changelog plugin which could write the release
notes to the CHANGELOG.md file. I tried to run locally (dry run) but could
not see any change, I think it may be because of the dry run.