### PR TITLE
Improvements

### DIFF
--- a/react/ListItemText/Readme.md
+++ b/react/ListItemText/Readme.md
@@ -1,11 +1,11 @@
-#### List item main text
+#### List item primary text
 
 ```
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
 <ListItemText primary="I'm a list item text"/>
 ```
 
-#### List item main text with an annotation text
+#### List item with secondary text
 
 ```
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText';

--- a/react/MuiCozyTheme/List/Readme.md
+++ b/react/MuiCozyTheme/List/Readme.md
@@ -11,6 +11,7 @@ Displays a List of items, with several metadata
 ```
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List';
+import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader';
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem';
 import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon';
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
@@ -22,6 +23,7 @@ import Button from 'cozy-ui/transpiled/react/Button';
 
 <MuiCozyTheme>
   <List>
+    <ListSubheader>Section 1</ListSubheader>
     <ListItem>
       <ListItemIcon>
         <Icon icon="folder" width="32" height="32" />
@@ -49,6 +51,7 @@ import Button from 'cozy-ui/transpiled/react/Button';
         </Menu>
       </ListItemSecondaryAction>
     </ListItem>
+    <ListSubheader>Section 2</ListSubheader>
     <ListItem>
       <ListItemIcon>
         <Icon icon="file" width="32" height="32" />

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -108,6 +108,10 @@ export const normalTheme = createMuiTheme({
       dark: getCssVariableValue('azure'),
       contrastText: getCssVariableValue('white')
     },
+    text: {
+      primary: getCssVariableValue('charcoalGrey'),
+      secondary: getCssVariableValue('slateGrey')
+    },
     grey: {
       0: getCssVariableValue('white'),
       100: getCssVariableValue('paleGrey'),
@@ -512,8 +516,12 @@ export const invertedTheme = {
     primary: {
       main: 'rgb(255,255,255)'
     },
+    secondary: {
+      main: 'rgba(255, 255, 255)'
+    },
     text: {
-      primary: getCssVariableValue('white')
+      primary: 'rgb(255,255,255)',
+      secondary: 'rgb(255,255,255)'
     }
   }
 }

--- a/react/Radio/Readme.md
+++ b/react/Radio/Readme.md
@@ -24,3 +24,36 @@ import Radio from 'cozy-ui/transpiled/react/Radio';
 import Radio from 'cozy-ui/transpiled/react/Radio';
 <div><Radio name="radioForm"value="radioValue1" label="This is a disabled radio button" disabled /></div>
 ```
+
+### No gutter
+
+By default Radio and Checkbox have a small gutter next to them for their label not to be touching
+the edge of the radio/checkbox. This can be cumbersome when aligning horizontally inside a container.
+You can set `gutter` to `false` to cancel the default gutter.
+
+```
+import Radio from 'cozy-ui/transpiled/react/Radio';
+
+const Box = ({ children }) => {
+  return   <div style={{ height: '3rem', width: '3rem', border: '2px dashed #CCC', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+    { children }
+  </div>
+}
+
+const bboxStyle = { border: '1px solid red' };
+
+initialState.bbox = isTesting();
+
+<>
+  <p>
+    <Radio checked={state.bbox} onClick={() => setState({ bbox: !state.bbox })} label="View bounding box" />
+  </p>
+  <p>Default gutter</p>
+  <Box>
+    <Radio checked style={state.bbox ? bboxStyle : null}/>
+  </Box>
+  <p>Gutter set to false</p>
+  <Box>
+    <Radio gutter={false} checked style={state.bbox ? bboxStyle : null} />
+  </Box>
+</>

--- a/react/Radio/Readme.md
+++ b/react/Radio/Readme.md
@@ -57,3 +57,5 @@ initialState.bbox = isTesting();
     <Radio gutter={false} checked style={state.bbox ? bboxStyle : null} />
   </Box>
 </>
+
+```

--- a/react/Radio/index.jsx
+++ b/react/Radio/index.jsx
@@ -12,6 +12,7 @@ const Radio = props => {
     error,
     disabled,
     style,
+    gutter,
     ...restProps
   } = props
   return (
@@ -19,6 +20,7 @@ const Radio = props => {
       className={cx(
         styles['c-input-radio'],
         {
+          [styles['c-input-radio--noGutter']]: gutter === false,
           [styles['is-error']]: error
         },
         className
@@ -48,7 +50,8 @@ Radio.propTypes = {
 }
 
 Radio.defaultProps = {
-  error: false
+  error: false,
+  gutter: true
 }
 
 export default Radio

--- a/react/Typography/Readme.md
+++ b/react/Typography/Readme.md
@@ -43,6 +43,12 @@ const variants = [
 </MuiCozyTheme>
 ```
 
+You can use `color="textSecondary"`:
+
+```
+<Typography variant='body1' color="textSecondary">A text written in secondary text color.</Typography>
+```
+
 From old to new :
 
 ```

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -6840,6 +6840,16 @@ exports[`Radio should render examples: Radio 3`] = `
 </div>"
 `;
 
+exports[`Radio should render examples: Radio 4`] = `
+"<div>
+  <p><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" value=\\"\\" checked=\\"\\"><span>View bounding box</span></label></p>
+  <p>Default gutter</p>
+  <div style=\\"height: 3rem; width: 3rem; border: 2px dashed #ccc; display: flex; justify-content: center; align-items: center;\\"><label class=\\"styles__c-input-radio___XJQt1\\" style=\\"border: 1px solid red;\\"><input type=\\"radio\\" value=\\"\\" checked=\\"\\"><span></span></label></div>
+  <p>Gutter set to false</p>
+  <div style=\\"height: 3rem; width: 3rem; border: 2px dashed #ccc; display: flex; justify-content: center; align-items: center;\\"><label class=\\"styles__c-input-radio___XJQt1 styles__c-input-radio--noGutter___3WtC2\\" style=\\"border: 1px solid red;\\"><input type=\\"radio\\" value=\\"\\" checked=\\"\\"><span></span></label></div>
+</div>"
+`;
+
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div style=\\"background: whitesmoke; padding: .5em;\\">

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -309,8 +309,9 @@ $input-text--fullwidth
 $checkbox
     // To make sure that checkbox's wrapper have the height of the checkbox
     display flex
-    margin-bottom rem(8)
     align-items center
+    min-width checkbox-size
+    min-height checkbox-size
 
     span
         position relative
@@ -384,6 +385,10 @@ $checkbox
         &::before
             box-shadow inset 0 0 0 rem(2) var(--pomegranate)
             background-color var(--yourPink)
+
+    &--noGutter span
+            padding-left 0
+
 
 $radio
     @extend $checkbox


### PR DESCRIPTION
- Alignment of checkbox and radio is easier to control
- Add secondary text color

BREAKING CHANGE: A bottom margin has been removed from Radio/Checkbox, it could have visual impacts but generally the alignment should be better now. See Argos screenshots to see the removed bottom margin.

If an app needs the margin-bottom behavior, it is easy to re-add u-mb-half to the Radio or Checkbox.

https://ptbrowne.github.io/cozy-ui/react/#!/Radio