### PR TITLE
WIP fix: Scroll not locked when Modal is opened for screen width < 1024px

### DIFF
--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -33,6 +33,8 @@ import {
   FixedDialog,
   FixedActionsDialog
 } from  'cozy-ui/transpiled/react/CozyDialogs'
+import ActionMenu, { ActionMenuItem, ActionMenuRadio } from 'cozy-ui/transpiled/react/ActionMenu';
+import { Text, Caption } from 'cozy-ui/transpiled/react/Text';
 
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -52,6 +54,29 @@ initialState = {
 }
 
 const DialogComponent = state.modal
+
+const ExampleActionMenu = ({ onClose }) => {
+  return (
+    <ActionMenu
+        anchorElRef={this.ref}
+        autoclose={true}
+        onClose={onClose}>
+        <ActionMenuItem left={<Icon icon='file' />} right={<Icon icon='warning' />}>Item 1</ActionMenuItem>
+        <ActionMenuItem left={<ActionMenuRadio />}>Item 2</ActionMenuItem>
+        <ActionMenuItem left={<Icon icon='file' />}>
+          <Text>
+            Item 3
+          </Text>
+          <Caption>
+            Descriptive text to elaborate on what item 3 does.
+          </Caption>
+        </ActionMenuItem>
+    </ActionMenu>
+  )
+}
+
+const handleOpenActionMenu = () => setState({ showActionMenu: true })
+const handleCloseActionMenu = () => setState({ showActionMenu: false })
 
 const ExampleDialogActions = () => {
   return (
@@ -100,7 +125,15 @@ const dialogContents = {
   IllustrationDialog: "An IllustrationDialog contains short content." + content.ada.short,
   FixedDialog: "A FixedDialog can contain very long content. Actions are at the bottom of the content are not visible to the user if she has not scrolled to the bottom. " + content.ada.long,
   FixedActionsDialog: "A FixedActionsDialog can contain very long content. Actions are visible even without scrolling. " + content.ada.long,
-  Dialog: "A normal Dialog should contain short content. " + content.ada.short
+  Dialog: <>
+    <p>
+      {"A normal Dialog should contain short content. " + content.ada.short}
+    </p>
+    <p>
+      <Button theme="secondary" size="small" onClick={handleOpenActionMenu} label="Open action menu" />
+    </p>
+  { state.showActionMenu ? <ExampleActionMenu onClose={handleCloseActionMenu} /> : null }
+  </>
 }
 
 const dialogActions = {

--- a/react/CozyDialogs/useCozyDialog.js
+++ b/react/CozyDialogs/useCozyDialog.js
@@ -1,10 +1,26 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import useBreakpoints from '../hooks/useBreakpoints'
 import DialogTransition from './DialogTransition'
 
 let globalId = 0
 
 const modalSizes = ['small', 'medium', 'large']
+
+const useScrollLock = active => {
+  useEffect(() => {
+    const html = document.body.parentNode
+    const backup = html.style.overflow
+    if (active) {
+      html.style.overflow = 'hidden'
+    }
+    return () => {
+      if (active && html.style.overflow === 'hidden') {
+        html.style.overflow = backup
+      }
+    }
+  }, [active])
+}
+
 /**
  * Returns the className and isFullscreen bool to be used in the Dialog
  * according to the size of the modal.
@@ -61,6 +77,14 @@ const useCozyDialog = props => {
       root: listItemClassName
     }
   }
+
+  // Here is a crude fix until we upgrade to material-ui to version > 3.9.4.
+  // This is to block the scroll on the html node element otherwise mui only puts
+  // overflow: hidden on the body and html is still scrollable for screen widths < 1024px.
+  // Improvement seems to have been done in mui ModalManager, we should be able
+  // to remove our own useScrollLock after update to mui 4.9.11
+  // https://github.com/mui-org/material-ui/pull/17972
+  useScrollLock(open || opened)
 
   return {
     dialogProps,


### PR DESCRIPTION
Add a simple scroll locker in useCozyDialogs. This can be removed when
we upgrade material ui.

I've added an example with an ActionMenu (inside CozyDialogs::Dialog) and everything seems to work
OK. I need to test on mobile browsers now.

https://ptbrowne.github.io/cozy-ui/react/#!/Dialog

On safari iOS I still have the problem : the issue from material ui is here : https://github.com/mui-org/material-ui/issues/5750. 