### PR TITLE
feat: Use primaryColorDark CSS variable in MUI theme

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -96,7 +96,7 @@ export const normalTheme = createMuiTheme({
     primary: {
       light: getCssVariableValue('primaryColorLight'),
       main: getCssVariableValue('primaryColor'),
-      dark: getCssVariableValue('scienceBlue'),
+      dark: getCssVariableValue('primaryColorDark'),
       contrastText: getCssVariableValue('primaryContrastTextColor')
     },
     error: {


### PR DESCRIPTION
The theme had scienceBlue instead of using the CSS variable.