### PR TITLE
feat: Better support for secondary color

### DIFF
--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -103,10 +103,10 @@ export const normalTheme = createMuiTheme({
       main: getCssVariableValue('pomegranate')
     },
     secondary: {
-      light: getCssVariableValue('monza'),
-      main: getCssVariableValue('portage'),
-      dark: getCssVariableValue('azure'),
-      contrastText: getCssVariableValue('white')
+      light: getCssVariableValue('secondaryColorLight'),
+      main: getCssVariableValue('secondaryColor'),
+      dark: getCssVariableValue('secondaryColorDark'),
+      contrastText: getCssVariableValue('secondaryContrastTextColor')
     },
     text: {
       primary: getCssVariableValue('charcoalGrey'),
@@ -126,6 +126,9 @@ export const normalTheme = createMuiTheme({
     MuiTabs: {
       textColor: 'primary',
       TabIndicatorProps: { color: 'primary' }
+    },
+    MuiButton: {
+      disableRipple: true
     }
   },
   ...(isTesting() && { transitions: { create: () => 'none' } })
@@ -146,8 +149,19 @@ normalTheme.overrides = {
     }
   },
   MuiButton: {
-    root: {
-      borderRadius: 0
+    outlined: {
+      borderRadius: 2,
+      height: 40,
+      minWidth: 112
+    },
+    contained: {
+      borderRadius: 2,
+      boxShadow: 0,
+      height: 40,
+      minWidth: 112
+    },
+    containedSecondary: {
+      color: 'white'
     }
   },
   MuiTab: {

--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -154,11 +154,17 @@ html
     Styleguide Settings.theme.primary
     */
 html, .CozyTheme--normal
-    --primaryColor var(--dodgerBlue)
-    --primaryColorDark var(--scienceBlue)
-    --primaryColorLight #5C9DF5 // lighten(dodgerBlue, 24)
-    --primaryColorLighter #4B93F7
+    --primaryColor #297EF2
+    --primaryColorDark #0B61D6
+    --primaryColorLight #5C9DF5
+    --primaryColorLighter #4B93F7 // should not be used
     --primaryColorLightest #9FC4FB
+
+    --secondaryColor #fd7461
+    --secondaryColorDark #E3503B
+    --secondaryColorLight #ffdeda // lighten(dodgerBlue, 24)
+    --secondaryColorLighter #fd7461 //
+    --secondaryColorLightest #FECDC6
 
     --primaryBackgroundLight: var(--zircon)
 


### PR DESCRIPTION
- We do not use the secondary color much but it can be useful for
custom themes.
- Tweak MUI button styles so that they follow our chart. We now
can use MUIButtons directly

I checked with @joel-costa and we're aligned.

Styleguide : https://ptbrowne.github.io/cozy-ui/react/#!/Buttons