### PR TITLE
Dialog improvements

### DIFF
--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -170,7 +170,7 @@ const toggleDialog = dialog => {
     </MuiCozyTheme>
   </BreakpointsProvider>
   {dialogs.map(dialog => (
-    <button data-test-id={`open-btn-${dialog.name}`} onClick={() => toggleDialog(dialog)}>
+    <button key={`open-btn-${dialog.name}`} data-test-id={`open-btn-${dialog.name}`} onClick={() => toggleDialog(dialog)}>
       Open {dialog.name}
     </button>
   ))}

--- a/react/CozyDialogs/useCozyDialog.js
+++ b/react/CozyDialogs/useCozyDialog.js
@@ -33,7 +33,7 @@ const useCozyDialog = props => {
   const dialogProps = {
     'aria-labelledby': `modal-title-${id}`,
     fullScreen,
-    open: open || opened,
+    open: open !== undefined ? open : opened,
     onClose,
     TransitionComponent,
     ...otherProps,


### PR DESCRIPTION
- A warning was displayed if open={false} and opened was not passed since
  we would take the value of opened when open was falsy
- Fix key warning in example