### PR TITLE
feat: BlockScroll on mobile screen

### DIFF
--- a/react/Dialog/index.jsx
+++ b/react/Dialog/index.jsx
@@ -1,5 +1,30 @@
-import Dialog from '@material-ui/core/Dialog'
+import React from 'react'
+import { default as MUIDialog } from '@material-ui/core/Dialog'
+import { RemoveScroll } from 'react-remove-scroll'
+import useBreakpoints from '../hooks/useBreakpoints'
 
+// Here is a crude fix until we upgrade to material-ui to version > 3.9.4.
+// This is to block the scroll on the html node element otherwise mui only puts
+// overflow: hidden on the body and html is still scrollable for screen widths < 1024px.
+// Improvement seems to have been done in mui ModalManager, we should be able
+// to remove this RemoveScroll after update to mui 4.9.11
+// https://github.com/mui-org/material-ui/pull/17972
+// See also this related issue https://github.com/cozy/cozy-ui/pull/1597 on UI's side
+// to have more information about RemoveScroll
+
+const Dialog = props => {
+  const { isMobile, isTablet } = useBreakpoints()
+  const shouldBlockScroll = isMobile || isTablet
+  const Wrapper =
+    (props.open || props.opened) && shouldBlockScroll
+      ? RemoveScroll
+      : React.Fragment
+  return (
+    <Wrapper>
+      <MUIDialog {...props} />
+    </Wrapper>
+  )
+}
 export default Dialog
 
 export { default as DialogActions } from './DialogActions'


### PR DESCRIPTION
This is a fix to block scroll on Dialog with screen < 1024. This is based on the work done in #1597 to block scroll on Overlay on iOS. 

The comment in the Dialog should be enough. I took the one done by @ptbrowne on its previous attempt (https://github.com/cozy/cozy-ui/pull/1666) and the issue we fixed with ActionMenu / Overlay (#1597)  


https://crash--.github.io/cozy-ui/react/#!/CozyDialogs