### PR TITLE
fix: Safe-Area  for FixedDialog

### DIFF
--- a/react/CozyDialogs/ConfirmDialog.jsx
+++ b/react/CozyDialogs/ConfirmDialog.jsx
@@ -14,7 +14,13 @@ import DialogCloseButton from './DialogCloseButton'
 
 const ConfirmDialog = props => {
   const { onClose, title, content, actions, actionsLayout } = props
-  const { dialogProps, dialogTitleProps, fullScreen, id } = useCozyDialog(props)
+  const {
+    dialogProps,
+    dialogTitleProps,
+    fullScreen,
+    id,
+    dialogActionsProps
+  } = useCozyDialog(props)
   return (
     <Dialog {...dialogProps}>
       {!fullScreen && (
@@ -31,6 +37,7 @@ const ConfirmDialog = props => {
           </DialogTitle>
           {content}
           <DialogActions
+            {...dialogActionsProps}
             disableActionSpacing
             className={cx('dialogActionsFluid', {
               columnLayout: actionsLayout == 'column'

--- a/react/CozyDialogs/Dialog.jsx
+++ b/react/CozyDialogs/Dialog.jsx
@@ -15,7 +15,13 @@ import DialogCloseButton from './DialogCloseButton'
 
 const Dialog = props => {
   const { onClose, title, content, actions, actionsLayout } = props
-  const { dialogProps, dialogTitleProps, fullScreen, id } = useCozyDialog(props)
+  const {
+    dialogProps,
+    dialogTitleProps,
+    fullScreen,
+    id,
+    dialogActionsProps
+  } = useCozyDialog(props)
 
   return (
     <MUIDialog {...dialogProps}>
@@ -34,6 +40,7 @@ const Dialog = props => {
         <div className="dialogContentInner withFluidActions">
           {content}
           <DialogActions
+            {...dialogActionsProps}
             disableActionSpacing
             className={cx('dialogActionsFluid', {
               columnLayout: actionsLayout == 'column'

--- a/react/CozyDialogs/FixedActionsDialog.jsx
+++ b/react/CozyDialogs/FixedActionsDialog.jsx
@@ -15,7 +15,13 @@ import DialogCloseButton from './DialogCloseButton'
 
 const FixedActionsDialog = props => {
   const { onClose, title, content, actions, actionsLayout } = props
-  const { dialogProps, dialogTitleProps, fullScreen, id } = useCozyDialog(props)
+  const {
+    dialogProps,
+    dialogTitleProps,
+    fullScreen,
+    id,
+    dialogActionsProps
+  } = useCozyDialog(props)
 
   return (
     <Dialog {...dialogProps}>
@@ -36,6 +42,7 @@ const FixedActionsDialog = props => {
       </DialogContent>
       <Divider />
       <DialogActions
+        {...dialogActionsProps}
         disableActionSpacing
         className={cx({ columnLayout: actionsLayout == 'column' })}
       >

--- a/react/CozyDialogs/FixedDialog.jsx
+++ b/react/CozyDialogs/FixedDialog.jsx
@@ -15,7 +15,13 @@ import DialogCloseButton from './DialogCloseButton'
 
 const FixedDialog = props => {
   const { onClose, title, content, actions, actionsLayout } = props
-  const { dialogProps, dialogTitleProps, fullScreen, id } = useCozyDialog(props)
+  const {
+    dialogProps,
+    dialogTitleProps,
+    fullScreen,
+    id,
+    dialogActionsProps
+  } = useCozyDialog(props)
 
   return (
     <Dialog {...dialogProps}>
@@ -35,6 +41,7 @@ const FixedDialog = props => {
       </DialogContent>
       <Divider />
       <DialogActions
+        {...dialogActionsProps}
         disableActionSpacing
         className={cx({ columnLayout: actionsLayout == 'column' })}
       >

--- a/react/CozyDialogs/IllustrationDialog.jsx
+++ b/react/CozyDialogs/IllustrationDialog.jsx
@@ -14,7 +14,13 @@ import DialogCloseButton from './DialogCloseButton'
 
 const IllustrationDialog = props => {
   const { onClose, title, content, actions, actionsLayout } = props
-  const { dialogProps, dialogTitleProps, id, fullScreen } = useCozyDialog(props)
+  const {
+    dialogProps,
+    dialogTitleProps,
+    id,
+    fullScreen,
+    dialogActionsProps
+  } = useCozyDialog(props)
 
   return (
     <Dialog {...dialogProps}>
@@ -35,6 +41,7 @@ const IllustrationDialog = props => {
           </DialogTitle>
           {content}
           <DialogActions
+            {...dialogActionsProps}
             disableActionSpacing
             className={cx('dialogActionsFluid', {
               columnLayout: actionsLayout == 'column'

--- a/react/CozyDialogs/useCozyDialog.js
+++ b/react/CozyDialogs/useCozyDialog.js
@@ -68,13 +68,22 @@ const useCozyDialog = props => {
       root: dividerClassName
     }
   }
+
+  const dialogActionsClassName = 'cozyDialogActions'
+  const dialogActionsProps = {
+    classes: {
+      root: dialogActionsClassName
+    }
+  }
+
   return {
     dialogProps,
     dialogTitleProps,
     listItemProps,
     id,
     fullScreen,
-    dividerProps
+    dividerProps,
+    dialogActionsProps
   }
 }
 

--- a/react/Dialog/Readme.md
+++ b/react/Dialog/Readme.md
@@ -3,7 +3,7 @@
 If no ready made [CozyDialogs](#/CozyDialogs) corresponds to what you need, you can use
 Dialog directly. The useCozyDialog takes [CozyDialog props]([CozyDialogs](#/CozyDialogs))
 and returns props to spread on the components used in your custom Dialog. Those props
-will make sure that even your custom Dialogs will behave as CozyDialogs. 
+will make sure that even your custom Dialogs will behave as CozyDialogs.
 
 ```jsx
 import cx from 'classnames'
@@ -44,7 +44,7 @@ initialState = { modalOpened: isTesting() }
 
 const ExampleDialog = ({ open, onClose }) => {
   const { isMobile } = useBreakpoints()
-  const { dialogProps, dialogTitleProps, listItemProps, dividerProps } = useCozyDialog({
+  const { dialogProps, dialogTitleProps, listItemProps, dividerProps, dialogActionsProps } = useCozyDialog({
     size: 'medium',
     classes: {
       paper: 'my-class'
@@ -122,7 +122,7 @@ const ExampleDialog = ({ open, onClose }) => {
         </ListItem>
       </List>
       <Divider {...dividerProps} />
-      <DialogActions>
+      <DialogActions {...dialogActionsProps}>
         <Button
           theme="secondary"
           onClick={() => onClose()}

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -381,6 +381,11 @@ normalTheme.overrides = {
           maxWidth: '800px'
         }
       }
+    },
+    paperFullScreen: {
+      '& .cozyDialogActions': {
+        paddingBottom: 'env(safe-area-inset-bottom)'
+      }
     }
   },
   MuiDialogTitle: {


### PR DESCRIPTION
DialogActions should respect the safe-area except for ConfirmDialog

The Dialogs are in fullscreen in mobile so it is not embarrassing to add the safe-area in all cases.

ConfirmDialog is not supposed to display a lot of content. Moreover ConfirmDialog is not fullscreen like other Dialogs, so  no need to add safe-area paddingBottom.

**Before**
<img width="409" alt="Capture d’écran 2020-11-30 à 18 21 04" src="https://user-images.githubusercontent.com/1107936/100643834-dafc0000-333a-11eb-8d3c-a6ca40daa248.png">

**After**
<img width="397" alt="Capture d’écran 2020-11-30 à 18 20 21" src="https://user-images.githubusercontent.com/1107936/100643826-d6cfe280-333a-11eb-84e7-dc2e0801a09e.png">
