### PR TITLE
fix: Missing variable in palette would cause blank page

### DIFF
--- a/stylus/settings/palette.styl
+++ b/stylus/settings/palette.styl
@@ -171,6 +171,7 @@ html, .CozyTheme--normal
     --primaryTextColor var(--charcoalGrey)
     --secondaryTextColor var(--coolGrey)
     --primaryContrastTextColor var(--white)
+    --secondaryContrastTextColor var(--white)
 
     --invertedTabsActiveTextColor var(--primaryContrastTextColor)
     --invertedTabsInactiveTextColor var(--primaryContrastTextColor)


### PR DESCRIPTION
The theme was relying on missing css custom prop
secondaryContrastTextColor