### PR TITLE
fix: Pass the filename to download()

### DIFF
--- a/react/Viewer/withFileUrl.jsx
+++ b/react/Viewer/withFileUrl.jsx
@@ -53,7 +53,7 @@ const withFileUrl = BaseComponent =>
     getDownloadLink(file) {
       return this.context.client
         .collection('io.cozy.files')
-        .getDownloadLinkById(file._id)
+        .getDownloadLinkById(file._id, file.name)
     }
 
     clearTimeout() {


### PR DESCRIPTION
Fix lot of `undefined` in the stack's prod log file. For the user it doesn't change anything except if they use a browser not supporting the download attribute hack (https://github.com/cozy/cozy-client/blob/master/packages/cozy-stack-client/src/FileCollection.js#L481-L488) 