### PR TITLE
Viewer : Add blocks in info panel

### DIFF
--- a/react/Viewer/InformationPanel.jsx
+++ b/react/Viewer/InformationPanel.jsx
@@ -1,29 +1,37 @@
 import React from 'react'
-
+import PropTypes from 'prop-types'
 import Drawer from '@material-ui/core/Drawer'
 import { withStyles } from '@material-ui/core/styles'
 
 export const infoWidth = '22rem'
 
-const styles = () => ({
+const customStyles = () => ({
   drawer: {
     width: infoWidth,
     flexShrink: 0
   },
   drawerPaper: {
-    width: infoWidth
+    width: infoWidth,
+    backgroundColor: 'var(--defaultBackgroundColor)'
   }
 })
 
-const InformationPanel = ({ classes }) => {
+const InformationPanel = ({ classes, children }) => {
   return (
     <Drawer
       className={classes.drawer}
       classes={{ paper: classes.drawerPaper }}
       variant="permanent"
       anchor="right"
-    />
+    >
+      {children}
+    </Drawer>
   )
 }
 
-export default withStyles(styles)(InformationPanel)
+InformationPanel.propTypes = {
+  classes: PropTypes.object,
+  children: PropTypes.element
+}
+
+export default withStyles(customStyles)(InformationPanel)

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -2,12 +2,19 @@ The `Viewer` component can be used to display the content of various file types.
 
 Once rendered, the `Viewer` will take up all the available space in it's container (using `position: absolute`). It can be paired with the `Overlay` component to take up the whole screen.
 
+The `Viewer` can display an **information panel** to show additional information about the current file (e.g. whether a file is certified).
+
 ```jsx
 import Variants from 'docs/components/Variants';
 import Card from 'cozy-ui/transpiled/react/Card';
 import Checkbox from 'cozy-ui/transpiled/react/Checkbox';
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme';
 import Viewer from 'cozy-ui/transpiled/react/Viewer';
+import Stack from 'cozy-ui/transpiled/react/Stack';
+import Paper from 'cozy-ui/transpiled/react/Paper';
+import Typography from 'cozy-ui/transpiled/react/Typography';
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media';
+import Icon from 'cozy-ui/transpiled/react/Icon';
 // The DemoProvider inserts a fake cozy-client in the React context.
 import DemoProvider from './docs/DemoProvider';
 import Overlay from 'cozy-ui/transpiled/react/Overlay';
@@ -48,19 +55,47 @@ const files = [
 
 // The host app will usually need a small wrapper to display the Viewer. This is a very small example of such a wrapper that handles opening, closing, and navigating between files.
 initialState = {
-  viewerOpened: false,
+  viewerOpened: isTesting(),
   currentFileIndex: 0,
-  close: true
+  showToolbarCloseButton: true
 };
 
 const initialVariants = [
-  { infoPanel: false, navigation: true, toolbar: true }
+  { navigation: true, toolbar: true }
 ];
 
-const openViewer = () => setState({ viewerOpened: true });
-const closeViewer = () => setState({ viewerOpened: false });
-const handleToggleToolbarClose = () => setState({ close: !state.close });
+const toggleViewer = () => setState({ viewerOpened: !state.viewerOpened });
+const handleToggleToolbarClose = () => setState({ showToolbarCloseButton: !state.showToolbarCloseButton });
 const onFileChange = (file, nextIndex) => setState({ currentFileIndex: nextIndex });
+
+const PanelContent = ({ currentFile }) => {
+  return (
+    <Stack
+      spacing="l"
+      className="u-flex u-flex-column u-h-100"
+    >
+      <Paper className={'u-ph-2 u-flex u-flex-items-center u-h-3'} elevation={2} square>
+        <Typography variant="h4">Informations utiles</Typography>
+      </Paper>
+      <Paper className={'u-ph-2 u-pv-1-half'} elevation={2} square>
+        <Typography variant="body1">Titre du fichier : {currentFile.name}</Typography>
+      </Paper>
+      <Paper className={'u-ph-2 u-pv-1-half u-flex-grow-1'} elevation={2} square>
+        <Typography variant="h4">
+          <Media className="u-mb-half">
+            <Img>
+              <Icon icon="carbonCopy" className="u-mr-half" />
+            </Img>
+            <Bd>
+              <Typography variant="body1">Copie conforme</Typography>
+            </Bd>
+          </Media>
+          <Typography variant="caption">Ce document a été fourni par Grand Lyon. Il est défini “authentique et original” par Cozy Cloud, hébergeur de votre Cozy, car il peut affirmer qu'il provient directement du service du Grand Lyon, sans qu’il n’ait subit aucune modification.</Typography>
+        </Typography>
+      </Paper>
+    </Stack>
+  )
+};
 
 <MuiCozyTheme>
   <DemoProvider>
@@ -73,25 +108,28 @@ const onFileChange = (file, nextIndex) => setState({ currentFileIndex: nextIndex
                 <Checkbox
                   className="u-dib"
                   label="Close"
-                  checked={state.close}
+                  checked={state.showToolbarCloseButton}
                   onChange={handleToggleToolbarClose}
                 />
               </Card>
             )}
-            <button onClick={openViewer}>Open viewer</button>
+            <button onClick={toggleViewer}>Open viewer</button>
             {state.viewerOpened && (
               <Overlay>
                 <Viewer
                   files={files}
                   currentIndex={state.currentFileIndex}
-                  onCloseRequest={closeViewer}
+                  onCloseRequest={toggleViewer}
                   onChangeRequest={onFileChange}
                   showNavigation={variant.navigation}
                   toolbarProps={{
                     showToolbar: variant.toolbar,
-                    showClose: state.close
+                    showClose: state.showToolbarCloseButton
                   }}
-                  showInfo={variant.infoPanel}
+                  panelInfoProps={{
+                    showPanel: ({ currentFile }) => currentFile.class === "pdf" || currentFile.class === "audio",
+                    PanelContent: PanelContent
+                  }}
                 />
               </Overlay>
             )}

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -121,8 +121,8 @@ export class Viewer extends Component {
       currentIndex,
       dark,
       toolbarProps,
+      panelInfoProps,
       showNavigation,
-      showInfo,
       breakpoints: { isDesktop }
     } = this.props
     const currentFile = files[currentIndex]
@@ -131,7 +131,8 @@ export class Viewer extends Component {
     const hasNext = currentIndex < fileCount - 1
     // this `expanded` property makes the next/previous controls cover the displayed image
     const expanded = currentFile && currentFile.class === 'image'
-    const showInfoPanel = showInfo && isDesktop
+    const showInfoPanel =
+      isDesktop && panelInfoProps && panelInfoProps.showPanel({ currentFile })
 
     return (
       <ViewerWrapper className={className} dark={dark}>
@@ -151,7 +152,11 @@ export class Viewer extends Component {
         >
           {this.renderViewer(currentFile)}
         </ViewerControls>
-        {showInfoPanel && <InformationPanel />}
+        {showInfoPanel && (
+          <InformationPanel>
+            <panelInfoProps.PanelContent currentFile={currentFile} />
+          </InformationPanel>
+        )}
       </ViewerWrapper>
     )
   }
@@ -181,8 +186,12 @@ Viewer.propTypes = {
   showNavigation: PropTypes.bool,
   /** A render prop that is called when a file can't be displayed */
   renderFallbackExtraContent: PropTypes.func,
-  /** Whether to show more informations about the file */
-  showInfo: PropTypes.bool
+  panelInfoProps: PropTypes.shape({
+    /** Whether to show the panel containing more information about the file */
+    showPanel: PropTypes.func,
+    /** Content to be shown  */
+    PanelContent: PropTypes.func
+  })
 }
 
 Viewer.defaultProps = {

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -37,8 +37,8 @@
         max-width   90%
 
     +medium-screen()
-      margin-left      0
-      width            100%
+        margin-left      0
+        width            100%
 
 // rules for specific viewers below
 
@@ -50,35 +50,35 @@
 
 .viewer-textviewer
     .viewer-textviewer-content
-      white-space pre-line
-      width 100%
-      max-height 70%
-      overflow auto
+        white-space pre-line
+        width 100%
+        max-height 70%
+        overflow auto
 
-      a
+    a
         color var(--azure)
 
     +medium-screen()
-      width 90%
-      margin-left 5%
+        width 90%
+        margin-left 5%
 
 .viewer-filename
     max-width     90%
     text-overflow ellipsis
 
 .viewer-pdfviewer-pdf
-  overflow auto
-  width 100%
+    overflow auto
+    width 100%
 
 .viewer-pdfviewer-page > *
-  margin auto
+    margin auto
 
 .viewer-pdfviewer-toolbar
-  position absolute
-  bottom 2rem
-  background var(--charcoalGrey)
-  color var(--white)
-  border-radius .5rem
+    position absolute
+    bottom 2rem
+    background var(--charcoalGrey)
+    color var(--white)
+    border-radius .5rem
 
 .viewer-imageviewer
     flex             1 1 100%
@@ -89,4 +89,4 @@
         display     block
         max-width   100%
         max-height  100%
-        box-shadow  0 .375rem 1.5rem 0 rgba(0, 0, 0, 0.5)
+        box-shadow  0 .375rem 1.5rem 0 rgba(0, 0, 0, .5)


### PR DESCRIPTION
Ajout d'exemples d'utilisation des blocs dans le panneau d'info du Viewer. Pour l'instant pas de souhait d'avoir un composant haut niveau dans UI, l'approche étant que ce soit l'app qui puisse ajouter les blocs dans le panneau d'info comme elle le souhaite.

Petit changement également pour screenshoter le viewer et non la doc.

https://jf-cozy.github.io/cozy-ui/react/#!/Viewer