### PR TITLE
Remove required onClose required propType on CozyDialogs

### DIFF
--- a/react/CozyDialogs/dialogPropTypes.js
+++ b/react/CozyDialogs/dialogPropTypes.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 export default {
   open: PropTypes.bool.isRequired,
-  onClose: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   title: PropTypes.node,
   content: PropTypes.node,
   actions: PropTypes.node,


### PR DESCRIPTION
Sometimes we do not want to have the onClose proptype.
In those cases, the DialogCloseButton is not displayed (the check
was already in place).