### PR TITLE
chore: Add travis_wait on yarn screenshots --mode kss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - yarn screenshots --mode react --viewport desktop
   - yarn screenshots --mode react --viewport 300x600 --no-empty-screenshot-dir
   - yarn screenshots --mode stack --no-empty-screenshot-dir
-  - yarn screenshots --mode kss --no-empty-screenshot-dir
+  - travis_wait yarn screenshots --mode kss --no-empty-screenshot-dir
   - yarn argos --token $ARGOS_TOKEN --branch $TRAVIS_BRANCH --commit $TRAVIS_COMMIT
 deploy:
   - provider: script


### PR DESCRIPTION
Le build Travis n'aboutit pas parfois. Il est alors nécessaire de relancer le build manuellement. Travis termine sur un `No output has been received in the last 10m0s` alors qu'il devrait faire quelque chose comme `exit with 0`.

Ce fix est une tentative de correction, suivant ce qui est indiqué sur la doc https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received et du fait qu'il s'agisse du script `yarn screenshots --mode kss --no-empty-screenshot-dir`.

Voici le log : 

```
$ yarn screenshots --mode kss --no-empty-screenshot-dir
yarn run v1.22.4
$ node scripts/screenshots.js --screenshot-dir ./screenshots --styleguide-dir ./build/react --kss-dir ./build/styleguide --mode kss --no-empty-screenshot-dir
Browser opened and set up
Screenshotting section kssref-settings-breakpoints
Screenshotting section kssref-settings-colors
Screenshotting section kssref-settings-fonts
Screenshotting section kssref-settings-icons
Screenshotting section kssref-settings-theme
Screenshotting section kssref-settings-z-index
Screenshotting section kssref-settings-breakpoints-mixins
Screenshotting section kssref-settings-colors-grey
Screenshotting section kssref-settings-colors-blue
Screenshotting section kssref-settings-colors-green
Screenshotting section kssref-settings-colors-orange
Screenshotting section kssref-settings-colors-purple
Screenshotting section kssref-settings-colors-red
Screenshotting section kssref-settings-icons-sizes
Screenshotting section kssref-settings-icons-options
Screenshotting section kssref-settings-theme-primary
Screenshotting section kssref-tools-mixins
Screenshotting section kssref-tools-mixins-rem
Screenshotting section kssref-tools-mixins-hide
Screenshotting section kssref-tools-mixins-hide
Screenshotting section kssref-tools-mixins-reset
Screenshotting section kssref-generic-animation
Screenshotting section kssref-generic-normalize
Ignoring utilities-typography
Ignoring utilities-border
Ignoring utilities-cursor
Ignoring utilities-hide
Ignoring utilities-margins
Ignoring utilities-paddings
Ignoring utilities-spacings
Ignoring utilities-text
Ignoring utilities-boxsizing
Ignoring utilities-card
Ignoring utilities-display
Ignoring utilities-elevation
Ignoring utilities-flexbox
Ignoring utilities-list
Ignoring utilities-position
Ignoring utilities-position-directions
Ignoring utilities-dimensions
Ignoring utilities-bgcolor
Ignoring utilities-opacity
Ignoring utilities-effects
Ignoring utilities-overflow
Ignoring utilities-border-radius
Ignoring utilities-border-width
Ignoring utilities-text-colors
Ignoring utilities-text-error
Ignoring utilities-text-valid
Ignoring utilities-text-warn
Ignoring utilities-text-line-height
Ignoring utilities-text-fontsize
Ignoring utilities-text-fontstyle
Ignoring utilities-text-fontweight
Ignoring utilities-text-alignment
Ignoring utilities-text-ellipsis
Ignoring utilities-text-spacellipsis
Ignoring utilities-text-midellipsis
Ignoring utilities-text-link
Ignoring utilities-flexbox-direction
Ignoring utilities-flexbox-wrap
Ignoring utilities-flexbox-items
Ignoring utilities-flexbox-justify
Ignoring utilities-flexbox-content
Ignoring utilities-flexbox-self
Ignoring utilities-flexbox-order
Ignoring utilities-flexbox-grow
Ignoring utilities-flexbox-shrink
Ignoring utilities-dimensions-min
Ignoring utilities-dimensions-max
Screenshotting section kssref-components-accordion
Screenshotting section kssref-components-avatar
Screenshotting section kssref-components-chip

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
The build has been terminated
```