### PR TITLE
fix: Viewer now uses UI locales only for specific component

### DIFF
--- a/react/Viewer/NoNetworkViewer.jsx
+++ b/react/Viewer/NoNetworkViewer.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
+
 import Icon from '../Icon'
+import CloudBrokenIcon from '../Icons/CloudBroken'
 import Button from '../Button'
-import { translate } from '../I18n'
 
+import { withViewerLocales } from './withViewerLocales'
 import styles from './styles.styl'
-
-import CloudBrokenIcon from 'cozy-ui/transpiled/react/Icons/CloudBroken'
 
 const NoNetworkViewer = ({ t, onReload }) => (
   <div className={styles['viewer-canceled']}>
@@ -15,4 +15,4 @@ const NoNetworkViewer = ({ t, onReload }) => (
   </div>
 )
 
-export default translate()(NoNetworkViewer)
+export default withViewerLocales(NoNetworkViewer)

--- a/react/Viewer/NoViewer/DownloadButton.jsx
+++ b/react/Viewer/NoViewer/DownloadButton.jsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import flow from 'lodash/flow'
+
 import { withClient } from 'cozy-client'
-import { translate } from '../../I18n'
-import Button from '../../Button'
-import styles from '../styles.styl'
+
 import { FileDoctype } from '../../proptypes'
+import Button from '../../Button'
+
+import { withViewerLocales } from '../withViewerLocales'
+import styles from '../styles.styl'
 
 const DownloadButton = ({ t, client, file }) => (
   <Button
@@ -20,4 +24,7 @@ DownloadButton.propTypes = {
   file: FileDoctype
 }
 
-export default translate()(withClient(DownloadButton))
+export default flow(
+  withClient,
+  withViewerLocales
+)(DownloadButton)

--- a/react/Viewer/PdfJsViewer.jsx
+++ b/react/Viewer/PdfJsViewer.jsx
@@ -3,11 +3,15 @@ import PropTypes from 'prop-types'
 import { Document, Page } from 'react-pdf'
 import cx from 'classnames'
 import throttle from 'lodash/throttle'
+import flow from 'lodash/flow'
+
 import { Spinner } from '../Spinner'
+
+import { withViewerLocales } from './withViewerLocales'
 import withFileUrl from './withFileUrl'
 import ToolbarButton from './PdfToolbarButton'
 import NoViewer from './NoViewer'
-import { translate } from '../I18n'
+
 import styles from './styles.styl'
 
 export const MIN_SCALE = 0.25
@@ -196,4 +200,7 @@ PdfJsViewer.propTypes = {
   renderFallbackExtraContent: PropTypes.func
 }
 
-export default withFileUrl(translate()(PdfJsViewer))
+export default flow(
+  withFileUrl,
+  withViewerLocales
+)(PdfJsViewer)

--- a/react/Viewer/ShortcutViewer.jsx
+++ b/react/Viewer/ShortcutViewer.jsx
@@ -2,14 +2,13 @@ import React from 'react'
 import { useClient, useFetchShortcut } from 'cozy-client'
 import get from 'lodash/get'
 
+import { withViewerLocales } from './withViewerLocales'
 import { ButtonLink } from '../Button'
-import { useI18n } from '../I18n'
 import NoViewer from './NoViewer'
 import { FileDoctype } from '../proptypes'
 
-const ShortcutViewer = ({ file }) => {
+const ShortcutViewer = ({ t, file }) => {
   const client = useClient()
-  const { t } = useI18n()
   const { shortcutInfos } = useFetchShortcut(client, file.id)
   let url = ''
   if (shortcutInfos) {
@@ -34,4 +33,4 @@ ShortcutViewer.propTypes = {
   file: FileDoctype.isRequired
 }
 
-export default ShortcutViewer
+export default withViewerLocales(ShortcutViewer)

--- a/react/Viewer/ShortcutViewer.spec.jsx
+++ b/react/Viewer/ShortcutViewer.spec.jsx
@@ -5,7 +5,13 @@ import I18n from '../I18n'
 import { render, wait } from '@testing-library/react'
 
 import ShortcutViewer from './ShortcutViewer'
-import { locales } from './index'
+
+import en from './locales/en.json'
+
+export const locales = {
+  en
+}
+
 const setup = () => {
   const client = new CozyClient({})
   return (

--- a/react/Viewer/Toolbar.jsx
+++ b/react/Viewer/Toolbar.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 
 import { useClient } from 'cozy-client'
 
-import { useI18n } from '../I18n'
+import { withViewerLocales } from './withViewerLocales'
 import Button from '../Button'
 import IconButton from '../IconButton'
 import Icon from '../Icon'
@@ -21,9 +21,9 @@ const Toolbar = ({
   onMouseEnter,
   onMouseLeave,
   currentFile,
-  onClose
+  onClose,
+  t
 }) => {
-  const { t } = useI18n()
   const client = useClient()
 
   return (
@@ -71,4 +71,4 @@ Toolbar.propTypes = {
   onClose: PropTypes.func.isRequired
 }
 
-export default Toolbar
+export default withViewerLocales(Toolbar)

--- a/react/Viewer/__snapshots__/index.spec.jsx.snap
+++ b/react/Viewer/__snapshots__/index.spec.jsx.snap
@@ -60,7 +60,7 @@ exports[`Viewer should render the various viewers: noviewer 1`] = `
 `;
 
 exports[`Viewer should render the various viewers: pdfviewer 1`] = `
-<withI18n(PdfJsViewer)
+<withI18n(withLocales(withFileUrlClass))
   file={
     Object {
       "_id": "pdffileid",
@@ -70,12 +70,11 @@ exports[`Viewer should render the various viewers: pdfviewer 1`] = `
     }
   }
   onClose={[Function]}
-  url="https://testurl.com/pdffileid"
 />
 `;
 
 exports[`Viewer should render the various viewers: shortcutviewer 1`] = `
-<ShortcutViewer
+<withI18n(withLocales(ShortcutViewer))
   file={
     Object {
       "_id": "shortcutfileid",

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -1,10 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import flow from 'lodash/flow'
 
 import { isMobileApp, isMobile as isMobileDevice } from 'cozy-device-helper'
 
-import withLocales from '../I18n/withLocales'
 import withBreakpoints from '../helpers/withBreakpoints'
 import { FileDoctype } from '../proptypes'
 
@@ -18,14 +16,6 @@ import TextViewer from './TextViewer'
 import NoViewer from './NoViewer'
 import ShortcutViewer from './ShortcutViewer'
 import InformationPanel from './InformationPanel'
-
-import en from './locales/en.json'
-import fr from './locales/fr.json'
-
-export const locales = {
-  en,
-  fr
-}
 
 const KEY_CODE_LEFT = 37
 const KEY_CODE_RIGHT = 39
@@ -202,7 +192,4 @@ Viewer.defaultProps = {
   panelInfoProps: { showPanel: () => false }
 }
 
-export default flow(
-  withLocales(locales),
-  withBreakpoints()
-)(Viewer)
+export default withBreakpoints()(Viewer)

--- a/react/Viewer/withViewerLocales.jsx
+++ b/react/Viewer/withViewerLocales.jsx
@@ -1,0 +1,11 @@
+import withLocales from '../I18n/withLocales'
+
+import en from './locales/en.json'
+import fr from './locales/fr.json'
+
+export const locales = {
+  en,
+  fr
+}
+
+export const withViewerLocales = withLocales(locales)


### PR DESCRIPTION
Ceci est nécessaire lors de l'utilisation du Panel afin d'utiliser le provider de langue de l'app et non celui de UI