### PR TITLE
feat: Read tracking setting from data-cozy or data-cozy-tracking

### DIFF
--- a/react/helpers/appDataset.js
+++ b/react/helpers/appDataset.js
@@ -1,0 +1,44 @@
+import memoize from 'lodash/memoize'
+
+export const readApplicationDataset = memoize(() => {
+  const root = document.querySelector('[role=application]')
+  return root && root.dataset
+})
+
+export const readCozyData = memoize(() => {
+  const dataset = readApplicationDataset()
+  if (dataset && dataset.cozy) {
+    return JSON.parse(dataset.cozy)
+  }
+  return null
+})
+
+/**
+ * Reads an attribute set by the stack from the DOM
+ *
+ * A cozy app must receives on data from the stack, typically on the
+ * [role=application] node. Here, we try first to read from data-cozy
+ * and we fallback on data-[attrName].
+ */
+export const readCozyDataFromDOM = memoize(attrName => {
+  const data = readCozyData()
+
+  if (data && data[attrName] !== undefined) {
+    return data[attrName]
+  }
+
+  const appDataset = readApplicationDataset()
+  if (!appDataset) {
+    return
+  }
+
+  const attrName2 = `cozy${attrName[0].toUpperCase()}${attrName.substring(1)}`
+  const value = appDataset[attrName2]
+  return value === undefined ? undefined : value === '' || JSON.parse(value)
+})
+
+export const resetCache = () => {
+  readCozyDataFromDOM.cache = new memoize.Cache()
+  readCozyData.cache = new memoize.Cache()
+  readApplicationDataset.cache = new memoize.Cache()
+}

--- a/react/helpers/appDataset.spec.js
+++ b/react/helpers/appDataset.spec.js
@@ -1,0 +1,54 @@
+import memoize from 'lodash/memoize'
+import {
+  readCozyDataFromDOM,
+  readApplicationDataset,
+  readCozyData
+} from './appDataset'
+
+describe('appdataset', () => {
+  beforeEach(() => {
+    readCozyDataFromDOM.cache = new memoize.Cache()
+    readApplicationDataset.cache = new memoize.Cache()
+    readCozyData.cache = new memoize.Cache()
+  })
+
+  describe('data-cozy', () => {
+    it('should work for true value', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy=\'{"tracking": true}\'></div>'
+      expect(readCozyDataFromDOM('tracking')).toBe(true)
+    })
+
+    it('should work for false value', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy=\'{"tracking": false}\'></div>'
+      expect(readCozyDataFromDOM('tracking')).toBe(false)
+    })
+
+    it('should work for other type of values', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy=\'{"token": "abcd456"}\'></div>'
+      expect(readCozyDataFromDOM('token')).toBe('abcd456')
+    })
+  })
+
+  describe('data-<attr>', () => {
+    it('should work for empty boolean attributes', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy-tracking></div>'
+      expect(readCozyDataFromDOM('tracking')).toBe(true)
+    })
+
+    it('should work for filled boolean attributes', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy-tracking="true"></div>'
+      expect(readCozyDataFromDOM('tracking')).toBe(true)
+    })
+
+    it('should work for filled boolean attributes', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy-tracking="false"></div>'
+      expect(readCozyDataFromDOM('tracking')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
The stack introduced the data-cozy attribute a while ago. All the
future data coming from the stack to the cozy should come from
there.

Here the tracking setup code is refactored to use helpers that can
read either from data-cozy attribute or data-cozy-<attrName> attribute.