### PR TITLE
Improvements

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -20,6 +20,7 @@ module.exports = {
         '../react/InfosBadge/index.jsx',
         '../react/GhostFileBadge/index.jsx',
         '../react/Button/index.jsx',
+        '../react/MuiCozyTheme/Buttons',
         '../react/ButtonAction/index.jsx',
         '../react/Card/index.jsx',
         '../react/Chip/index.jsx',
@@ -43,6 +44,8 @@ module.exports = {
         '../react/Checkbox/index.jsx',
         '../react/DateMonthPicker/index.jsx',
         '../react/Field/index.jsx',
+        '../react/MuiCozyTheme/TextField',
+        '../react/Labs/CollectionField',
         '../react/FileInput/index.jsx',
         '../react/Input/index.jsx',
         '../react/InputGroup/index.jsx',
@@ -60,6 +63,7 @@ module.exports = {
       components: () => [
         '../react/Circle/index.jsx',
         '../react/MuiCozyTheme/Divider/index.jsx',
+        '../react/MuiCozyTheme/ExpansionPanel',
         '../react/Hero/index.jsx',
         '../react/hooks/useBreakpoints/index.jsx',
         '../react/Layout/Layout.jsx',
@@ -113,9 +117,9 @@ module.exports = {
       name: 'Navigation',
       components: () => [
         '../react/ActionMenu/index.jsx',
+        '../react/MuiCozyTheme/Menus',
         '../react/AppLinker/index.jsx',
         '../react/Breadcrumbs/index.jsx',
-        '../react/Menu/index.jsx',
         '../react/Tabs/index.jsx',
         '../react/NavigationList/index.jsx'
       ]
@@ -141,14 +145,10 @@ module.exports = {
     {
       name: 'Material-UI',
       components: () => [
-        '../react/MuiCozyTheme/Buttons',
-        '../react/MuiCozyTheme/ExpansionPanel',
         '../react/MuiCozyTheme/Grid',
         '../react/MuiCozyTheme/index.jsx',
         '../react/MuiCozyTheme/List',
-        '../react/MuiCozyTheme/Menus',
-        '../react/MuiCozyTheme/RaisedList',
-        '../react/MuiCozyTheme/TextField'
+        '../react/MuiCozyTheme/RaisedList'
       ]
     },
     {
@@ -156,7 +156,6 @@ module.exports = {
       components: () => [
         '../react/Labs/GridItem',
         '../react/Labs/IconGrid',
-        '../react/Labs/CollectionField',
         '../react/Labs/PasswordInput'
       ]
     },
@@ -175,10 +174,11 @@ module.exports = {
     {
       name: 'Deprecated',
       components: () => [
+        '../react/Menu/index.jsx',
         '../react/Modal/index.jsx',
         '../react/Text/index.jsx',
         '../react/CompositeRow/index.jsx',
-        '../react/InlineCard/index.jsx',
+        '../react/InlineCard/index.jsx'
       ]
     }
   ],

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -31,7 +31,6 @@ module.exports = {
         '../react/IconStack/index.jsx',
         '../react/Paper/index.js',
         '../react/PercentageBar/index.jsx',
-        '../react/PercentageLine/index.jsx',
         '../react/Progress',
         '../react/ProgressionBanner',
         '../react/Spinner/index.jsx',
@@ -86,6 +85,7 @@ module.exports = {
         '../react/Figure/Figure.jsx',
         '../react/Figure/FigureBlock.jsx',
         '../react/Filename/index.jsx',
+        '../react/MuiCozyTheme/Grid',
         '../react/Infos/index.jsx',
         '../react/InfosCarrousel/index.jsx',
         '../react/LoadMore/index.jsx',
@@ -93,7 +93,6 @@ module.exports = {
         '../react/MidEllipsis/index.jsx',
         '../react/CozyDialogs',
         '../react/Dialog',
-        '../react/OrderedList/index.jsx',
         '../react/Table/index.jsx',
         '../react/Typography/index.jsx',
         '../react/Tooltip/index.jsx',
@@ -111,7 +110,11 @@ module.exports = {
     },
     {
       name: 'List',
-      components: () => ['../react/ListItemText/index.jsx']
+      components: () => [
+        '../react/MuiCozyTheme/List',
+        '../react/ListItemText/index.jsx',
+        '../react/OrderedList/index.jsx'
+      ]
     },
     {
       name: 'Navigation',
@@ -143,15 +146,6 @@ module.exports = {
       ]
     },
     {
-      name: 'Material-UI',
-      components: () => [
-        '../react/MuiCozyTheme/Grid',
-        '../react/MuiCozyTheme/index.jsx',
-        '../react/MuiCozyTheme/List',
-        '../react/MuiCozyTheme/RaisedList'
-      ]
-    },
-    {
       name: 'Labs',
       components: () => [
         '../react/Labs/GridItem',
@@ -177,8 +171,10 @@ module.exports = {
         '../react/Menu/index.jsx',
         '../react/Modal/index.jsx',
         '../react/Text/index.jsx',
+        '../react/MuiCozyTheme/RaisedList',
         '../react/CompositeRow/index.jsx',
-        '../react/InlineCard/index.jsx'
+        '../react/InlineCard/index.jsx',
+        '../react/PercentageLine/index.jsx'
       ]
     }
   ],

--- a/react/Breadcrumbs/index.jsx
+++ b/react/Breadcrumbs/index.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import styles from './styles.styl'
 import Icon from '../Icon'
+import Typography from '../Typography'
+import IconButton from '@material-ui/core/IconButton'
+import LeftIcon from '../Icons/Left'
 
 const BreadcrumbSeparator = () => (
   <span className={styles.BreadcrumbSeparator}>/</span>
@@ -17,11 +20,7 @@ const BreadcrumbItem = ({
 }) => {
   const Tag = tag
   return (
-    <div
-      className={cx(styles.BreadcrumbItem, {
-        [styles['BreadcrumbItem--current']]: isCurrent
-      })}
-    >
+    <Typography variant={isCurrent ? 'h3' : 'body1'} gutterBottom={isCurrent}>
       <Tag
         onClick={onClick}
         className={cx({
@@ -31,7 +30,7 @@ const BreadcrumbItem = ({
         {name}
       </Tag>
       {showSeparator && <BreadcrumbSeparator />}
-    </div>
+    </Typography>
   )
 }
 
@@ -55,11 +54,12 @@ const Breadcrumbs = ({ items, className, style }) => {
   return (
     <div style={style} className={cx(styles.Breadcrumb, className)}>
       {items.length > 1 && (
-        <Icon
-          icon={'left'}
-          className={styles.Breadcrumb__previousButton}
+        <IconButton
           onClick={lastPreviousItem.onClick}
-        />
+          className={styles.Breadcrumb__previousButton}
+        >
+          <Icon icon={LeftIcon} />
+        </IconButton>
       )}
       <div className={styles.Breadcrumb__items}>
         <div className={styles.Breadcrumb__previousItems}>

--- a/react/Breadcrumbs/styles.styl
+++ b/react/Breadcrumbs/styles.styl
@@ -7,7 +7,9 @@
     color var(--primaryTextColor)
 
 .Breadcrumb__previousButton
-    margin-right (spacing_values.m)
+    // Tweak the margin-left to account for the IconButton wrapper
+    margin-left -(spacing_values.s)
+    margin-right (spacing_values.xs / 2)
     cursor pointer
 
 .Breadcrumb__items
@@ -15,15 +17,6 @@
 
 .Breadcrumb__previousItems
     display flex
-
-.BreadcrumbItem
-    font-size $small-font-size
-    line-height 1
-
-.BreadcrumbItem--current
-    font-size $h1-font-size
-    font-weight bold
-    line-height 1.67
 
 .BreadcrumbSeparator
     display inline-block

--- a/react/Menu/index.jsx
+++ b/react/Menu/index.jsx
@@ -37,6 +37,10 @@ class MenuItem extends Component {
 }
 
 const logMenuDepecrated = createDepreciationLogger()
+
+/**
+ * @deprecated This component is deprecated, please use ActionMenu instead. See styleguide > Menu for more information on how to migrate.
+ */
 class Menu extends Component {
   constructor(props, context) {
     super(props, context)

--- a/react/MuiCozyTheme/RaisedList/README.md
+++ b/react/MuiCozyTheme/RaisedList/README.md
@@ -5,14 +5,13 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText';
 
 <RaisedList>
-  <Divider />
   <ListItem button divider>
     <ListItemText primaryText="cozy.io" secondaryText="Claude Douillet" />
   </ListItem>
   <ListItem button divider>
     <ListItemText primaryText="cozy.io" secondaryText="Isabelle Durand" />
   </ListItem>
-  <ListItem button divider>
+  <ListItem button>
     <ListItemText primaryText="cozy.io" secondaryText="Geneviève Durand" />
   </ListItem>
 </RaisedList>

--- a/react/MuiCozyTheme/RaisedList/index.js
+++ b/react/MuiCozyTheme/RaisedList/index.js
@@ -1,14 +1,17 @@
-import BaseList from '@material-ui/core/List'
-import { withStyles } from '@material-ui/core/styles'
+import React from 'react'
+import List from '@material-ui/core/List'
+import Paper from '@material-ui/core/Paper'
+import createDepreciationLogger from '../../helpers/createDepreciationLogger'
 
-const styles = {
-  root: {
-    borderRadius: 8,
-    overflow: 'hidden',
-    borderLeft: '1px solid var(--silver)',
-    borderRight: '1px solid var(--silver)',
-    boxShadow: '0 4px 12px 0 rgba(0, 0, 0, 0.08)'
-  }
+const logRaisedListDepecrated = createDepreciationLogger()
+
+export default props => {
+  logRaisedListDepecrated(
+    'RaisedList is deprecated, please use a combination of List & Paper : <Paper elevation={4}><List /></Paper>'
+  )
+  return (
+    <Paper elevation={2}>
+      <List {...props} />
+    </Paper>
+  )
 }
-
-export default withStyles(styles, 'RaisedList')(BaseList)

--- a/react/MuiCozyTheme/RaisedList/index.js
+++ b/react/MuiCozyTheme/RaisedList/index.js
@@ -5,6 +5,9 @@ import createDepreciationLogger from '../../helpers/createDepreciationLogger'
 
 const logRaisedListDepecrated = createDepreciationLogger()
 
+/**
+ * @deprecated Please use a combination of List & Paper : <Paper elevation={4}><List /></Paper>
+ */
 export default props => {
   logRaisedListDepecrated(
     'RaisedList is deprecated, please use a combination of List & Paper : <Paper elevation={4}><List /></Paper>'


### PR DESCRIPTION
- Use IconButton in Breadcrumbs

Improve breadcrumbs by using an IconButton for the backbutton. Breadcrumbs is used in banks when navigating categories.

- Do not put material UI components in a dedicated section

We do not want to make a distinction between components made with MUI and other components. Next step would be to remove the MuiCozyTheme folder, and simplify the imports for cozy-ui.

- Put deprecated components inside the deprecated section


See result on https://ptbrowne.github.io/cozy-ui/react/#!/Breadcrumbs