### PR TITLE
Viewer: global style for mobile

### DIFF
--- a/react/Viewer/Toolbar.jsx
+++ b/react/Viewer/Toolbar.jsx
@@ -17,7 +17,6 @@ import styles from './styles.styl'
 const Toolbar = ({
   hidden,
   isMobile,
-  isMobileApp,
   onMouseEnter,
   onMouseLeave,
   file,
@@ -29,15 +28,14 @@ const Toolbar = ({
   return (
     <div
       className={cx(styles['viewer-toolbar'], {
-        [styles['viewer-toolbar--hidden']]: hidden,
-        [styles['viewer-toolbar--mobilebrowser']]: !isMobileApp && isMobile
+        [styles['viewer-toolbar--hidden']]: hidden
       })}
       role="viewer-toolbar"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
       {onClose && (
-        <IconButton onClick={onClose} className="u-white">
+        <IconButton onClick={onClose} className={cx({ 'u-white': !isMobile })}>
           <Icon icon={PreviousIcon} />
         </IconButton>
       )}
@@ -64,7 +62,6 @@ const Toolbar = ({
 Toolbar.propTypes = {
   hidden: PropTypes.bool,
   isMobile: PropTypes.bool.isRequired,
-  isMobileApp: PropTypes.bool.isRequired,
   onMouseEnter: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func.isRequired,
   file: PropTypes.object.isRequired,

--- a/react/Viewer/ViewerControls.jsx
+++ b/react/Viewer/ViewerControls.jsx
@@ -102,7 +102,6 @@ class ViewerControls extends Component {
       showNavigation,
       showInfoPanel,
       children,
-      isMobileApp,
       classes
     } = this.props
     const { showToolbar, showClose } = toolbarProps
@@ -122,7 +121,6 @@ class ViewerControls extends Component {
           <Toolbar
             file={file}
             onClose={showClose && onClose}
-            isMobileApp={isMobileApp}
             onMouseEnter={this.showControls}
             onMouseLeave={this.hideControls}
             isMobile={isMobile}
@@ -163,7 +161,6 @@ ViewerControls.propTypes = {
   expanded: PropTypes.bool.isRequired,
   toolbarProps: PropTypes.shape(toolbarPropsPropType),
   showNavigation: PropTypes.bool.isRequired,
-  isMobileApp: PropTypes.bool.isRequired,
   showInfoPanel: PropTypes.bool
 }
 

--- a/react/Viewer/ViewerWrapper.jsx
+++ b/react/Viewer/ViewerWrapper.jsx
@@ -4,21 +4,15 @@ import cx from 'classnames'
 
 import styles from './styles.styl'
 
-const ViewerWrapper = ({ className, children, dark }) => (
-  <div
-    className={cx(styles['viewer-wrapper'], className, {
-      [styles['viewer-wrapper--light']]: !dark
-    })}
-    role="viewer"
-  >
+const ViewerWrapper = ({ className, children }) => (
+  <div className={cx(styles['viewer-wrapper'], className)} role="viewer">
     {children}
   </div>
 )
 
 ViewerWrapper.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.array,
-  dark: PropTypes.bool
+  children: PropTypes.array
 }
 
 export default ViewerWrapper

--- a/react/Viewer/controls.styl
+++ b/react/Viewer/controls.styl
@@ -70,12 +70,12 @@ $toolbarHeightMedium = 3rem
     justify-content flex-start
     align-items center
 
-    &--mobilebrowser
-        background-color var(--charcoalGrey)
-        opacity .9
-
     &--hidden
         opacity 0
 
     +medium-screen()
         height $toolbarHeightMedium
+
+    +small-screen()
+        background var(--white)
+        border-bottom 1px solid var(--silver)

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -109,7 +109,6 @@ export class Viewer extends Component {
       files,
       className,
       currentIndex,
-      dark,
       toolbarProps,
       panelInfoProps,
       showNavigation,
@@ -127,7 +126,7 @@ export class Viewer extends Component {
       panelInfoProps.showPanel({ file: currentFile })
 
     return (
-      <ViewerWrapper className={className} dark={dark}>
+      <ViewerWrapper className={className}>
         <ViewerControls
           file={currentFile}
           onClose={this.onClose}
@@ -171,8 +170,6 @@ Viewer.propTypes = {
   onCloseRequest: PropTypes.func,
   /** Called with (nextFile, nextIndex) when the user requests to navigate to another file */
   onChangeRequest: PropTypes.func,
-  /** Switch between light and dark mode */
-  dark: PropTypes.bool,
   toolbarProps: PropTypes.shape(toolbarPropsPropType),
   /** Whether to show left and right arrows to navigate between files */
   showNavigation: PropTypes.bool,
@@ -188,7 +185,6 @@ Viewer.propTypes = {
 
 Viewer.defaultProps = {
   currentIndex: 0,
-  dark: true,
   toolbarProps: { showToolbar: true, showClose: true },
   showNavigation: true,
   panelInfoProps: { showPanel: () => false }

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import { isMobileApp, isMobile as isMobileDevice } from 'cozy-device-helper'
+import { isMobile as isMobileDevice } from 'cozy-device-helper'
 
 import withBreakpoints from '../helpers/withBreakpoints'
 import { FileDoctype } from '../proptypes'
@@ -138,7 +138,6 @@ export class Viewer extends Component {
           expanded={expanded}
           toolbarProps={toolbarProps}
           showNavigation={showNavigation}
-          isMobileApp={isMobileApp()}
           showInfoPanel={showInfoPanel}
         >
           {this.renderViewer(currentFile)}

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -10,9 +10,13 @@
     top             0
     bottom          0
     z-index         $overlay-index
-    background      var(--charcoalGrey)
     overflow        hidden
+    background      var(--charcoalGrey)
     color           var(--white)
+
+    +small-screen()
+        color var(--charcoalGrey)
+        background var(--white)
 
 .viewer-imageviewer
 .viewer-noviewer

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -14,10 +14,6 @@
     overflow        hidden
     color           var(--white)
 
-    &--light
-        background  var(--white)
-        color       var(--black)
-
 .viewer-imageviewer
 .viewer-noviewer
 .viewer-audioviewer


### PR DESCRIPTION
- Il n'est plus possible de choisir si le Viewer est foncé ou clair.
  - Le viewer sur desktop est maintenant toujours gris foncé
  - Le viewer sur mobile est maintenant toujours blanc

https://jf-cozy.github.io/cozy-ui/react/#!/Viewer

Le bouton "back" n'apparaît pas dans les screenshot d'argos mais est bien présent suite au build... je valide donc la CI