### PR TITLE
fix: CozyDialog Title should have ellipsis with long text

### DIFF
--- a/react/CozyDialogs/DialogBackButton.jsx
+++ b/react/CozyDialogs/DialogBackButton.jsx
@@ -9,7 +9,7 @@ import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
 
 const customStyles = () => ({
   root: {
-    margin: '-1rem 0.25rem -1rem -0.5rem'
+    margin: '-1.1rem 0.25rem -0.9rem -0.5rem'
   }
 })
 

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -128,25 +128,32 @@ const toggleDialog = dialog => {
 }
 
 initialState = {
-  modalOpened: false,
+  modalOpened: isTesting(),
   modal: Dialog,
   size: 'medium',
   actionsLayout: 'row',
+  title: 'short',
   content: 'default',
   theme: 'normal'
 };
 
 <>
   <BreakpointsProvider>
+    <p>Title:
+      <StateRadio value='short' name='title' /> short{' '}
+      <StateRadio value='long' name='title' /> long
+    </p>
     <p>Content:
       <StateRadio value='default' name='content' /> default{' '}
       <StateRadio value='short' name='content' /> short{' '}
       <StateRadio value='long' name='content' /> long
-    </p><p>Size:
+    </p>
+    <p>Size:
       <StateRadio value='small' name='size' /> small {' '}
       <StateRadio value='medium' name='size' /> medium {' '}
       <StateRadio value='large' name='size' /> large
-    </p><p>Actions layout:
+    </p>
+    <p>Actions layout:
       <StateRadio value='row' name='actionsLayout' /> row{' '}
       <StateRadio value='column' name='actionsLayout' /> column
     </p>
@@ -154,7 +161,10 @@ initialState = {
       size={DialogComponent !== ConfirmDialog ? state.size : undefined}
       open={state.modalOpened}
       onClose={handleClose}
-      title={dialogTitles[DialogComponent.name]}
+      title={DialogComponent !== IllustrationDialog && state.title === "long"
+        ? `${dialogTitles[DialogComponent.name]} - ${content.ada.short}`
+        : dialogTitles[DialogComponent.name]
+      }
       content={
         <Typography variant='body1' color='textPrimary'>
           { state.content == 'default'

--- a/react/MuiCozyTheme/theme.js
+++ b/react/MuiCozyTheme/theme.js
@@ -421,8 +421,6 @@ const makeOverrides = theme => ({
       ...theme.typography.h3,
       width: 'calc(100% - (58px + 30px))', // remove close button width and margin
       padding: '24px 32px',
-      display: 'flex',
-      alignItems: 'center',
       [theme.breakpoints.down('sm')]: {
         ...theme.typography.h4,
         width: 'calc(100% - 58px)', // remove close button width and margin


### PR DESCRIPTION
fix bug introduced with https://github.com/cozy/cozy-ui/commit/4bc03f4106ded21b425b92da09e1c30ab23f960d because of display flex