### PR TITLE
fix: Viewer isMobile based on breakpoint, not device

### DIFF
--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -19,6 +19,9 @@ import CarbonCopyIcon from 'cozy-ui/transpiled/react/Icons/CarbonCopy';
 // The DemoProvider inserts a fake cozy-client in the React context.
 import DemoProvider from './docs/DemoProvider';
 import Overlay from 'cozy-ui/transpiled/react/Overlay';
+import {
+  BreakpointsProvider
+} from 'cozy-ui/transpiled/react/hooks/useBreakpoints';
 
 // We provide a collection of (fake) io.cozy.files to be rendered
 const files = [
@@ -99,46 +102,48 @@ const PanelContent = ({ file }) => {
 };
 
 <MuiCozyTheme>
-  <DemoProvider>
-    <Variants initialVariants={initialVariants}>{
-        variant => (
-          <>
-            {variant.toolbar && (
-              <Card className="u-mb-1">
-                <div className="u-dib u-mr-1">Toolbar props :</div>
-                <Checkbox
-                  className="u-dib"
-                  label="Close"
-                  checked={state.showToolbarCloseButton}
-                  onChange={handleToggleToolbarClose}
-                />
-              </Card>
-            )}
-            <button onClick={toggleViewer}>Open viewer</button>
-            {state.viewerOpened && (
-              <Overlay>
-                <Viewer
-                  files={files}
-                  currentIndex={state.currentIndex}
-                  onCloseRequest={toggleViewer}
-                  onChangeRequest={onFileChange}
-                  showNavigation={variant.navigation}
-                  toolbarProps={{
-                    showToolbar: variant.toolbar,
-                    showClose: state.showToolbarCloseButton
-                  }}
-                  panelInfoProps={{
-                    showPanel: ({ file }) => file.class === "pdf" || file.class === "audio",
-                    PanelContent
-                  }}
-                />
-              </Overlay>
-            )}
-          </>
-        )
-      }
-    </Variants>
-  </DemoProvider>
+  <BreakpointsProvider>
+    <DemoProvider>
+      <Variants initialVariants={initialVariants}>{
+          variant => (
+            <>
+              {variant.toolbar && (
+                <Card className="u-mb-1">
+                  <div className="u-dib u-mr-1">Toolbar props :</div>
+                  <Checkbox
+                    className="u-dib"
+                    label="Close"
+                    checked={state.showToolbarCloseButton}
+                    onChange={handleToggleToolbarClose}
+                  />
+                </Card>
+              )}
+              <button onClick={toggleViewer}>Open viewer</button>
+              {state.viewerOpened && (
+                <Overlay>
+                  <Viewer
+                    files={files}
+                    currentIndex={state.currentIndex}
+                    onCloseRequest={toggleViewer}
+                    onChangeRequest={onFileChange}
+                    showNavigation={variant.navigation}
+                    toolbarProps={{
+                      showToolbar: variant.toolbar,
+                      showClose: state.showToolbarCloseButton
+                    }}
+                    panelInfoProps={{
+                      showPanel: ({ file }) => file.class === "pdf" || file.class === "audio",
+                      PanelContent
+                    }}
+                  />
+                </Overlay>
+              )}
+            </>
+          )
+        }
+      </Variants>
+    </DemoProvider>
+  </BreakpointsProvider>
 </MuiCozyTheme>
 ```
 

--- a/react/Viewer/Toolbar.jsx
+++ b/react/Viewer/Toolbar.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 
 import { useClient } from 'cozy-client'
 
-import { withViewerLocales } from './withViewerLocales'
+import useBreakpoints from '../hooks/useBreakpoints'
 import Button from '../Button'
 import IconButton from '../IconButton'
 import Icon from '../Icon'
@@ -12,18 +12,13 @@ import Typography from '../Typography'
 import PreviousIcon from '../Icons/Previous'
 import DownloadIcon from '../Icons/Download'
 
+import { withViewerLocales } from './withViewerLocales'
+
 import styles from './styles.styl'
 
-const Toolbar = ({
-  hidden,
-  isMobile,
-  onMouseEnter,
-  onMouseLeave,
-  file,
-  onClose,
-  t
-}) => {
+const Toolbar = ({ hidden, onMouseEnter, onMouseLeave, file, onClose, t }) => {
   const client = useClient()
+  const { isMobile } = useBreakpoints()
 
   return (
     <div
@@ -61,7 +56,6 @@ const Toolbar = ({
 
 Toolbar.propTypes = {
   hidden: PropTypes.bool,
-  isMobile: PropTypes.bool.isRequired,
   onMouseEnter: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func.isRequired,
   file: PropTypes.object.isRequired,

--- a/react/Viewer/ViewerControls.jsx
+++ b/react/Viewer/ViewerControls.jsx
@@ -1,9 +1,12 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
+import flow from 'lodash/flow'
 import cx from 'classnames'
 import Hammer from 'hammerjs'
 import { withStyles } from '@material-ui/core/styles'
+
+import withBreakpoints from '../helpers/withBreakpoints'
 
 import { toolbarPropsPropType } from './index'
 import { infoWidth } from './InformationPanel'
@@ -96,13 +99,13 @@ class ViewerControls extends Component {
       hasNext,
       onPrevious,
       onNext,
-      isMobile,
       expanded,
       toolbarProps,
       showNavigation,
       showInfoPanel,
       children,
-      classes
+      classes,
+      breakpoints: { isMobile }
     } = this.props
     const { showToolbar, showClose } = toolbarProps
     const { hidden } = this.state
@@ -123,7 +126,6 @@ class ViewerControls extends Component {
             onClose={showClose && onClose}
             onMouseEnter={this.showControls}
             onMouseLeave={this.hideControls}
-            isMobile={isMobile}
           />
         )}
         {showNavigation && !isMobile && hasPrevious && (
@@ -157,11 +159,13 @@ ViewerControls.propTypes = {
   hasNext: PropTypes.bool.isRequired,
   onPrevious: PropTypes.func.isRequired,
   onNext: PropTypes.func.isRequired,
-  isMobile: PropTypes.bool.isRequired,
   expanded: PropTypes.bool.isRequired,
   toolbarProps: PropTypes.shape(toolbarPropsPropType),
   showNavigation: PropTypes.bool.isRequired,
   showInfoPanel: PropTypes.bool
 }
 
-export default withStyles(customStyles)(ViewerControls)
+export default flow(
+  withBreakpoints(),
+  withStyles(customStyles)
+)(ViewerControls)

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -134,7 +134,6 @@ export class Viewer extends Component {
           hasNext={hasNext}
           onPrevious={this.onPrevious}
           onNext={this.onNext}
-          isMobile={isMobileDevice()}
           expanded={expanded}
           toolbarProps={toolbarProps}
           showNavigation={showNavigation}


### PR DESCRIPTION
Ce qui fait qu'on a bien maintenant les changements au redimensionnement de la fenêtre, sans avoir besoin d'actualiser la page.

Pour info on voit que Argos se base également sur les breakpoints et non le type de device