### PR TITLE
feat: Use semantic colors for wizard

### DIFF
--- a/stylus/components/wizard.styl
+++ b/stylus/components/wizard.styl
@@ -25,7 +25,7 @@ $wizard
 
 $wizard--waiting
     color var(--white)
-    background-color var(--dodgerBlue)
+    background-color var(--primaryColor)
 
 $wizard--scroll
     position absolute
@@ -80,7 +80,7 @@ $wizard-dual
     &:first-child
         justify-content flex-end
         color var(--white)
-        background-color var(--dodgerBlue)
+        background-color var(--primaryColor)
 
 $wizard-errors
     order 1
@@ -181,7 +181,7 @@ $wizard-logo-badge
     width rem(32)
     height rem(32)
     border .125rem solid var(--white)
-    background-color var(--dodgerBlue)
+    background-color var(--primaryColor)
     border-radius 50%
 
 $wizard-header-help
@@ -224,12 +224,12 @@ $wizard-desc
     line-height 1.5
 
     a
-        color var(--dodgerBlue)
+        color var(--primaryColor)
         text-decoration none
 
         &:hover
         &:focus
-            color var(--scienceBlue)
+            color var(--primaryColorDark)
 
     +small-device()
         margin rem(24) 0 0
@@ -422,10 +422,10 @@ $wizard-dualfield
     border-radius rem(2)
 
 $wizard-dualfield--focus
-    border-color var(--dodgerBlue)
+    border-color var(--primaryColor)
 
 $wizard-dualfield--error
-    border-color var(--pomegranate)
+    border-color var(--errorColor)
 
 $wizard-dualfield-wrapper
     flex 1 1 auto


### PR DESCRIPTION
Wizard uses color names variables instead of semantic variables.
This makes theming impossible.