### PR TITLE
fix: Revert travis and deploy modification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,3 @@ deploy:
     script: yarn deploy:doc -- --username cozycloud --email contact@cozycloud.cc --repo https://cozy-bot:$GH_TOKEN@github.com/cozy/cozy-ui.git && yarn semantic-release
     on:
       branch: master
-  - provider: script
-    repo: cozy/cozy-ui
-    skip-cleanup: true
-    script: yarn semantic-release
-    on:
-      branch: next-major

--- a/release.config.js
+++ b/release.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "branch": "master",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
- revert de https://github.com/cozy/cozy-ui/commit/ab2622f1f99fa478b0487e5566ed770946da8f51 qui pose problème dans travis
```
error: The destination you provided is not a full refname (i.e.,\nstarting with "refs/"). We tried to guess what you meant by:\n\n- Looking for a ref that matches \'undefined\' on the remote side.\n- Checking if the <src> being pushed (\'HEAD\')\n  is a ref in "refs/{heads,tags}/". If so we add a corresponding\n  refs/{heads,tags}/ prefix on the remote side.\n\nNeither worked, so we gave up. You must fully qualify the ref.\nhint: The <src> part of the refspec is a commit object.\nhint: Did you mean to create a new branch by pushing to\nhint: \'HEAD:refs/heads/undefined\'?\nerror: failed to push some refs to \'https://github.com/cozy/cozy-ui.git\'
```
suite à la commande `'git push --tags https://[secure]@github.com/cozy/cozy-ui.git HEAD:undefined'`

- revert de https://github.com/cozy/cozy-ui/commit/43ad8346a5f6bf898e9a7464dee8b1a1bbf2d85c
car sinon lorsqu'on merge master dans next-major, le changelog est publié ensuite sur master, ce qui fait comme un merge de next-major dans master et supprime donc la branche next-major