### PR TITLE
docs: udpate licence in the README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -162,7 +162,7 @@ See our [travis configuration](./travis.yml) for more information.
 
 ## License
 
-Cozy UI is developed by Cozy Cloud and distributed under the AGPL-3.0 license.
+Cozy UI is developed by Cozy Cloud and distributed under the MIT license.
 
 ## What is Cozy?
 


### PR DESCRIPTION
The licence indicated in `docs/README.md` is not the same as the one in `LICENCE`.
That part was probably forgotten in [this commit](https://github.com/mkrtchian/cozy-ui/commit/e3bb473b974f7cf134f2ccc976a5a979386b1faf).

---

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

```
yarn build:doc:react
yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
```

- [ ] Deployed the styleguidist
- [ ] Did you think of ARIA attributes if you are coding new components ?
