### PR TITLE
fix: Viewer spinners should not be white in mobile

### DIFF
--- a/react/Viewer/ImageViewer.jsx
+++ b/react/Viewer/ImageViewer.jsx
@@ -1,13 +1,11 @@
 import React, { Component } from 'react'
-
 import Hammer from 'hammerjs'
 
-import styles from './styles.styl'
-
-import Spinner from '../Spinner'
+import ViewerSpinner from './ViewerSpinner'
 import ImageLoader from './ImageLoader'
-
 import NoNetworkViewer from './NoNetworkViewer'
+
+import styles from './styles.styl'
 
 const MIN_SCALE = 1
 const MAX_SCALE = 6
@@ -16,7 +14,7 @@ const FRICTION = 0.9 // When the photo is paning after a pan gesture ended sudde
 
 const clamp = (min, value, max) => Math.max(min, Math.min(max, value))
 
-export default class ImageViewer extends Component {
+class ImageViewer extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -213,16 +211,16 @@ export default class ImageViewer extends Component {
     if (this.state.canceled) {
       return <NoNetworkViewer onReload={this.reload} />
     }
+
     const { file } = this.props
     const { scale, offsetX, offsetY } = this.state
     const style = {
       transform: `scale(${scale}) translate(${offsetX}px, ${offsetY}px)`
     }
+
     return (
       <div className={styles['viewer-imageviewer']}>
-        {this.state.loading && (
-          <Spinner size="xxlarge" middle noMargin color="white" />
-        )}
+        {this.state.loading && <ViewerSpinner />}
         {file && (
           <ImageLoader
             file={file}
@@ -326,3 +324,5 @@ export default class ImageViewer extends Component {
     }
   }
 }
+
+export default ImageViewer

--- a/react/Viewer/PdfJsViewer.jsx
+++ b/react/Viewer/PdfJsViewer.jsx
@@ -5,8 +5,7 @@ import cx from 'classnames'
 import throttle from 'lodash/throttle'
 import flow from 'lodash/flow'
 
-import { Spinner } from '../Spinner'
-
+import ViewerSpinner from './ViewerSpinner'
 import { withViewerLocales } from './withViewerLocales'
 import withFileUrl from './withFileUrl'
 import ToolbarButton from './PdfToolbarButton'
@@ -132,7 +131,7 @@ export class PdfJsViewer extends Component {
           onLoadSuccess={this.onLoadSuccess}
           onLoadError={this.onLoadError}
           className={styles['viewer-pdfviewer-pdf']}
-          loading={<Spinner size="xxlarge" middle noMargin color="white" />}
+          loading={<ViewerSpinner />}
         >
           {renderAllPages ? (
             [...Array(totalPages)].map((_, page) => (

--- a/react/Viewer/TextViewer.jsx
+++ b/react/Viewer/TextViewer.jsx
@@ -2,12 +2,16 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+
 import { withClient, models } from 'cozy-client'
-import Spinner from '../Spinner'
-import withFileUrl from './withFileUrl'
-import styles from './styles.styl'
-import NoViewer from './NoViewer'
+
+import ViewerSpinner from './ViewerSpinner'
 import { FileDoctype } from '../proptypes'
+
+import withFileUrl from './withFileUrl'
+import NoViewer from './NoViewer'
+
+import styles from './styles.styl'
 
 const MarkdownRenderer = ({ text }) => (
   <ReactMarkdown
@@ -24,11 +28,13 @@ const PlainTextRenderer = ({ text }) => (
   </pre>
 )
 
-const Loader = () => (
-  <div className={styles['viewer-textviewer']}>
-    <Spinner size="xxlarge" middle noMargin color="white" />
-  </div>
-)
+const Loader = () => {
+  return (
+    <div className={styles['viewer-textviewer']}>
+      <ViewerSpinner />
+    </div>
+  )
+}
 
 export const isMarkdown = file =>
   file.mime === 'text/markdown' ||

--- a/react/Viewer/TextViewer.spec.jsx
+++ b/react/Viewer/TextViewer.spec.jsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { TextViewer, isMarkdown } from './TextViewer'
-import { createMockClient } from 'cozy-client'
 import renderer from 'react-test-renderer'
+
+import { createMockClient } from 'cozy-client'
+
+import { BreakpointsProvider } from '../hooks/useBreakpoints'
+import { TextViewer, isMarkdown } from './TextViewer'
 
 const client = createMockClient({})
 
@@ -45,19 +48,31 @@ describe('TextViewer Component', () => {
     const comp = shallow(<TextViewer {...props} />)
     expect(comp).toMatchSnapshot()
   })
+
   it('should display the error component and render with renderFallback', () => {
     const comp = renderer.create(
-      <TextViewer
-        {...props}
-        renderFallbackExtraContent={file => <span>{file.name}</span>}
-      />
+      <BreakpointsProvider>
+        <TextViewer
+          {...props}
+          renderFallbackExtraContent={file => <span>{file.name}</span>}
+        />
+      </BreakpointsProvider>
     )
-    comp.getInstance().setState({ error: true, loading: false })
+
+    const inst = comp.root.children[0].instance
+    inst.setState({ error: true, loading: false })
     expect(comp.toJSON()).toMatchSnapshot()
   })
+
   it('should display the text viewer', () => {
-    const comp = renderer.create(<TextViewer {...props} />)
-    comp.getInstance().setState({
+    const comp = renderer.create(
+      <BreakpointsProvider>
+        <TextViewer {...props} />
+      </BreakpointsProvider>
+    )
+
+    const inst = comp.root.children[0].instance
+    inst.setState({
       loading: false,
       isMarkdown: false,
       text: 'The content of my file'
@@ -66,8 +81,14 @@ describe('TextViewer Component', () => {
   })
 
   it('should display the markdown viewer', () => {
-    const comp = renderer.create(<TextViewer {...props} />)
-    comp.getInstance().setState({
+    const comp = renderer.create(
+      <BreakpointsProvider>
+        <TextViewer {...props} />
+      </BreakpointsProvider>
+    )
+
+    const inst = comp.root.children[0].instance
+    inst.setState({
       loading: false,
       isMarkdown: true,
       text:

--- a/react/Viewer/ViewerSpinner.jsx
+++ b/react/Viewer/ViewerSpinner.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import useBreakpoints from '../hooks/useBreakpoints'
+import Spinner from '../Spinner'
+
+const ViewerSpinner = () => {
+  const { isMobile } = useBreakpoints()
+
+  return (
+    <Spinner
+      size="xxlarge"
+      middle
+      noMargin
+      {...!isMobile && { color: 'white' }}
+    />
+  )
+}
+
+export default ViewerSpinner

--- a/react/Viewer/withFileUrl.jsx
+++ b/react/Viewer/withFileUrl.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Spinner from '../Spinner'
 
+import ViewerSpinner from './ViewerSpinner'
 import NoNetworkViewer from './NoNetworkViewer'
 
 const TTL = 6000
@@ -68,7 +68,7 @@ const withFileUrl = BaseComponent =>
 
     render() {
       if (this.state.status === LOADING) {
-        return <Spinner size="xxlarge" middle noMargin color="white" />
+        return <ViewerSpinner />
       }
       if (this.state.status === FAILED) {
         return <NoNetworkViewer onReload={this.reset} />


### PR DESCRIPTION
Sur mobile, le Viewer est sur fond blanc (contrairement à un fond gris sur Desktop). Les spinners doivent donc être de la couleur primaire, et non blanc, pour être visibles.