### PR TITLE
feat: Add filter grayscale utility class to styleguide

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -2051,18 +2051,33 @@ Display an chip that represents complex identity
 */
 
 /*
- Overflow
+    Overflow
 
- Tells a container how its exceeding content behaves
+    Tells a container how its exceeding content behaves
 
- Markup: <div style="border:1px solid var(--dividerColor);" class="u-mb-2 u-p-half u-w-5 u-h-4 {{modifier_class}}">Non habitant lobortis hac maecenas eleifend donec parturient, lacinia aenean ac varius mattis purus scelerisque, congue montes dapibus tempor semper proin. Ullamcorper malesuada proin nec accumsan fermentum ac suspendisse posuere, lectus tristique tortor lorem faucibus primis sodales.</div>
+    Markup: <div style="border:1px solid var(--dividerColor);" class="u-mb-2 u-p-half u-w-5 u-h-4 {{modifier_class}}">Non habitant lobortis hac maecenas eleifend donec parturient, lacinia aenean ac varius mattis purus scelerisque, congue montes dapibus tempor semper proin. Ullamcorper malesuada proin nec accumsan fermentum ac suspendisse posuere, lectus tristique tortor lorem faucibus primis sodales.</div>
 
- .u-ov-visible - Sets a visible overflow
- .u-ov-hidden - Sets an hidden overflow
- .u-ov-scroll - Sets a scroll overflow
- .u-ov-auto - Sets an auto overflow
+    .u-ov-visible - Sets a visible overflow
+    .u-ov-hidden - Sets an hidden overflow
+    .u-ov-scroll - Sets a scroll overflow
+    .u-ov-auto - Sets an auto overflow
 
- Weight: 17
+    Weight: 17
 
- Styleguide utilities.overflow
+    Styleguide utilities.overflow
+*/
+
+/*
+    Filter
+
+    Applies graphical effects like grayscale to an element. Filters are commonly used to adjust the rendering of images, backgrounds, and borders.
+
+    .u-filter-gray-100 - filter: grayscale(1)
+
+    Markup:
+    <img class="{{modifier_class}}" src="https://cozy.io/fr/images/cozy-logo_white.png" alt="" width="50" heigh="50">
+
+    Styleguide utilities.filter
+
+    Weight: 18
 */

--- a/stylus/utilities/filter.styl
+++ b/stylus/utilities/filter.styl
@@ -1,0 +1,2 @@
+.u-filter-gray-100
+    filter: grayscale(1)


### PR DESCRIPTION
Le cas d'usage est ici https://github.com/cozy/cozy-libs/blob/master/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx#L27 afin de remplacer le withStyle. (on a déjà la classe utilitaire opacity)

Ce remplacement ne peut être fait que comme ça ou via un stylus. Comme on évite de faire du stylus et que j'ai pensé que cette classe utilitaire pourrait resservir dans d'autres contextes, j'ai choisi cette façon de faire.

La nécessité de remplacer le withStyle est due au fait qu'on a un conflit de classe css `jss` générée dans Banks lors de l'utilisation du Viewer (de cozy-ui) via un intent Drive. Après quelques recherches je pense que c'est dû à un différence de version de MUI utilisé (Banks et Harvest sont en v3, Drive en v4), et ayant une feature qui commence à dater qu'on aimerait finaliser, j'ai penché pour cette solution en attendant un mise à jour de Banks. 