### PR TITLE
feat: Ability to choose which status will be shown

### DIFF
--- a/react/AppTile/Readme.md
+++ b/react/AppTile/Readme.md
@@ -11,6 +11,11 @@ const locale = {}
 const app = mockApps[0];
 
 <I18n dictRequire={lang => locale} lang="en">
-  <AppTile app={app} />
+  <div className='u-flex'>
+    <AppTile app={app} />
+    <AppTile app={{...app, maintenance: true}} />
+    <AppTile app={{...app, availableVersion: true}} />
+    <AppTile app={{...app, availableVersion: true}} showStatus={['maintenance']} />
+  </div>
 </I18n>
 ```

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -47,7 +47,10 @@ export const AppTile = ({
   const name = nameProp || app.name
   const { t } = useI18n()
   const { developer = {} } = app
-  const statusToDisplay = showStatus && getCurrentStatusLabel(app)
+  const statusLabel = getCurrentStatusLabel(app)
+  const statusToDisplay = Array.isArray(showStatus)
+    ? showStatus.indexOf(statusLabel) > -1 && statusLabel
+    : showStatus && statusLabel
   IconComponent = IconComponent || AppIcon
   return (
     <Tile tag="button" type="button" onClick={onClick}>
@@ -77,7 +80,7 @@ AppTile.propTypes = {
   namePrefix: PropTypes.string,
   onClick: PropTypes.func,
   showDeveloper: PropTypes.bool,
-  showStatus: PropTypes.bool
+  showStatus: PropTypes.oneOfType([PropTypes.bool, PropTypes.array])
 }
 
 AppTile.defaultProps = {


### PR DESCRIPTION
The showStatus prop of AppTile can now be an array listing
the statuses that should be shown. This way an app can
choose to show only "maintenance" and "update" statuses and
not show the "installed" status.