### PR TITLE
chore: fix for travis with build longer than 10 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - yarn screenshots --mode react --viewport desktop
   - yarn screenshots --mode react --viewport 300x600 --no-empty-screenshot-dir
   - yarn screenshots --mode stack --no-empty-screenshot-dir
-  - yarn screenshots --mode kss --no-empty-screenshot-dir
+  - travis_wait yarn screenshots --mode kss --no-empty-screenshot-dir
   - yarn argos:upload --token $ARGOS_TOKEN --branch $TRAVIS_BRANCH --commit $TRAVIS_COMMIT
 deploy:
   - provider: script


### PR DESCRIPTION
Travis met plus de 10 minutes et crash avant la fin avec le message suivant : 
```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
```