### PR TITLE
feat: Replace "role" of Viewer toolbar by "ref"

### DIFF
--- a/react/Viewer/Toolbar.jsx
+++ b/react/Viewer/Toolbar.jsx
@@ -16,16 +16,24 @@ import { withViewerLocales } from './withViewerLocales'
 
 import styles from './styles.styl'
 
-const Toolbar = ({ hidden, onMouseEnter, onMouseLeave, file, onClose, t }) => {
+const Toolbar = ({
+  hidden,
+  onMouseEnter,
+  onMouseLeave,
+  file,
+  onClose,
+  t,
+  toolbarRef
+}) => {
   const client = useClient()
   const { isMobile } = useBreakpoints()
 
   return (
     <div
+      ref={toolbarRef}
       className={cx(styles['viewer-toolbar'], {
         [styles['viewer-toolbar--hidden']]: hidden
       })}
-      role="viewer-toolbar"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >

--- a/react/Viewer/ViewerControls.jsx
+++ b/react/Viewer/ViewerControls.jsx
@@ -114,7 +114,7 @@ class ViewerControls extends Component {
       classes,
       breakpoints: { isMobile }
     } = this.props
-    const { showToolbar, showClose } = toolbarProps
+    const { showToolbar, showClose, toolbarRef } = toolbarProps
     const { hidden } = this.state
 
     return (
@@ -129,6 +129,7 @@ class ViewerControls extends Component {
       >
         {showToolbar && (
           <Toolbar
+            toolbarRef={toolbarRef}
             file={file}
             onClose={showClose && onClose}
             onMouseEnter={this.showControls}

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, createRef } from 'react'
 import PropTypes from 'prop-types'
 
 import { isMobile as isMobileDevice } from 'cozy-device-helper'
@@ -47,6 +47,10 @@ export const getViewerComponentName = (file, isDesktop) => {
 }
 
 export class Viewer extends Component {
+  constructor() {
+    super()
+    this.toolbarRef = createRef()
+  }
   componentDidMount() {
     document.addEventListener('keyup', this.onKeyUp, false)
   }
@@ -138,7 +142,7 @@ export class Viewer extends Component {
           onPrevious={this.onPrevious}
           onNext={this.onNext}
           expanded={expanded}
-          toolbarProps={toolbarProps}
+          toolbarProps={{ ...toolbarProps, toolbarRef: this.toolbarRef }}
           showNavigation={showNavigation}
           showInfoPanel={showInfoPanel}
         >
@@ -146,7 +150,10 @@ export class Viewer extends Component {
         </ViewerControls>
         {footerProps && (
           <Footer>
-            <footerProps.FooterContent file={currentFile} />
+            <footerProps.FooterContent
+              file={currentFile}
+              toolbarRef={this.toolbarRef}
+            />
           </Footer>
         )}
         {showInfoPanel && (
@@ -163,7 +170,8 @@ export const toolbarPropsPropType = {
   /** Whether to show the toolbar or not. Note that the built-in close button is in the toolbar. */
   showToolbar: PropTypes.bool,
   /** Whether to show close button in toolbar */
-  showClose: PropTypes.bool
+  showClose: PropTypes.bool,
+  toolbarRef: PropTypes.object
 }
 
 Viewer.propTypes = {


### PR DESCRIPTION
Since this is an invalid role.

BREAKING CHANGE: there is no role anymore on Viewer toolbar
Ref is useful to get the height value of this element