### PR TITLE
feat: Add bp provider in BarContextProvider

### DIFF
--- a/react/BarContextProvider/index.jsx
+++ b/react/BarContextProvider/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { I18nContext } from '../I18n'
+import { BreakpointsProvider } from '../hooks/useBreakpoints'
+
 import { CozyProvider } from 'cozy-client'
 import { Provider } from 'react-redux'
 
@@ -11,7 +13,7 @@ const BarContextProvider = props => {
         <I18nContext.Provider
           value={{ f: props.f, t: props.t, lang: props.lang }}
         >
-          {props.children}
+          <BreakpointsProvider>{props.children}</BreakpointsProvider>
         </I18nContext.Provider>
       </CozyProvider>
     </Provider>


### PR DESCRIPTION
Afin d'éviter l'erreur `Error: Cannot use useBreakpoints without BreakpointsProvider. The component must have a BreakpointsProvider above it` dans un ActionMenu présent dans la cozy-bar importée dans une app via 
```
const { BarRight } = cozy.bar
<BarRight>
  <BarContextProvider>
    <ActionMenu>
    </ActionMenu>
  </BarContextProvider>
</BarRight>
```