### PR TITLE
feat: Upgrade react-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "react-pdf": "^4.0.5",
     "react-popper": "^2.2.3",
     "react-remove-scroll": "^2.4.0",
-    "react-select": "^2.2.0",
+    "react-select": "^4.3.0",
     "react-swipeable-views": "^0.13.3"
   },
   "peerDependencies": {

--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -212,6 +212,10 @@ You can display additional actions inside an Option with the ActionsOption compo
 
 ```
 import SelectBox, { ActionsOption } from 'cozy-ui/transpiled/react/SelectBox';
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash';
+import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename';
+
+
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry', isDisabled: true },
@@ -220,8 +224,8 @@ const options = [
 ];
 
 const CustomOption = (props) => (<ActionsOption {...props} actions={[
-    { icon: 'delete', onClick: () => alert('deleting') },
-    { icon: 'rename', onClick: ({ data }) => alert(data.value) }
+    { icon: TrashIcon, onClick: () => alert('deleting') },
+    { icon: RenameIcon, onClick: ({ data }) => alert(data.value) }
   ]} />);
 
 <SelectBox options={options} components={{

--- a/react/SelectBox/SelectBox.jsx
+++ b/react/SelectBox/SelectBox.jsx
@@ -122,20 +122,6 @@ const reactSelectControl = CustomControl => ({
   </div>
 )
 
-export const withPrefix = (reactSelectCx, className) => {
-  // react-select implement a classnames function https://git.io/fhT8S
-  // it's not the same as classnames library (https://www.npmjs.com/package/classnames)
-  // 1st parameter is bound by react-select with prefix https://git.io/fhkIj
-  // 2nd parameter is cssKey. We don't need it so it's set to null
-  // 3rd parameter is used to add prefix but we don't want to stick with
-  //   webpack className so we add space (' ') in front of it
-  const classNameWithPrefix = reactSelectCx(null, { [` ${className}`]: true })
-
-  // When we don't use classNamePrefix cx return '' so we verify to send
-  // className
-  return classNameWithPrefix === '' ? className : classNameWithPrefix
-}
-
 const Option = ({
   children,
   isSelected,
@@ -144,43 +130,35 @@ const Option = ({
   innerProps,
   innerRef,
   labelComponent,
-  cx,
   withCheckbox
 }) => (
   <div
     {...innerProps}
     ref={innerRef}
-    className={withPrefix(
-      cx,
-      classNames(styles['select-option'], {
-        [styles['select-option--selected']]: isSelected && !withCheckbox,
-        [styles['select-option--focused']]: isFocused,
-        [styles['select-option--disabled']]: isDisabled
-      })
-    )}
+    className={classNames(styles['select-option'], {
+      [styles['select-option--selected']]: isSelected && !withCheckbox,
+      [styles['select-option--focused']]: isFocused,
+      [styles['select-option--disabled']]: isDisabled
+    })}
   >
     {withCheckbox && (
       <input
         type="checkbox"
         readOnly
         checked={isSelected}
-        className={withPrefix(cx, styles['select-option__checkbox'])}
+        className={styles['select-option__checkbox']}
       />
     )}
-    <span className={withPrefix(cx, styles['select-option__label'])}>
-      <span className={withPrefix(cx, 'u-ellipsis')}>
+    <span className={styles['select-option__label']}>
+      <span className="u-ellipsis">
         {labelComponent ? labelComponent : children}
       </span>
       {labelComponent ? children : false}
     </span>
     {!withCheckbox && (
-      <span className={withPrefix(cx, styles['select-option__checkmark'])}>
+      <span className={styles['select-option__checkmark']}>
         {isSelected && (
-          <Icon
-            icon={CheckIcon}
-            color={dodgerBlue}
-            className={withPrefix(cx, 'u-ph-half')}
-          />
+          <Icon icon={CheckIcon} color={dodgerBlue} className="u-ph-half" />
         )}
       </span>
     )}
@@ -202,14 +180,14 @@ CheckboxOption.propTypes = {}
 
 const ActionsOption = ({ actions, ...props }) => (
   <Option {...props} labelComponent={props.children}>
-    <span className={withPrefix(props.cx, styles['select-option__actions'])}>
+    <span className={styles['select-option__actions']}>
       {actions.map((action, index) => (
         <Icon
           {...action.iconProps}
           key={index}
           icon={action.icon}
           color={props.isFocused ? coolGrey : silver}
-          className={withPrefix(props.cx, 'u-ph-half')}
+          className="u-ph-half"
           onClick={e => {
             e.stopPropagation()
             action.onClick(props)

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2216,18 +2216,18 @@ exports[`Field should render examples: Field 7`] = `
 "<div>
   <form>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'am a SelectBox</label>
-      <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-vo6n8w-control\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-151xaom-placeholder\\">Select ...</div>
-            <div class=\\"css-1g6gooi\\">
+      <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\" id=\\"\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+        <div class=\\" css-fg5tdu-control\\">
+          <div class=\\" css-11jzfys-ValueContainer\\">
+            <div class=\\" css-1wa3eu0-placeholder\\">Select ...</div>
+            <div class=\\"css-b8ldur-Input\\">
               <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-2-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
           </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+          <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+            <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
                 <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
               </svg></div>
           </div>
@@ -2235,18 +2235,18 @@ exports[`Field should render examples: Field 7`] = `
       </div>
     </div>
     <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">I'am a SelectBox with a value</label>
-      <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\" id=\\"\\">
-        <div class=\\"css-vo6n8w-control\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-dvua67-singleValue\\">Choice 2</div>
-            <div class=\\"css-1g6gooi\\">
+      <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\" id=\\"\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+        <div class=\\" css-fg5tdu-control\\">
+          <div class=\\" css-11jzfys-ValueContainer\\">
+            <div class=\\" css-1uccc91-singleValue\\">Choice 2</div>
+            <div class=\\"css-b8ldur-Input\\">
               <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-3-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
           </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+          <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+            <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
                 <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
               </svg></div>
           </div>
@@ -6818,18 +6818,18 @@ exports[`InputGroup should render examples: InputGroup 4`] = `
       <div class=\\"styles__c-inputgroup___12OVJ\\">
         <div class=\\"styles__c-inputgroup-main___1LP4B\\"><input type=\\"text\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"URL\\" value=\\"\\"></div>
         <div class=\\"styles__c-inputgroup-side___60v0v\\">
-          <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp u-w-4\\">
-            <div class=\\"css-e5fm8t-control\\">
-              <div class=\\"css-1phseng\\">
-                <div class=\\"css-151xaom-placeholder\\">Select...</div>
-                <div class=\\"css-1g6gooi\\">
+          <div class=\\"styles__select--autowidth___16AEp u-w-4 css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+            <div class=\\" css-1x8e986-control\\">
+              <div class=\\" css-11jzfys-ValueContainer\\">
+                <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+                <div class=\\"css-b8ldur-Input\\">
                   <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-4-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                     <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
                   </div>
                 </div>
               </div>
-              <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-                <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+              <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+                <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
                     <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
                   </svg></div>
               </div>
@@ -7135,18 +7135,18 @@ exports[`Radio should render examples: Radio 4`] = `
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div style=\\"background: whitesmoke; padding: .5em;\\">
-    <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-      <div class=\\"css-vo6n8w-control\\">
-        <div class=\\"css-1phseng\\">
-          <div class=\\"css-151xaom-placeholder\\">Select...</div>
-          <div class=\\"css-1g6gooi\\">
+    <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+      <div class=\\" css-fg5tdu-control\\">
+        <div class=\\" css-11jzfys-ValueContainer\\">
+          <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+          <div class=\\"css-b8ldur-Input\\">
             <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-5-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-          <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+        <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+          <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
               <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
             </svg></div>
         </div>
@@ -7158,24 +7158,24 @@ exports[`SelectBox should render examples: SelectBox 1`] = `
 
 exports[`SelectBox should render examples: SelectBox 2`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-    <div class=\\"css-vo6n8w-control\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-fg5tdu-control\\">
+      <div class=\\" css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-6-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M20.603 17.825a1.571 1.571 0 002.222-2.222l-9.428-9.428a1.571 1.571 0 00-2.222 0l-9.429 9.428a1.571 1.571 0 002.222 2.222l8.318-8.317 8.317 8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
     </div>
-    <div class=\\"css-1qveapp-menu\\">
-      <div class=\\"css-11unzgr\\">
+    <div class=\\" css-govwq4-menu\\">
+      <div class=\\" css-4ljt47-MenuList\\">
         <div id=\\"react-select-6-option-0\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Chocolate</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
       </div>
     </div>
@@ -7186,18 +7186,18 @@ exports[`SelectBox should render examples: SelectBox 2`] = `
 exports[`SelectBox should render examples: SelectBox 3`] = `
 "<div>
   <div style=\\"height: 12rem; padding: .5rem; overflow: auto;\\">Container height: 12rem. <button>Change container height</button>
-    <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-      <div class=\\"css-vo6n8w-control\\">
-        <div class=\\"css-1phseng\\">
-          <div class=\\"css-151xaom-placeholder\\">Select...</div>
-          <div class=\\"css-1g6gooi\\">
+    <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+      <div class=\\" css-fg5tdu-control\\">
+        <div class=\\" css-11jzfys-ValueContainer\\">
+          <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+          <div class=\\"css-b8ldur-Input\\">
             <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-7-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-          <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+        <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+          <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
               <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
             </svg></div>
         </div>
@@ -7209,18 +7209,18 @@ exports[`SelectBox should render examples: SelectBox 3`] = `
 
 exports[`SelectBox should render examples: SelectBox 4`] = `
 "<div>
-  <div class=\\"css-ssi0ig-container styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
-    <div class=\\"css-exduax-control\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp styles__select--disabled___1W3en css-14jk2my-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-ofrup8-control\\">
+      <div class=\\" css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-1bwsx9e-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input disabled=\\"\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-8-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
@@ -7231,18 +7231,18 @@ exports[`SelectBox should render examples: SelectBox 4`] = `
 
 exports[`SelectBox should render examples: SelectBox 5`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--fullwidth___2l_xM\\">
-    <div class=\\"css-vo6n8w-control\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--fullwidth___2l_xM css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-fg5tdu-control\\">
+      <div class=\\" css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-9-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
@@ -7254,18 +7254,18 @@ exports[`SelectBox should render examples: SelectBox 5`] = `
 exports[`SelectBox should render examples: SelectBox 6`] = `
 "<div>
   <div>
-    <div class=\\"css-ssi0ig-container styles__select--autowidth___16AEp styles__select--disabled___1W3en\\">
-      <div class=\\"css-exduax-control\\">
-        <div class=\\"css-1phseng\\">
-          <div class=\\"css-151xaom-placeholder\\">Select...</div>
-          <div class=\\"css-1g6gooi\\">
+    <div class=\\"styles__select--autowidth___16AEp styles__select--disabled___1W3en css-14jk2my-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+      <div class=\\" css-ofrup8-control\\">
+        <div class=\\" css-11jzfys-ValueContainer\\">
+          <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+          <div class=\\"css-1bwsx9e-Input\\">
             <div class=\\"\\" style=\\"display: inline-block;\\"><input disabled=\\"\\" autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-10-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-          <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+        <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+          <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
               <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
             </svg></div>
         </div>
@@ -7279,18 +7279,18 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 "<div>
   <div>
     <div class=\\"u-mb-1\\">
-      <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-        <div class=\\"css-1shzg36-control\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-dvua67-singleValue\\">I am a tiny SelectBox</div>
-            <div class=\\"css-1g6gooi\\">
+      <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+        <div class=\\" css-1ac6j6n-control\\">
+          <div class=\\" css-11jzfys-ValueContainer\\">
+            <div class=\\" css-1uccc91-singleValue\\">I am a tiny SelectBox</div>
+            <div class=\\"css-b8ldur-Input\\">
               <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-11-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
           </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+          <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+            <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
                 <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
               </svg></div>
           </div>
@@ -7298,18 +7298,18 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
       </div>
     </div>
     <div class=\\"u-mb-1\\">
-      <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-        <div class=\\"css-1cy9omn-control\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-dvua67-singleValue\\">I am a medium SelectBox</div>
-            <div class=\\"css-1g6gooi\\">
+      <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+        <div class=\\" css-7stifj-control\\">
+          <div class=\\" css-11jzfys-ValueContainer\\">
+            <div class=\\" css-1uccc91-singleValue\\">I am a medium SelectBox</div>
+            <div class=\\"css-b8ldur-Input\\">
               <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-12-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
           </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+          <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+            <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
                 <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
               </svg></div>
           </div>
@@ -7317,18 +7317,18 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
       </div>
     </div>
     <div class=\\"u-mb-1\\">
-      <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-        <div class=\\"css-vo6n8w-control\\">
-          <div class=\\"css-1phseng\\">
-            <div class=\\"css-dvua67-singleValue\\">I am a large SelectBox</div>
-            <div class=\\"css-1g6gooi\\">
+      <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+        <div class=\\" css-fg5tdu-control\\">
+          <div class=\\" css-11jzfys-ValueContainer\\">
+            <div class=\\" css-1uccc91-singleValue\\">I am a large SelectBox</div>
+            <div class=\\"css-b8ldur-Input\\">
               <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-13-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
                 <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
               </div>
             </div>
           </div>
-          <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-            <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+          <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+            <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
                 <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
               </svg></div>
           </div>
@@ -7341,19 +7341,19 @@ exports[`SelectBox should render examples: SelectBox 7`] = `
 
 exports[`SelectBox should render examples: SelectBox 8`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
     <div><button>toggle options</button>
       <div class=\\"styles__select-control__input___1xDlj\\">
-        <div class=\\"css-1phseng\\">
-          <div class=\\"css-151xaom-placeholder\\">Select...</div>
-          <div class=\\"css-1g6gooi\\">
+        <div class=\\" css-11jzfys-ValueContainer\\">
+          <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+          <div class=\\"css-b8ldur-Input\\">
             <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-14-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
               <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
             </div>
           </div>
         </div>
-        <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-          <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+        <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+          <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
               <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
             </svg></div>
         </div>
@@ -7365,18 +7365,18 @@ exports[`SelectBox should render examples: SelectBox 8`] = `
 
 exports[`SelectBox should render examples: SelectBox 9`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-    <div class=\\"css-vo6n8w-control\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-fg5tdu-control\\">
+      <div class=\\" css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-15-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
@@ -7387,18 +7387,18 @@ exports[`SelectBox should render examples: SelectBox 9`] = `
 
 exports[`SelectBox should render examples: SelectBox 10`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-    <div class=\\"css-vo6n8w-control\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-fg5tdu-control\\">
+      <div class=\\" css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-16-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
@@ -7409,25 +7409,25 @@ exports[`SelectBox should render examples: SelectBox 10`] = `
 
 exports[`SelectBox should render examples: SelectBox 11`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-    <div class=\\"css-vo6n8w-control\\">
-      <div class=\\"css-1phseng\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-fg5tdu-control\\">
+      <div class=\\" css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-17-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M20.603 17.825a1.571 1.571 0 002.222-2.222l-9.428-9.428a1.571 1.571 0 00-2.222 0l-9.429 9.428a1.571 1.571 0 002.222 2.222l8.318-8.317 8.317 8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
     </div>
-    <div class=\\"css-1qveapp-menu\\">
-      <div class=\\"css-11unzgr styles__MenuList___1H_pH\\">
-        <div class=\\"css-1s9izoc styles__Group___J6s7k\\">
+    <div class=\\" css-govwq4-menu\\">
+      <div class=\\"styles__MenuList___1H_pH css-4ljt47-MenuList\\">
+        <div class=\\"styles__Group___J6s7k css-syji7d-Group\\">
           <div>
             <div id=\\"react-select-17-option-0-0\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">B</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
             <div id=\\"react-select-17-option-0-1\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">C</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
@@ -7455,7 +7455,7 @@ exports[`SelectBox should render examples: SelectBox 11`] = `
             <div id=\\"react-select-17-option-0-23\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Y</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
           </div>
         </div>
-        <div class=\\"css-1s9izoc styles__FixedGroup___2izTc\\">
+        <div class=\\"styles__FixedGroup___2izTc css-syji7d-Group\\">
           <div>
             <div id=\\"react-select-17-option-1-0\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">A</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
             <div id=\\"react-select-17-option-1-1\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Z</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
@@ -7469,18 +7469,18 @@ exports[`SelectBox should render examples: SelectBox 11`] = `
 
 exports[`SelectBox should render examples: SelectBox 12`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-    <div class=\\"css-vo6n8w-control\\">
-      <div class=\\"css-1phseng needsclick\\">
-        <div class=\\"css-151xaom-placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\" css-fg5tdu-control\\">
+      <div class=\\"needsclick css-11jzfys-ValueContainer\\">
+        <div class=\\" css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-18-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6\\"><span class=\\"css-1hyfx7x\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\" css-1hb7zxy-IndicatorsContainer\\"><span class=\\" css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\" css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M3.968 6.175a1.571 1.571 0 00-2.222 2.222l9.429 9.428a1.571 1.571 0 002.222 0l9.428-9.428a1.571 1.571 0 00-2.222-2.222l-8.317 8.317-8.318-8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
@@ -7491,25 +7491,25 @@ exports[`SelectBox should render examples: SelectBox 12`] = `
 
 exports[`SelectBox should render examples: SelectBox 13`] = `
 "<div>
-  <div class=\\"css-1pcexqc-container styles__select--autowidth___16AEp\\">
-    <div class=\\"css-vo6n8w-control needsclick cz__control needsclick cz__control--menu-is-open\\">
-      <div class=\\"css-1phseng needsclick cz__value-container\\">
-        <div class=\\"css-151xaom-placeholder needsclick cz__placeholder\\">Select...</div>
-        <div class=\\"css-1g6gooi\\">
+  <div class=\\"styles__select--autowidth___16AEp css-2b097c-container\\"><span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" class=\\"css-1f43avz-a11yText-A11yText\\"></span>
+    <div class=\\"needsclick cz__control needsclick cz__control--menu-is-open css-fg5tdu-control\\">
+      <div class=\\"needsclick cz__value-container css-11jzfys-ValueContainer\\">
+        <div class=\\"needsclick cz__placeholder css-1wa3eu0-placeholder\\">Select...</div>
+        <div class=\\"css-b8ldur-Input\\">
           <div class=\\"needsclick cz__input\\" style=\\"display: inline-block;\\"><input autocapitalize=\\"none\\" autocomplete=\\"off\\" autocorrect=\\"off\\" id=\\"react-select-19-input\\" spellcheck=\\"false\\" tabindex=\\"0\\" type=\\"text\\" aria-autocomplete=\\"list\\" style=\\"box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;\\" value=\\"\\">
             <div style=\\"position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;\\"></div>
           </div>
         </div>
       </div>
-      <div class=\\"css-1wy0on6 needsclick cz__indicators\\"><span class=\\"css-1hyfx7x needsclick cz__indicator-separator\\"></span>
-        <div aria-hidden=\\"true\\" class=\\"css-1pfbu56-indicatorContainer needsclick cz__indicator needsclick cz__dropdown-indicator\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
+      <div class=\\"needsclick cz__indicators css-1hb7zxy-IndicatorsContainer\\"><span class=\\"needsclick cz__indicator-separator css-1xjgjl1-IndicatorSeparator\\"></span>
+        <div class=\\"needsclick cz__indicator needsclick cz__dropdown-indicator css-c1md1-indicatorContainer\\" aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"20\\" height=\\"16\\">
             <path d=\\"M20.603 17.825a1.571 1.571 0 002.222-2.222l-9.428-9.428a1.571 1.571 0 00-2.222 0l-9.429 9.428a1.571 1.571 0 002.222 2.222l8.318-8.317 8.317 8.317z\\" fill-rule=\\"evenodd\\"></path>
           </svg></div>
       </div>
     </div>
-    <div class=\\"css-1qveapp-menu needsclick cz__menu\\">
-      <div class=\\"css-11unzgr needsclick cz__menu-list\\">
-        <div id=\\"react-select-19-option-0\\" tabindex=\\"-1\\" class=\\"needsclick cz__ styles__select-option___ov_IT\\"><span class=\\"needsclick cz__ styles__select-option__label___1Xi5R\\"><span class=\\"needsclick cz__ u-ellipsis\\">Chocolate</span></span><span class=\\"needsclick cz__ styles__select-option__checkmark___ChXXs\\"></span></div>
+    <div class=\\"needsclick cz__menu css-govwq4-menu\\">
+      <div class=\\"needsclick cz__menu-list css-4ljt47-MenuList\\">
+        <div id=\\"react-select-19-option-0\\" tabindex=\\"-1\\" class=\\"styles__select-option___ov_IT\\"><span class=\\"styles__select-option__label___1Xi5R\\"><span class=\\"u-ellipsis\\">Chocolate</span></span><span class=\\"styles__select-option__checkmark___ChXXs\\"></span></div>
       </div>
     </div>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,7 +878,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -1129,57 +1129,70 @@
   dependencies:
     microee "0.0.6"
 
-"@emotion/babel-utils@^0.6.4":
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"
-  integrity sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==
+"@emotion/cache@^11.0.0", "@emotion/cache@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
+  integrity sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==
   dependencies:
-    "@emotion/hash" "^0.6.6"
-    "@emotion/memoize" "^0.6.6"
-    "@emotion/serialize" "^0.9.1"
-    convert-source-map "^1.5.1"
-    find-root "^1.1.0"
-    source-map "^0.7.2"
-
-"@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
-  integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
-  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+"@emotion/memoize@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
-"@emotion/serialize@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.9.1.tgz#a494982a6920730dba6303eb018220a2b629c145"
-  integrity sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==
+"@emotion/react@^11.1.1":
+  version "11.1.5"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.1.5.tgz#15e78f9822894cdc296e6f4e0688bac8120dfe66"
+  integrity sha512-xfnZ9NJEv9SU9K2sxXM06lzjK245xSeHRpUh67eARBm3PBHjjKIZlfWZ7UQvD0Obvw6ZKjlC79uHrlzFYpOB/Q==
   dependencies:
-    "@emotion/hash" "^0.6.6"
-    "@emotion/memoize" "^0.6.6"
-    "@emotion/unitless" "^0.6.7"
-    "@emotion/utils" "^0.8.2"
+    "@babel/runtime" "^7.7.2"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
 
-"@emotion/stylis@^0.7.0":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
-  integrity sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==
+"@emotion/serialize@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.1.tgz#322cdebfdbb5a88946f17006548191859b9b0855"
+  integrity sha512-TXlKs5sgUKhFlszp/rg4lIAZd7UUSmJpwaf9/lAEFcUh2vPi32i7x4wk7O8TN8L8v2Ol8k0CxnhRBY0zQalTxA==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
 
-"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
-  integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+  integrity sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g==
 
-"@emotion/utils@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
-  integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
@@ -2938,24 +2951,6 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^9.2.11:
-  version "9.2.11"
-  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz#319c005a9ee1d15bb447f59fe504c35fd5807728"
-  integrity sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/babel-utils" "^0.6.4"
-    "@emotion/hash" "^0.6.2"
-    "@emotion/memoize" "^0.6.1"
-    "@emotion/stylis" "^0.7.0"
-    babel-plugin-macros "^2.0.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    convert-source-map "^1.5.0"
-    find-root "^1.1.0"
-    mkdirp "^0.5.1"
-    source-map "^0.5.7"
-    touch "^2.0.1"
-
 babel-plugin-inline-json-import@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.3.2.tgz#fdec1a59364d632895d421aec4c9435ccbbcadd3"
@@ -2978,20 +2973,6 @@ babel-plugin-jest-hoist@^24.9.0:
   integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
-
-babel-plugin-macros@^2.0.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
-  integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    cosmiconfig "^6.0.0"
-    resolve "^1.12.0"
-
-babel-plugin-syntax-jsx@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
-  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-polyfill@6.26.0:
   version "6.26.0"
@@ -4445,7 +4426,7 @@ conventional-commits-parser@^3.0.0, conventional-commits-parser@^3.0.7:
     through2 "^4.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1, convert-source-map@^1.7.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4664,19 +4645,6 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
-
-create-emotion@^9.2.12:
-  version "9.2.12"
-  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
-  integrity sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==
-  dependencies:
-    "@emotion/hash" "^0.6.2"
-    "@emotion/memoize" "^0.6.1"
-    "@emotion/stylis" "^0.7.0"
-    "@emotion/unitless" "^0.6.2"
-    csstype "^2.5.2"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -5458,13 +5426,6 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-helpers@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
@@ -5664,14 +5625,6 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
-
-emotion@^9.1.2:
-  version "9.2.12"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
-  integrity sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
-  dependencies:
-    babel-plugin-emotion "^9.2.11"
-    create-emotion "^9.2.12"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -6628,11 +6581,6 @@ find-npm-prefix@^1.0.2:
   resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
   integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
 
-find-root@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
-  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
-
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -7520,7 +7468,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -13551,10 +13499,10 @@ react-icons@^3.7.0:
   dependencies:
     camelcase "^5.0.0"
 
-react-input-autosize@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
-  integrity sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==
+react-input-autosize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
+  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
 
@@ -13636,18 +13584,18 @@ react-remove-scroll@^2.4.0:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-select@^2.2.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.4.4.tgz#ba72468ef1060c7d46fbb862b0748f96491f1f73"
-  integrity sha512-C4QPLgy9h42J/KkdrpVxNmkY6p4lb49fsrbDk/hRcZpX7JvZPNb6mGj+c5SzyEtBv1DmQ9oPH4NmhAFvCrg8Jw==
+react-select@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-4.3.0.tgz#6bde634ae7a378b49f3833c85c126f533483fa2e"
+  integrity sha512-SBPD1a3TJqE9zoI/jfOLCAoLr/neluaeokjOixr3zZ1vHezkom8K0A9J4QG9IWDqIDE9K/Mv+0y1GjidC2PDtQ==
   dependencies:
-    classnames "^2.2.5"
-    emotion "^9.1.2"
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.0.0"
+    "@emotion/react" "^11.1.1"
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
-    raf "^3.4.0"
-    react-input-autosize "^2.2.1"
-    react-transition-group "^2.2.1"
+    react-input-autosize "^3.0.0"
+    react-transition-group "^4.3.0"
 
 react-simple-code-editor@^0.9.7:
   version "0.9.15"
@@ -13772,17 +13720,7 @@ react-test-renderer@16.12.0, react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.18.0"
 
-react-transition-group@^2.2.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
-
-react-transition-group@^4.4.0:
+react-transition-group@^4.3.0, react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
@@ -14726,7 +14664,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.6.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -15410,7 +15348,7 @@ source-map@^0.1.34:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -15420,7 +15358,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.2, source-map@^0.7.3:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -15907,15 +15845,10 @@ stylint@1.5.9:
     user-home "2.0.0"
     yargs "4.7.1"
 
-stylis-rule-sheet@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
-
-stylis@^3.5.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
-  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+stylis@^4.0.3:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.8.tgz#b03cc47dcedcd2dbac93d8224e687c43ceda4e20"
+  integrity sha512-WCHD2YHu2gp4GN9M8TqD7DZljL/UC5mIFaKyYJRuRyPdnqkTqzTnxCIQ1Z3VgQvz1aPcua5bSS2h0HrcbDUdBg==
 
 stylus-loader@3.0.2:
   version "3.0.2"
@@ -16402,13 +16335,6 @@ toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
   integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
-
-touch@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
-  integrity sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==
-  dependencies:
-    nopt "~1.0.10"
 
 touch@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Hopefully, this will remove duplicate dependencies (like an old version of react-transition) from our builds.

BREAKING CHANGE: react-select is upgraded from v2 to v4. It should not
impact you but you should be extra careful around the areas that use a
select.

Values are now normalized:
https://github.com/JedWatson/react-select/pull/4339 The onChange callback
receives values that are more coherent now (array if multi select, value is
always an array (can be empty), if a single select, value can be
object/null.

V4 changelog:
https://github.com/JedWatson/react-select/blob/master/packages/react-select/     CHANGELOG.md#400
V3 changelog:
https://github.com/JedWatson/react-select/blob/master/packages/react-select/     CHANGELOG.md#300