### PR TITLE
fix(Dialogs): Fix closing issue with the cross on iOS

### DIFF
--- a/react/CozyDialogs/styles.styl
+++ b/react/CozyDialogs/styles.styl
@@ -4,7 +4,7 @@
     position absolute
     top 0.75rem
     right 0.75rem
-
+    z-index var(--zIndex-modal) //needed for an iOS bug https://github.com/cozy/cozy-ui/pull/1790
     +small-screen()
         top 0.25rem
         right 0.25rem


### PR DESCRIPTION
On iPhone (at least) we had a bug with few kinds
of Dialog:
- ConfirmDialog small

We can't close them by clicking on the top right cross.

In fact, this is when we have conflicts with few dom elements
 (when dialogContentInner withFluidActions).
The DialogCloseButton is "behing" others.

I don't know why it's work on Safari Dekstop but not on Safari Mobile...


Go to https://docs.cozy.io/cozy-ui/react/#!/CozyDialogs with an iOS device. 
Select Small then "Open confirm dialog" and try to close it from the right top cross. 



Go to https://crash--.github.io/cozy-ui/react/#!/CozyDialogs and do the same. It should works. 