### PR TITLE
fix: UploadQueue header style

### DIFF
--- a/react/UploadQueue/Readme.md
+++ b/react/UploadQueue/Readme.md
@@ -9,7 +9,7 @@ the upload queue:
 * in a fixed bottom-right position on desktop
 * underneath the top-bar on mobile
 
-```
+```jsx
 import isTesting from '../helpers/isTesting'
 import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
 
@@ -61,15 +61,27 @@ const data = {
     successCount={data.successCount}
     popover={state.popover}
   />
-  {isTesting() ?
-    <UploadQueue
-      lang='fr'
-      app='Cozy Drive'
-      getMimeTypeIcon={() => FileIcon}
-      queue={data.queue}
-      doneCount={data.doneCount}
-      successCount={data.successCount}
-      popover={true}
-    /> : null }
+  {isTesting() && (
+    <>
+      <UploadQueue
+        lang='fr'
+        app='Cozy Drive'
+        getMimeTypeIcon={() => FileIcon}
+        queue={data.queue}
+        doneCount={data.queue.length}
+        successCount={data.queue.length}
+        popover={false}
+      />
+      <UploadQueue
+        lang='fr'
+        app='Cozy Drive'
+        getMimeTypeIcon={() => FileIcon}
+        queue={data.queue}
+        doneCount={data.doneCount}
+        successCount={data.successCount}
+        popover={true}
+      />
+    </>
+  )}
 </>
 ```

--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -1,25 +1,25 @@
 import React, { Component } from 'react'
 import cx from 'classnames'
-import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
-import { splitFilename } from 'cozy-client/dist/models/file'
-import CrossIcon from 'cozy-ui/transpiled/react/Icons/Cross'
-import WarningIcon from 'cozy-ui/transpiled/react/Icons/Warning'
-import CheckIcon from 'cozy-ui/transpiled/react/Icons/Check'
-import MuiButton from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
 import { withStyles } from '@material-ui/core/styles'
+import LinearProgress from '@material-ui/core/LinearProgress'
+import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
 
-import { translate } from '../I18n'
+import { splitFilename } from 'cozy-client/dist/models/file'
+
+import CrossIcon from '../Icons/Cross'
+import WarningIcon from '../Icons/Warning'
+import CheckIcon from '../Icons/Check'
+import { translate, useI18n } from '../I18n'
+import withLocales from '../I18n/withLocales'
 import Icon from '../Icon'
 import Spinner from '../Spinner'
-import withLocales from '../I18n/withLocales'
-import { useI18n } from '../I18n'
-import LinearProgress from '@material-ui/core/LinearProgress'
 import Typography from '../Typography'
 import List from '../MuiCozyTheme/List'
 import ListItem from '../MuiCozyTheme/ListItem'
 import ListItemText from '../ListItemText'
 import ListItemIcon from '../MuiCozyTheme/ListItemIcon'
 import { Img } from '../Media'
+import Button from '../Button'
 
 import styles from './styles.styl'
 import localeEn from './locales/en.json'
@@ -249,12 +249,16 @@ class UploadQueue extends Component {
               <Typography variant="h6" className="u-hide--mob">
                 {t('header', { smart_count: queue.length, app: app })}
               </Typography>
-              <MuiButton color="primary" className="u-hide--tablet">
+              <Typography
+                color="primary"
+                variant="h6"
+                className="u-hide--tablet"
+              >
                 {t('header_mobile', {
                   done: doneCount,
                   total: queue.length
                 })}
-              </MuiButton>
+              </Typography>
             </div>
           )}
           {doneCount >= queue.length && (
@@ -268,9 +272,12 @@ class UploadQueue extends Component {
                   total: queue.length
                 })}
               </Typography>
-              <button className={cx(styles['btn-close'])} onClick={purgeQueue}>
-                {t('close')}
-              </button>
+              <Button
+                subtle
+                className="u-mv-0"
+                label={t('close')}
+                onClick={purgeQueue}
+              />
             </div>
           )}
         </h4>

--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -53,6 +53,10 @@ $coz-bar-size=3rem
     transform  translate(0)
 
 .upload-queue-header
+    display          flex
+    flex-direction   column
+    justify-content  center
+    height           2rem
     background-color var(--defaultBackgroundColor)
     font-weight      bold
     margin           0
@@ -63,14 +67,6 @@ $coz-bar-size=3rem
         justify-content space-between
         align-items center
 
-    .btn-close
-        border 0
-        background 0
-        margin 0
-        padding .4rem 0 .4rem .8rem
-        color var(--dodgerBlue)
-        text-transform uppercase
-        font-size .8rem
 
 progress.upload-queue-progress
     -webkit-appearance none
@@ -130,7 +126,7 @@ progress.upload-queue-progress
     .upload-queue-header
         background 0
         text-transform uppercase
-        padding 0
+        padding .5rem
 
     .upload-queue-content
         display none


### PR DESCRIPTION
Harmonisation du style entre la phase d'`upload` et la phase `done`. Ajout de l'état `done` dans les screenshots.

Besoin de ce correctif pour Drive.

Exemple UI : https://jf-cozy.github.io/cozy-ui/react/#!/UploadQueue

Screenshot Drive : 

**Avant :**
![image](https://user-images.githubusercontent.com/67680939/113877315-e2378c80-97b8-11eb-850e-602c28d76199.png)

![image](https://user-images.githubusercontent.com/67680939/113877385-f1b6d580-97b8-11eb-8e02-1810909640a0.png)


**Après :**
![image](https://user-images.githubusercontent.com/67680939/113876971-8b31b780-97b8-11eb-8ed2-c64e1944033d.png)

![image](https://user-images.githubusercontent.com/67680939/113876884-75bc8d80-97b8-11eb-8e3b-45f678dff4be.png)
