### PR TITLE
feat: Show alerts on top of mui dialogs

### DIFF
--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -35,6 +35,7 @@ import {
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import Button from 'cozy-ui/transpiled/react/Button'
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
@@ -177,7 +178,8 @@ initialState = {
           ? dialogContents[DialogComponent.name]
           : state.content == 'long'
             ? content.ada.long
-            : content.ada.short}
+            : content.ada.short}<br/>
+          <Button className='u-mt-1 u-ml-0' label="Show an alert" onClick={() => Alerter.success('Hello', { duration: 100000 })}/>
         </Typography>}
       actions={dialogActions[DialogComponent.name]}
       actionsLayout={state.actionsLayout}

--- a/react/MuiCozyTheme/theme.jsx
+++ b/react/MuiCozyTheme/theme.jsx
@@ -144,6 +144,9 @@ export const normalTheme = createMuiTheme({
       xl: 1200
     }
   },
+  zIndex: {
+    modal: getCssVariableValue('zIndex-modal')
+  },
   palette: normalPalette,
   props: {
     MuiTabs: {
@@ -417,9 +420,6 @@ const makeOverrides = theme => ({
     }
   },
   MuiDialog: {
-    root: {
-      zIndex: getCssVariableValue('zIndex-modal')
-    },
     paper: {
       '&.small': {
         width: '480px',


### PR DESCRIPTION
Previously, the z-index was too low and alerts would appear beneath
the MUI Dialog overlay.

See https://ptbrowne.github.io/cozy-ui/react/#/Content?id=cozydialogs