### PR TITLE
fix: Prevent default when opening intent dialog

### DIFF
--- a/react/IntentDialogOpener/IntentDialogOpener.jsx
+++ b/react/IntentDialogOpener/IntentDialogOpener.jsx
@@ -26,7 +26,10 @@ const IntentDialogOpener = props => {
   } = props
   const [modalOpened, setModalOpened] = useState(false)
 
-  const openModal = () => setModalOpened(true)
+  const openModal = ev => {
+    ev.preventDefault()
+    setModalOpened(true)
+  }
   const closeModal = () => setModalOpened(false)
 
   const handleComplete = useCallback(result => {


### PR DESCRIPTION
The problem was that a click on chip inside a row with an onClick
handler would trigger both the row and chip onClick handlers. Here,
I preventDefault() on the ev as a way of saying "this event is
already taken care of", and the click handler of the row checks
ev.defaultPrevented and does not do anything if it is set to true.

I thought of using stopPropagation() but this solution seems less
brutal.