### PR TITLE
fix: TileTitle

### DIFF
--- a/react/AppSections/components/AppsSection.jsx
+++ b/react/AppSections/components/AppsSection.jsx
@@ -28,7 +28,7 @@ export const AppsSection = ({
               name={getTranslatedManifestProperty(app, 'name', t)}
               onClick={() => onAppClick(app.slug)}
               key={app.slug}
-              isMobile={isMobile}
+              showDeveloper={!isMobile}
               IconComponent={IconComponent}
             />
           ))}

--- a/react/Tile/index.jsx
+++ b/react/Tile/index.jsx
@@ -16,7 +16,9 @@ export const TileDescription = ({ children }) => {
 }
 
 export const TileTitle = ({ children }) => (
-  <Typography variant="h6">{children}</Typography>
+  <Typography variant="h6" className={styles['Tile-title']}>
+    {children}
+  </Typography>
 )
 
 export const TileSubtitle = ({ children }) => (

--- a/react/Tile/styles.styl
+++ b/react/Tile/styles.styl
@@ -97,7 +97,7 @@ $tileMobileHeight = 3.75rem
   .Tile-title
     height 1rem
     font-weight normal
-    font-size $subtitle-font-size
+    font-size $subtitle-font-size !important //to remove m-ui h6 font size
 
   .Tile-title, .Tile-developer, .Tile-status
     width 100%


### PR DESCRIPTION
Since a previous refactor title is not well displayed specialy
on mobile and when having a long title to display

We simply apply the previous className in order to fix
the issue

https://crash--.github.io/cozy-ui/react/#!/AppSections