### PR TITLE
Add maintenance display app sections

### DIFF
--- a/react/AppSections/Readme.md
+++ b/react/AppSections/Readme.md
@@ -1,17 +1,39 @@
-```
+```jsx
+import { useState } from 'react'
 import mockApps from './_mockApps';
-import Sections from 'cozy-ui/transpiled/react/AppSections';
 import { I18n } from '../I18n';
 import { BreakpointsProvider } from '../hooks/useBreakpoints';
+import Sections from 'cozy-ui/transpiled/react/AppSections';
+import Variants from 'cozy-ui/docs/components/Variants';
 
 const locale = {};
-const handleAppClick = app => {
+
+const WrapperSections = () => {
+  const handleAppClick = app => {
     alert(JSON.stringify(app, null, 2))
-};
+  }
+
+  const initialVariants = [
+    { displaySpecificMaintenanceStyle: false},
+    { displaySpecificMaintenanceStyle: true },
+  ]
+
+  return (
+    <Variants initialVariants={initialVariants}>
+      {
+      variant =>
+        <Sections
+            apps={mockApps}
+            onAppClick={handleAppClick} displaySpecificMaintenanceStyle={variant.displaySpecificMaintenanceStyle}
+        />
+      }
+    </Variants>
+  )
+}
 
 <BreakpointsProvider>
   <I18n dictRequire={lang => locale} lang="en">
-      <Sections apps={mockApps} onAppClick={handleAppClick} />
-  </I18n >
+     <WrapperSections />
+  </I18n>
 </BreakpointsProvider>
 ```

--- a/react/AppSections/Sections.jsx
+++ b/react/AppSections/Sections.jsx
@@ -89,7 +89,8 @@ export class Sections extends Component {
       showFilterDropdown,
       showTitles,
       showSubTitles,
-      showSubSubTitles
+      showSubSubTitles,
+      displaySpecificMaintenanceStyle
     } = this.props
     const { isMobile, isTablet } = breakpoints
 
@@ -148,6 +149,9 @@ export class Sections extends Component {
                     subtitle={<SectionSubtitle>{cat.label}</SectionSubtitle>}
                     onAppClick={onAppClick}
                     IconComponent={IconComponent}
+                    displaySpecificMaintenanceStyle={
+                      displaySpecificMaintenanceStyle
+                    }
                   />
                 )
               })}
@@ -170,6 +174,9 @@ export class Sections extends Component {
                     }
                     IconComponent={IconComponent}
                     onAppClick={onAppClick}
+                    displaySpecificMaintenanceStyle={
+                      displaySpecificMaintenanceStyle
+                    }
                   />
                 )
               })}
@@ -194,11 +201,15 @@ Sections.propTypes = {
   hasNav: PropTypes.bool,
 
   /** An initial search object. Changing it after mounting will do nothing. */
-  initialSearch: PropTypes.object
+  initialSearch: PropTypes.object,
+
+  displaySpecificMaintenanceStyle: PropTypes.bool
 }
 
 Sections.defaultProps = {
   hasNav: true,
+
+  displaySpecificMaintenanceStyle: false,
   /** Whether to show the top dropdown that is used to switch categories on mobile */
   showFilterDropdown: true,
 

--- a/react/AppSections/__snapshots__/index.spec.jsx.snap
+++ b/react/AppSections/__snapshots__/index.spec.jsx.snap
@@ -41,6 +41,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -159,6 +160,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -196,6 +198,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -239,6 +242,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -277,6 +281,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -326,6 +331,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -376,6 +382,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -494,6 +501,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -531,6 +539,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -574,6 +583,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -612,6 +622,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -661,6 +672,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -714,6 +726,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -832,6 +845,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -869,6 +883,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -912,6 +927,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -950,6 +966,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -999,6 +1016,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -1117,6 +1135,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -1235,6 +1254,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -1272,6 +1292,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -1315,6 +1336,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -1353,6 +1375,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -1402,6 +1425,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -1515,6 +1539,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -1633,6 +1658,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -1670,6 +1696,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubtitle>
@@ -1713,6 +1740,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -1751,6 +1779,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>
@@ -1800,6 +1829,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             },
           ]
         }
+        displaySpecificMaintenanceStyle={false}
         onAppClick={[MockFunction]}
         subtitle={
           <SectionSubSubtitle>

--- a/react/AppSections/_mockApps.js
+++ b/react/AppSections/_mockApps.js
@@ -67,6 +67,7 @@ export const apps = [
     version: '3.0.0-beta89bnhj3993',
     uninstallable: false,
     installed: true,
+    maintenance: true,
     related: 'http://drive.cozy.mock/'
   },
   {
@@ -128,7 +129,8 @@ export const apps = [
       dev: ['3.0.0']
     },
     uninstallable: true,
-    isInRegistry: true
+    isInRegistry: true,
+    maintenance: true
   },
   {
     slug: 'tasky',

--- a/react/AppSections/components/AppsSection.jsx
+++ b/react/AppSections/components/AppsSection.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { useI18n } from '../../I18n'
 import useBreakpoints from '../../hooks/useBreakpoints'
 import { getTranslatedManifestProperty } from '../helpers'
@@ -12,7 +13,8 @@ export const AppsSection = ({
   appsList,
   subtitle,
   onAppClick,
-  IconComponent
+  IconComponent,
+  displaySpecificMaintenanceStyle
 }) => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
@@ -29,6 +31,7 @@ export const AppsSection = ({
               onClick={() => onAppClick(app.slug)}
               key={app.slug}
               showDeveloper={!isMobile}
+              displaySpecificMaintenanceStyle={displaySpecificMaintenanceStyle}
               IconComponent={IconComponent}
             />
           ))}
@@ -36,6 +39,14 @@ export const AppsSection = ({
       )}
     </div>
   )
+}
+
+AppsSection.propTypes = {
+  appsList: PropTypes.array,
+  subtitle: PropTypes.element,
+  onAppClick: PropTypes.func,
+  IconComponent: PropTypes.element,
+  displaySpecificMaintenanceStyle: PropTypes.bool
 }
 
 export default AppsSection

--- a/react/AppTile/AppTile.spec.jsx
+++ b/react/AppTile/AppTile.spec.jsx
@@ -70,12 +70,22 @@ describe('AppTile component', () => {
     const appInMaintenance = Object.assign({}, appMock2, {
       maintenance: { maintenance_options: {} }
     })
-    const root = render(
-      <Wrapper {...appInMaintenance} app={appInMaintenance} />
-    )
+    const setup = ({ displaySpecificMaintenanceStyle }) =>
+      render(
+        <Wrapper
+          {...appInMaintenance}
+          app={appInMaintenance}
+          displaySpecificMaintenanceStyle={displaySpecificMaintenanceStyle}
+        />
+      )
+    const root = setup({ displaySpecificMaintenanceStyle: false })
     expect(root.getByText('Test2')).toBeTruthy()
     expect(root.getByText('By Naming me')).toBeTruthy()
     expect(root.getByText('In maintenance')).toBeTruthy()
+    expect(root.queryByTestId('icon-maintenance')).toBeNull()
+
+    const rootWithIcon = setup({ displaySpecificMaintenanceStyle: true })
+    expect(rootWithIcon.getByTestId('icon-maintenance')).toBeTruthy()
   })
 
   it('should render correctly an installed app', () => {

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -78,6 +78,7 @@ export const AppTile = ({
         />
         {isInMaintenanceWithSpecificDisplay && (
           <Icon
+            data-testid="icon-maintenance"
             icon={WrenchCircleIcon}
             color={palette['coolGrey']}
             className={styles['AppTile-icon-maintenance']}

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -17,6 +17,9 @@ import { getCurrentStatusLabel } from './helpers'
 import styles from './styles.styl'
 import en from './locales/en.json'
 import fr from './locales/fr.json'
+import Icon from '../Icon'
+import WrenchCircleIcon from '../Icons/WrenchCircle'
+import palette from '../palette'
 
 const locales = { en, fr }
 
@@ -42,7 +45,8 @@ export const AppTile = ({
   onClick,
   showDeveloper,
   showStatus,
-  IconComponent
+  IconComponent,
+  displaySpecificMaintenanceStyle
 }) => {
   const name = nameProp || app.name
   const { t } = useI18n()
@@ -52,14 +56,33 @@ export const AppTile = ({
     ? showStatus.indexOf(statusLabel) > -1 && statusLabel
     : showStatus && statusLabel
   IconComponent = IconComponent || AppIcon
+  const isInMaintenanceWithSpecificDisplay =
+    displaySpecificMaintenanceStyle && statusLabel === 'maintenance'
+
   return (
-    <Tile tag="button" type="button" onClick={onClick}>
+    <Tile
+      tag="button"
+      type="button"
+      onClick={onClick}
+      className={
+        isInMaintenanceWithSpecificDisplay
+          ? styles['AppTile-container-maintenance']
+          : undefined
+      }
+    >
       <TileIcon>
         <IconComponent
           app={app}
           className={styles['AppTile-icon']}
           {...getAppIconProps()}
         />
+        {isInMaintenanceWithSpecificDisplay && (
+          <Icon
+            icon={WrenchCircleIcon}
+            color={palette['coolGrey']}
+            className={styles['AppTile-icon-maintenance']}
+          />
+        )}
       </TileIcon>
       <TileDescription>
         <TileTitle>{namePrefix ? `${namePrefix} ${name}` : name}</TileTitle>
@@ -79,13 +102,16 @@ AppTile.propTypes = {
   name: PropTypes.string.isRequired,
   namePrefix: PropTypes.string,
   onClick: PropTypes.func,
+  IconComponent: PropTypes.element,
   showDeveloper: PropTypes.bool,
-  showStatus: PropTypes.oneOfType([PropTypes.bool, PropTypes.array])
+  showStatus: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
+  displaySpecificMaintenanceStyle: PropTypes.bool
 }
 
 AppTile.defaultProps = {
   showDeveloper: true,
-  showStatus: true
+  showStatus: true,
+  displaySpecificMaintenanceStyle: false
 }
 
 export default AppTile

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -10,3 +10,19 @@
   height 100%
   padding 0 .5em
 
+.AppTile-icon-maintenance
+  position absolute
+  border 2px solid var(--primaryContrastTextColor)
+  border-radius 50%
+  background var(--primaryContrastTextColor)
+  bottom 80px
+  left 80px
+
+  +small-screen()
+    bottom 6px
+    left 40px
+
+.AppTile-container-maintenance
+  filter grayscale(1)
+  opacity .64
+


### PR DESCRIPTION
Add maintenance display in props

This display is similar to what we have already in cozy home, when a konnector is in maintenance.

By default: maintenanceDisplay is `false` (allow to keep current behavior)

<img width="404" alt="Capture d’écran 2021-06-03 à 17 25 55" src="https://user-images.githubusercontent.com/22611343/120675825-b6254880-c495-11eb-9cab-0e3cab339f7d.png">


[https://flohhhh.github.io/cozy-ui/react/#/Special?id=appsections](https://flohhhh.github.io/cozy-ui/react/#/Special?id=appsections)