### PR TITLE
fix: ReadCozyDataFromDOM can now deal with "boolean string"

### DIFF
--- a/react/helpers/appDataset.js
+++ b/react/helpers/appDataset.js
@@ -24,7 +24,9 @@ export const readCozyDataFromDOM = memoize(attrName => {
   const data = readCozyData()
 
   if (data && data[attrName] !== undefined) {
-    return data[attrName]
+    return data[attrName] === 'true' || data[attrName] === 'false'
+      ? JSON.parse(data[attrName])
+      : data[attrName]
   }
 
   const appDataset = readApplicationDataset()

--- a/react/helpers/appDataset.spec.js
+++ b/react/helpers/appDataset.spec.js
@@ -15,20 +15,38 @@ describe('appdataset', () => {
   describe('data-cozy', () => {
     it('should work for true value', () => {
       document.body.innerHTML =
-        '<div role="application" data-cozy=\'{"tracking": true}\'></div>'
-      expect(readCozyDataFromDOM('tracking')).toBe(true)
+        '<div role="application" data-cozy=\'{"isLoggedIn": true}\'></div>'
+      expect(readCozyDataFromDOM('isLoggedIn')).toBe(true)
     })
 
     it('should work for false value', () => {
       document.body.innerHTML =
-        '<div role="application" data-cozy=\'{"tracking": false}\'></div>'
+        '<div role="application" data-cozy=\'{"isLoggedIn": false}\'></div>'
+      expect(readCozyDataFromDOM('isLoggedIn')).toBe(false)
+    })
+
+    it('should work for true value inside a string', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy=\'{"tracking": "true"}\'></div>'
+      expect(readCozyDataFromDOM('tracking')).toBe(true)
+    })
+
+    it('should work for false value inside a string', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy=\'{"tracking": "false"}\'></div>'
       expect(readCozyDataFromDOM('tracking')).toBe(false)
     })
 
-    it('should work for other type of values', () => {
+    it('should work for string values', () => {
       document.body.innerHTML =
         '<div role="application" data-cozy=\'{"token": "abcd456"}\'></div>'
       expect(readCozyDataFromDOM('token')).toBe('abcd456')
+    })
+
+    it('should work for object values', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy=\'{"app": {"editor":"Cozy"}}\'></div>'
+      expect(readCozyDataFromDOM('app')).toMatchObject({ editor: 'Cozy' })
     })
   })
 


### PR DESCRIPTION
a "false" value previously returned true, as was the case for "tracking" before the stack patch https://github.com/cozy/cozy-stack/pull/3050