### PR TITLE
fix: Remove wide space between count and text in mobile SelectionBar

### DIFF
--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -50,8 +50,6 @@ $selectionbar
             // iPhone X environment tweak
             padding-bottom env(safe-area-inset-bottom)
 
-            .SelectionBar-count span
-
             .SelectionBar-separator
                 margin   0 0 0 rem(16)
 


### PR DESCRIPTION
before :
![image](https://user-images.githubusercontent.com/67680939/123229187-59d2a900-d4d6-11eb-8b60-74d2aad873d8.png)

after :
![image](https://user-images.githubusercontent.com/67680939/123228711-f5afe500-d4d5-11eb-8739-5ba48981f341.png)
