### PR TITLE
feat: Add disabled prop on SelectionBar actions

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -66,7 +66,11 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
             )}
             variant="text"
             key={index}
-            disabled={selectedCount < 1}
+            disabled={
+              actions[actionName].disabled === undefined
+                ? selectedCount < 1 // to avoid breaking change
+                : actions[actionName].disabled(selected)
+            }
             onClick={() => actions[actionName].action(selected)}
             startIcon={
               <Icon
@@ -82,7 +86,11 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
             className={styles['SelectionBar-action']}
             label={t('SelectionBar.' + actionName)}
             key={index}
-            disabled={selectedCount < 1}
+            disabled={
+              actions[actionName].disabled === undefined
+                ? selectedCount < 1 // to avoid breaking change
+                : actions[actionName].disabled(selected)
+            }
             onClick={() => actions[actionName].action(selected)}
           >
             <Icon icon={actions[actionName].icon || actionName.toLowerCase()} />


### PR DESCRIPTION
Pour être cabable de contrôler le disabled des actions. Nécessaire par exemple quand on veut rendre enable un bouton alors qu'aucun élément n'est sélectionné. Ce qui avant n'était pas possible, car dans ce cas on forçait le disabled.

Exemples : 

```
selectAll: {
  action: () => fillSelection(),
  displayCondition: selected => selected.length !== items.length,
  icon: SelectAllIcon,
  disabled: () => false
}
```

```
selectAll: {
  action: () => fillSelection(),
  displayCondition: selected => selected.length !== items.length,
  icon: SelectAllIcon,
  disabled: selected => selected.length > 1
}
```