### PR TITLE
docs: Add CSS build instruction in `README.md`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ It is convenient when modifying a component to use the styleguide site.
 
 ```bash
 yarn start # Transpile the files in watch mode
+yarn build:css:all # Build CSS files needed by the documentation
 yarn start:doc # Run the styleguide in watch mode
 ```
 


### PR DESCRIPTION
After a clean checkout, it is not possible to build docs without calling `yarn build:css:all` first.