### PR TITLE
fix: Set cozy-client minimum version in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "4",
-    "cozy-client": "^18.1.2",
+    "cozy-client": ">=18.1.2",
     "cozy-device-helper": "^1.10.0",
     "cozy-doctypes": "^1.69.0",
     "piwik-react-router": "^0.8.2",


### PR DESCRIPTION
Having exact required version may introduce resolution conflicts when
installed in a project using NPM 7 (which has automatic peer dependency
resolution)