### PR TITLE
fix: rename createMuiTheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/cli": "7.11.5",
     "@babel/core": "7.11.5",
     "@cozy/codemods": "^1.9.0",
-    "@material-ui/core": "4.11.4",
+    "@material-ui/core": "4.12.3",
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/git": "7.0.18",
     "@semantic-release/npm": "5.3.4",
@@ -157,7 +157,7 @@
     "react-swipeable-views": "^0.13.3"
   },
   "peerDependencies": {
-    "@material-ui/core": "4",
+    "@material-ui/core": ">=4.12.0",
     "cozy-client": ">=18.1.2",
     "cozy-device-helper": "^1.10.0",
     "cozy-doctypes": "^1.69.0",

--- a/react/MuiCozyTheme/theme.jsx
+++ b/react/MuiCozyTheme/theme.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { createMuiTheme } from '@material-ui/core/styles'
+import { createTheme } from '@material-ui/core/styles'
 import merge from 'lodash/merge'
 
 import { getCssVariableValue } from '../utils/color'
@@ -131,7 +131,7 @@ normalPalette.background = {
   selected: '#F5FAFF'
 }
 
-export const normalTheme = createMuiTheme({
+export const normalTheme = createTheme({
   typography: makeTypography(normalPalette),
   shape: {
     borderRadius: defaultValues.borderRadius
@@ -678,7 +678,7 @@ invertedPalette.action = {
 }
 
 const invertedTypography = makeTypography(invertedPalette)
-export const invertedTheme = createMuiTheme({
+export const invertedTheme = createTheme({
   palette: invertedPalette,
   typography: invertedTypography,
   shadows

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,14 +1521,14 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@material-ui/core@4.11.4":
-  version "4.11.4"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.4.tgz#4fb9fe5dec5dcf780b687e3a40cff78b2b9640a4"
-  integrity sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==
+"@material-ui/core@4.12.3":
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
+  integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/styles" "^4.11.4"
-    "@material-ui/system" "^4.11.3"
+    "@material-ui/system" "^4.12.1"
     "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
@@ -1561,10 +1561,10 @@
     jss-plugin-vendor-prefixer "^10.5.1"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
-  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"


### PR DESCRIPTION
BREAKING CHANGE: `@material-ui/core` has been updated to v4.12

Because `@material-ui/core` is a peerDependency, it was possible for consumers of this library to use a v4.12 mui version while cozy-ui was still using 4.11. This created an error because v4.11 `createMuiTheme` function was renamed to `createTheme` in mui v4.12. While this does not break the app, because mui semver is correctly used and allows apps to work with the depreciated function, it still throws an error in the console and does not look good. Moreover the function will most likely be deleted in a future major upgrade.

It will be necessary here to upgrade your version to match at least v4.12.0

update: will be handled more elegantly there: https://github.com/cozy/cozy-ui/issues/1865