### PR TITLE
feat: Do not render `DialogActions` when `actions` prop is undefined

### DIFF
--- a/react/CozyDialogs/ConfirmDialog.jsx
+++ b/react/CozyDialogs/ConfirmDialog.jsx
@@ -32,15 +32,17 @@ const ConfirmDialog = props => {
             {title}
           </DialogTitle>
           {content}
-          <DialogActions
-            {...dialogActionsProps}
-            disableSpacing
-            className={cx('dialogActionsFluid', {
-              columnLayout: actionsLayout == 'column'
-            })}
-          >
-            {actions}
-          </DialogActions>
+          {actions && (
+            <DialogActions
+              {...dialogActionsProps}
+              disableSpacing
+              className={cx('dialogActionsFluid', {
+                columnLayout: actionsLayout == 'column'
+              })}
+            >
+              {actions}
+            </DialogActions>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/react/CozyDialogs/Dialog.jsx
+++ b/react/CozyDialogs/Dialog.jsx
@@ -38,15 +38,17 @@ const Dialog = props => {
       <DialogContent>
         <div className="dialogContentInner withFluidActions">
           {content}
-          <DialogActions
-            {...dialogActionsProps}
-            disableSpacing
-            className={cx('dialogActionsFluid', {
-              columnLayout: actionsLayout == 'column'
-            })}
-          >
-            {actions}
-          </DialogActions>
+          {actions && (
+            <DialogActions
+              {...dialogActionsProps}
+              disableSpacing
+              className={cx('dialogActionsFluid', {
+                columnLayout: actionsLayout == 'column'
+              })}
+            >
+              {actions}
+            </DialogActions>
+          )}
         </div>
       </DialogContent>
     </MUIDialog>

--- a/react/CozyDialogs/FixedActionsDialog.jsx
+++ b/react/CozyDialogs/FixedActionsDialog.jsx
@@ -37,13 +37,15 @@ const FixedActionsDialog = props => {
         </div>
       </DialogContent>
       <Divider />
-      <DialogActions
-        {...dialogActionsProps}
-        disableSpacing
-        className={cx({ columnLayout: actionsLayout == 'column' })}
-      >
-        {actions}
-      </DialogActions>
+      {actions && (
+        <DialogActions
+          {...dialogActionsProps}
+          disableSpacing
+          className={cx({ columnLayout: actionsLayout == 'column' })}
+        >
+          {actions}
+        </DialogActions>
+      )}
     </Dialog>
   )
 }

--- a/react/CozyDialogs/FixedDialog.jsx
+++ b/react/CozyDialogs/FixedDialog.jsx
@@ -39,13 +39,15 @@ const FixedDialog = props => {
         <div className="dialogContentInner">{content}</div>
       </DialogContent>
       <Divider />
-      <DialogActions
-        {...dialogActionsProps}
-        disableSpacing
-        className={cx({ columnLayout: actionsLayout == 'column' })}
-      >
-        {actions}
-      </DialogActions>
+      {actions && (
+        <DialogActions
+          {...dialogActionsProps}
+          disableSpacing
+          className={cx({ columnLayout: actionsLayout == 'column' })}
+        >
+          {actions}
+        </DialogActions>
+      )}
     </Dialog>
   )
 }

--- a/react/CozyDialogs/IllustrationDialog.jsx
+++ b/react/CozyDialogs/IllustrationDialog.jsx
@@ -33,15 +33,17 @@ const IllustrationDialog = props => {
             <div className="u-flex u-flex-justify-center">{title}</div>
           </DialogTitle>
           {content}
-          <DialogActions
-            {...dialogActionsProps}
-            disableSpacing
-            className={cx('dialogActionsFluid', {
-              columnLayout: actionsLayout == 'column'
-            })}
-          >
-            {actions}
-          </DialogActions>
+          {actions && (
+            <DialogActions
+              {...dialogActionsProps}
+              disableSpacing
+              className={cx('dialogActionsFluid', {
+                columnLayout: actionsLayout == 'column'
+              })}
+            >
+              {actions}
+            </DialogActions>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -137,7 +137,8 @@ initialState = {
   withCloseButton: true,
   content: 'default',
   theme: 'normal',
-  align: 'middle'
+  align: 'middle',
+  showActions: true
 };
 
 <>
@@ -159,6 +160,10 @@ initialState = {
       <StateRadio value='small' name='size' /> small {' '}
       <StateRadio value='medium' name='size' /> medium {' '}
       <StateRadio value='large' name='size' /> large
+    </p>
+    <p>With actions:
+      <StateRadio value={true} name='showActions' /> yes
+      <StateRadio value={false} name='showActions' /> no
     </p>
     <p>Actions layout:
       <StateRadio value='row' name='actionsLayout' /> row{' '}
@@ -186,7 +191,7 @@ initialState = {
             : content.ada.short}<br/>
           <Button className='u-mt-1 u-ml-0' label="Show an alert" onClick={() => Alerter.success('Hello', { duration: 100000 })}/>
         </Typography>}
-      actions={dialogActions[DialogComponent.name]}
+      actions={state.showActions && dialogActions[DialogComponent.name]}
       actionsLayout={state.actionsLayout}
     />
   </BreakpointsProvider>


### PR DESCRIPTION
When a dialog doesn't have any action we shouldn't render the
`DialogActions` component, so it won't take any unused space in the
rendered DOM

Fixes #1861

Changes are visible here by switching off `With actions` option : https://ldoppea.github.io/cozy-ui/react/#!/CozyDialogs
