### PR TITLE
fix: Remove `height:auto` from `app-2panes-sticky` class

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -113,7 +113,6 @@ $app
 $app-2panes-sticky
     @extend $app
     flex 0 0 100%
-    height auto
     align-items stretch
 
     & > aside


### PR DESCRIPTION
This class is used when the UI is split in two panes, usually when the app has a sidebar and a main content

When using `height:auto`, this prevents the main content to be scrollable if it is smaller than the navbar. Also the navbar is not scrollable at all as its height won't adapt to the browser size

Another effect is that the main content is not scrollable to the end of document when the navbar overflows the document as it virtually push the document's limits outside of the browser view

This behavior is visible only in `cozy-store` as it is the only app that have a navbar tall enough to overflow the browser's body

Other apps are not impacted as their navbar is very small

By removing `height:auto`, then the navbar height adapt to its container size (vs its own size). This allow the main content to be scrollable when smaller

This fix should be completed by some CSS edit on apps side with an `overflow:auto` on the sidebar. But here again only `cozy-store` is impacted for now

If your changes have graphic impacts, it is useful to deploy a version of the styleguidist to your repository.

⚠️ this edit is not visible in docs, so I didn't upload them for previsualization

### Before (main content smaller than navbar):
Neither navbar nor main content are scrollable
![image](https://user-images.githubusercontent.com/1884255/131009250-624c7af3-cfa1-4e23-8f53-d9cc73ac5551.png)

### After (main content smaller than navbar):
Both navbar and main content are scrollable
![image](https://user-images.githubusercontent.com/1884255/131009344-618dcbdf-e49c-4dd5-b5cf-f885edf30d3c.png)

### Before (main content taller than navbar):
Navbar not scrollable and main content's scroll bar is overflowing the document view and we cannot scroll more.
![image](https://user-images.githubusercontent.com/1884255/131009993-380783b7-2a7c-4824-b247-97ee00aa7482.png)

### After (main content taller than navbar):
Navbar is scrollable and main content's can now be fully scrolled
![image](https://user-images.githubusercontent.com/1884255/131010175-392eb846-0121-40b2-9f3d-d1b7324dd465.png)
