### PR TITLE
feat: Decouple FilePathLink from stylesheet

### DIFF
--- a/react/FilePathLink/index.jsx
+++ b/react/FilePathLink/index.jsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import Link from '../Link'
 import FilePath from '../FilePath'
-import styles from './styles.styl'
 
-const FilePathLink = ({ children, className, ...props }) => (
-  <Link className={`${className} ${styles['c-file-path-link']}`} {...props}>
+const FilePathLink = ({ children, ...props }) => (
+  <Link color="textSecondary" underline="hover" {...props}>
     <FilePath>{children}</FilePath>
   </Link>
 )

--- a/react/FilePathLink/styles.styl
+++ b/react/FilePathLink/styles.styl
@@ -1,6 +1,0 @@
-.c-file-path-link
-  text-decoration: none
-
-  :first-child:hover 
-    color var(--secondaryTextColor)
-    text-decoration underline


### PR DESCRIPTION
Minor refactor: Use Material UI props on Link component instead of custom stylesheet