### PR TITLE
Feat/app tile UI

### DIFF
--- a/react/AppSections/_mockApps.js
+++ b/react/AppSections/_mockApps.js
@@ -108,6 +108,27 @@ export const apps = [
     uninstallable: true,
     isInRegistry: true
   },
+  {
+    slug: 'konnector-trinlane2',
+    name: 'Trinlane (with a very long name and no footer)',
+    icon: '<svg></svg>',
+    developer: { name: 'Author with long name' },
+    type: 'konnector',
+    categories: ['transport'],
+    tags: ['transport', 'files', 'bills'],
+    permissions: {
+      mock: {
+        type: 'io.mock.doctype'
+      }
+    },
+    versions: {
+      stable: ['0.1.0'],
+      beta: ['0.1.0'],
+      dev: ['0.1.0']
+    },
+    uninstallable: true,
+    isInRegistry: true
+  },
   // don't add permissions to Photos for testing
   {
     slug: 'photos',

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -88,7 +88,11 @@ export const AppTile = ({
         )}
       </TileIcon>
       <TileDescription className={styles[`AppTile-description`]}>
-        <TileTitle>{namePrefix ? `${namePrefix} ${name}` : name}</TileTitle>
+        <TileTitle
+          className={statusLabel ? '' : styles['AppTile-title-2lines']}
+        >
+          {namePrefix ? `${namePrefix} ${name}` : name}
+        </TileTitle>
         {developer.name && showDeveloper && (
           <TileSubtitle>{`${t('app_item.by')} ${developer.name}`}</TileSubtitle>
         )}

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -20,6 +20,7 @@ import fr from './locales/fr.json'
 import Icon from '../Icon'
 import WrenchCircleIcon from '../Icons/WrenchCircle'
 import palette from '../palette'
+import cx from 'classnames'
 
 const locales = { en, fr }
 
@@ -64,11 +65,12 @@ export const AppTile = ({
       tag="button"
       type="button"
       onClick={onClick}
-      className={
-        isInMaintenanceWithSpecificDisplay
-          ? styles['AppTile-container-maintenance']
-          : undefined
-      }
+      className={cx({
+        [styles[
+          'AppTile-container-maintenance'
+        ]]: isInMaintenanceWithSpecificDisplay,
+        [styles['AppTile-container-installed']]: statusLabel === 'installed'
+      })}
     >
       <TileIcon>
         <IconComponent

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -85,13 +85,15 @@ export const AppTile = ({
           />
         )}
       </TileIcon>
-      <TileDescription>
+      <TileDescription className={styles[`AppTile-description`]}>
         <TileTitle>{namePrefix ? `${namePrefix} ${name}` : name}</TileTitle>
         {developer.name && showDeveloper && (
           <TileSubtitle>{`${t('app_item.by')} ${developer.name}`}</TileSubtitle>
         )}
         {statusToDisplay && (
-          <TileFooter>{t(`app_item.${statusToDisplay}`)}</TileFooter>
+          <TileFooter className={styles[`AppTile-footer-${statusLabel}`]}>
+            {t(`app_item.${statusToDisplay}`)}
+          </TileFooter>
         )}
       </TileDescription>
     </Tile>

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -31,6 +31,13 @@
   border-color var(--defaultBackgroundColor)
 
 .AppTile-description
+  .AppTile-title-2lines
+    display -webkit-box
+    -webkit-line-clamp 2
+    -webkit-box-orient vertical
+    overflow hidden
+    white-space normal
+
   .AppTile-footer
     &-update
       color var(--primaryColor)

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -26,6 +26,9 @@
   filter grayscale(1)
   opacity .64
 
+.AppTile-container-installed
+  background var(--defaultBackgroundColor)
+  border-color var(--defaultBackgroundColor)
 
 .AppTile-description
   .AppTile-footer

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -26,3 +26,8 @@
   filter grayscale(1)
   opacity .64
 
+
+.AppTile-description
+  .AppTile-footer
+    &-update
+      color var(--primaryColor)

--- a/react/Tile/index.jsx
+++ b/react/Tile/index.jsx
@@ -11,8 +11,8 @@ const Tile = ({ children, className, tag: Tag, ...props }) => {
   )
 }
 
-export const TileDescription = ({ children }) => {
-  return <div className={styles['Tile-desc']}>{children}</div>
+export const TileDescription = ({ children, className }) => {
+  return <div className={`${styles['Tile-desc']} ${className}`}>{children}</div>
 }
 
 export const TileTitle = ({ children }) => (
@@ -27,8 +27,11 @@ export const TileSubtitle = ({ children }) => (
   </Typography>
 )
 
-export const TileFooter = ({ children }) => (
-  <Typography variant="caption" className={styles['Tile-status']}>
+export const TileFooter = ({ children, className }) => (
+  <Typography
+    variant="caption"
+    className={`${styles['Tile-status']} ${className}`}
+  >
     {children}
   </Typography>
 )

--- a/react/Tile/index.jsx
+++ b/react/Tile/index.jsx
@@ -15,8 +15,8 @@ export const TileDescription = ({ children, className }) => {
   return <div className={`${styles['Tile-desc']} ${className}`}>{children}</div>
 }
 
-export const TileTitle = ({ children }) => (
-  <Typography variant="h6" className={styles['Tile-title']}>
+export const TileTitle = ({ children, className }) => (
+  <Typography variant="h6" className={`${styles['Tile-title']} ${className}`}>
     {children}
   </Typography>
 )

--- a/react/Tile/styles.styl
+++ b/react/Tile/styles.styl
@@ -70,7 +70,6 @@ $tileMobileHeight = 3.75rem
   max-width 100%
 
 .Tile-title
-  height 1.25rem
   color var(--black)
 
 .Tile-developer


### PR DESCRIPTION
This PR add UI improvement on Tiles as they are displayed in `cozy-store`:

- Highlight app tiles that have available update (`update` text is now displayed in primaryColor)
![image](https://user-images.githubusercontent.com/1884255/131484061-70bfc987-c507-4cca-80aa-17fa67a69e16.png)
- Highlight app tiles that are installed (tile background is now grey)
![image](https://user-images.githubusercontent.com/1884255/131484159-688805c3-672f-44e4-8372-88c2ede662d5.png)
- Allow app tiles's names to be displayed on two line when no `status` (installed or update) is set
![image](https://user-images.githubusercontent.com/1884255/131484227-10b32492-0c81-4fd8-ab43-6f025a1afeea.png)


Changes can be observed here:

https://ldoppea.github.io/cozy-ui/react/#!/AppTile

https://ldoppea.github.io/cozy-ui/react/#!/AppSections