### PR TITLE
Feat/move app tile UI to tile

### DIFF
--- a/react/AppTile/helpers.js
+++ b/react/AppTile/helpers.js
@@ -1,7 +1,13 @@
+export const APP_STATUS = {
+  installed: 'installed',
+  maintenance: 'maintenance',
+  update: 'update'
+}
+
 export const getCurrentStatusLabel = app => {
-  if (hasPendingUpdate(app)) return 'update'
-  if (isUnderMaintenance(app)) return 'maintenance'
-  if (isInstalledAndNothingToReport(app)) return 'installed'
+  if (hasPendingUpdate(app)) return APP_STATUS.update
+  if (isUnderMaintenance(app)) return APP_STATUS.maintenance
+  if (isInstalledAndNothingToReport(app)) return APP_STATUS.installed
   return null
 }
 

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -88,9 +88,7 @@ export const AppTile = ({
         )}
       </TileIcon>
       <TileDescription className={styles[`AppTile-description`]}>
-        <TileTitle
-          className={statusLabel ? '' : styles['AppTile-title-2lines']}
-        >
+        <TileTitle isMultiline={!statusLabel}>
           {namePrefix ? `${namePrefix} ${name}` : name}
         </TileTitle>
         {developer.name && showDeveloper && (

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -13,7 +13,7 @@ import Tile, {
 import { createUseI18n } from '../I18n'
 import { AppDoctype } from '../proptypes'
 
-import { getCurrentStatusLabel } from './helpers'
+import { APP_STATUS, getCurrentStatusLabel } from './helpers'
 import styles from './styles.styl'
 import en from './locales/en.json'
 import fr from './locales/fr.json'
@@ -58,7 +58,7 @@ export const AppTile = ({
     : showStatus && statusLabel
   IconComponent = IconComponent || AppIcon
   const isInMaintenanceWithSpecificDisplay =
-    displaySpecificMaintenanceStyle && statusLabel === 'maintenance'
+    displaySpecificMaintenanceStyle && statusLabel === APP_STATUS.maintenance
 
   return (
     <Tile
@@ -70,7 +70,7 @@ export const AppTile = ({
           'AppTile-container-maintenance'
         ]]: isInMaintenanceWithSpecificDisplay
       })}
-      isSecondary={statusLabel === 'installed'}
+      isSecondary={statusLabel === APP_STATUS.installed}
     >
       <TileIcon>
         <IconComponent
@@ -95,7 +95,7 @@ export const AppTile = ({
           <TileSubtitle>{`${t('app_item.by')} ${developer.name}`}</TileSubtitle>
         )}
         {statusToDisplay && (
-          <TileFooter isAccent={statusLabel === 'update'}>
+          <TileFooter isAccent={statusLabel === APP_STATUS.update}>
             {t(`app_item.${statusToDisplay}`)}
           </TileFooter>
         )}

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -97,7 +97,7 @@ export const AppTile = ({
           <TileSubtitle>{`${t('app_item.by')} ${developer.name}`}</TileSubtitle>
         )}
         {statusToDisplay && (
-          <TileFooter className={styles[`AppTile-footer-${statusLabel}`]}>
+          <TileFooter isAccent={statusLabel === 'update'}>
             {t(`app_item.${statusToDisplay}`)}
           </TileFooter>
         )}

--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -68,9 +68,9 @@ export const AppTile = ({
       className={cx({
         [styles[
           'AppTile-container-maintenance'
-        ]]: isInMaintenanceWithSpecificDisplay,
-        [styles['AppTile-container-installed']]: statusLabel === 'installed'
+        ]]: isInMaintenanceWithSpecificDisplay
       })}
+      isSecondary={statusLabel === 'installed'}
     >
       <TileIcon>
         <IconComponent

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -26,10 +26,6 @@
   filter grayscale(1)
   opacity .64
 
-.AppTile-container-installed
-  background var(--defaultBackgroundColor)
-  border-color var(--defaultBackgroundColor)
-
 .AppTile-description
   .AppTile-title-2lines
     display -webkit-box

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -25,11 +25,3 @@
 .AppTile-container-maintenance
   filter grayscale(1)
   opacity .64
-
-.AppTile-description
-  .AppTile-title-2lines
-    display -webkit-box
-    -webkit-line-clamp 2
-    -webkit-box-orient vertical
-    overflow hidden
-    white-space normal

--- a/react/AppTile/styles.styl
+++ b/react/AppTile/styles.styl
@@ -33,7 +33,3 @@
     -webkit-box-orient vertical
     overflow hidden
     white-space normal
-
-  .AppTile-footer
-    &-update
-      color var(--primaryColor)

--- a/react/Tile/index.jsx
+++ b/react/Tile/index.jsx
@@ -1,11 +1,21 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import cx from 'classnames'
 import Typography from '../Typography'
 import styles from './styles.styl'
 
-const Tile = ({ children, className, tag: Tag, ...props }) => {
+const Tile = ({ children, className, tag: Tag, isSecondary, ...props }) => {
   return (
-    <Tag className={cx(styles.Tile, className)} {...props}>
+    <Tag
+      className={cx(
+        styles.Tile,
+        {
+          [styles['Tile-secondary']]: isSecondary
+        },
+        className
+      )}
+      {...props}
+    >
       {children}
     </Tag>
   )
@@ -40,7 +50,14 @@ export const TileIcon = ({ children }) => {
   return <div className={styles['Tile-icon-wrapper']}>{children}</div>
 }
 
+Tile.propTypes = {
+  className: PropTypes.string,
+  isSecondary: PropTypes.bool,
+  tag: PropTypes.string
+}
+
 Tile.defaultProps = {
+  isSecondary: false,
   tag: 'div'
 }
 

--- a/react/Tile/index.jsx
+++ b/react/Tile/index.jsx
@@ -37,10 +37,16 @@ export const TileSubtitle = ({ children }) => (
   </Typography>
 )
 
-export const TileFooter = ({ children, className }) => (
+export const TileFooter = ({ children, className, isAccent }) => (
   <Typography
     variant="caption"
-    className={`${styles['Tile-status']} ${className}`}
+    className={cx(
+      styles['Tile-status'],
+      {
+        [styles['Tile-status-accent']]: isAccent
+      },
+      className
+    )}
   >
     {children}
   </Typography>
@@ -48,6 +54,15 @@ export const TileFooter = ({ children, className }) => (
 
 export const TileIcon = ({ children }) => {
   return <div className={styles['Tile-icon-wrapper']}>{children}</div>
+}
+
+TileFooter.propTypes = {
+  className: PropTypes.string,
+  isAccent: PropTypes.bool
+}
+
+TileFooter.defaultProps = {
+  isAccent: false
 }
 
 Tile.propTypes = {

--- a/react/Tile/index.jsx
+++ b/react/Tile/index.jsx
@@ -22,11 +22,20 @@ const Tile = ({ children, className, tag: Tag, isSecondary, ...props }) => {
 }
 
 export const TileDescription = ({ children, className }) => {
-  return <div className={`${styles['Tile-desc']} ${className}`}>{children}</div>
+  return <div className={cx(styles['Tile-desc'], className)}>{children}</div>
 }
 
-export const TileTitle = ({ children, className }) => (
-  <Typography variant="h6" className={`${styles['Tile-title']} ${className}`}>
+export const TileTitle = ({ children, className, isMultiline }) => (
+  <Typography
+    variant="h6"
+    className={cx(
+      styles['Tile-title'],
+      {
+        [styles['Tile-title-multiline']]: isMultiline
+      },
+      className
+    )}
+  >
     {children}
   </Typography>
 )
@@ -54,6 +63,15 @@ export const TileFooter = ({ children, className, isAccent }) => (
 
 export const TileIcon = ({ children }) => {
   return <div className={styles['Tile-icon-wrapper']}>{children}</div>
+}
+
+TileTitle.propTypes = {
+  className: PropTypes.string,
+  isMultiline: PropTypes.bool
+}
+
+TileTitle.defaultProps = {
+  isMultiline: false
 }
 
 TileFooter.propTypes = {

--- a/react/Tile/styles.styl
+++ b/react/Tile/styles.styl
@@ -23,6 +23,10 @@ $tileMobileHeight = 3.75rem
   overflow hidden
   transition .15s ease all
 
+  &.Tile-secondary
+    background var(--defaultBackgroundColor)
+    border-color var(--defaultBackgroundColor)
+
 .Tile:hover,
 .Tile:active,
 .Tile:focus

--- a/react/Tile/styles.styl
+++ b/react/Tile/styles.styl
@@ -76,6 +76,13 @@ $tileMobileHeight = 3.75rem
 .Tile-title
   color var(--black)
 
+  &.Tile-title-multiline
+    display -webkit-box
+    -webkit-line-clamp 2
+    -webkit-box-orient vertical
+    overflow hidden
+    white-space normal
+
 .Tile-developer
   height 1rem
 

--- a/react/Tile/styles.styl
+++ b/react/Tile/styles.styl
@@ -83,6 +83,9 @@ $tileMobileHeight = 3.75rem
   margin-top .5rem
   height 1rem
 
+  &.Tile-status-accent
+    color var(--primaryColor)
+
 
 +small-screen()
   .Tile-icon-wrapper


### PR DESCRIPTION
This PR is a rewrite of the previous one : https://github.com/cozy/cozy-ui/pull/1884

Previous PR did not break anything but some of its edits were not effective in production. This is because CSS is not generated in the same order between `yarn build:doc` and `yarn build:css`. So what was visible in the cozy-ui documentation  would not be visible when used in an app.

### Exemple of CSS from the doc:
![image](https://user-images.githubusercontent.com/1884255/131560315-c8927c48-ce51-45de-8a50-636dfb567405.png)


### Exemple of the same CSS from an app (rules a inverted):
![image](https://user-images.githubusercontent.com/1884255/131560277-b50dd39c-265d-47a7-b965-3f5db26ae875.png)

New PR move the style from `AppTile` to `Tile` and use more specific CSS rules in order to be less dependant from the CSS order resulting from build.
