### PR TITLE
Fix/data-cozy-*

### DIFF
--- a/react/AppTile/index.jsx
+++ b/react/AppTile/index.jsx
@@ -28,12 +28,14 @@ let dataset
 const getDataset = () => {
   if (dataset) return dataset
   const root = document.querySelector('[role=application]')
-  dataset = root && root.dataset
+  if (root) {
+    dataset = root.dataset.cozy ? JSON.parse(root.dataset.cozy) : root.dataset
+  }
   return dataset
 }
 
 const getAppIconProps = () => ({
-  domain: getDataset() && getDataset().cozyDomain,
+  domain: getDataset() && (getDataset().cozyDomain || getDataset().domain),
   secure: window.location.protocol === 'https:'
 })
 

--- a/react/helpers/appDataset.js
+++ b/react/helpers/appDataset.js
@@ -36,7 +36,16 @@ export const readCozyDataFromDOM = memoize(attrName => {
 
   const attrName2 = `cozy${attrName[0].toUpperCase()}${attrName.substring(1)}`
   const value = appDataset[attrName2]
-  return value === undefined ? undefined : value === '' || JSON.parse(value)
+
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === 'true' || value === 'false') {
+    return JSON.parse(value)
+  }
+
+  return value === '' || value
 })
 
 export const resetCache = () => {

--- a/react/helpers/appDataset.spec.js
+++ b/react/helpers/appDataset.spec.js
@@ -68,5 +68,11 @@ describe('appdataset', () => {
         '<div role="application" data-cozy-tracking="false"></div>'
       expect(readCozyDataFromDOM('tracking')).toBe(false)
     })
+
+    it('should work for string values', () => {
+      document.body.innerHTML =
+        '<div role="application" data-cozy-token="abcd456"></div>'
+      expect(readCozyDataFromDOM('token')).toBe('abcd456')
+    })
   })
 })

--- a/react/helpers/tracker.jsx
+++ b/react/helpers/tracker.jsx
@@ -87,8 +87,8 @@ export const configureTracker = (options = {}) => {
   const root = document.querySelector('[role=application]')
 
   if (root && root.dataset) {
-    appName = readCozyDataFromDOM('appName')
-    cozyDomain = readCozyDataFromDOM('cozyDomain')
+    appName = readCozyDataFromDOM('appName') || readCozyDataFromDOM('app').name
+    cozyDomain = readCozyDataFromDOM('domain')
   }
 
   if (cozyDomain) {

--- a/react/helpers/tracker.spec.js
+++ b/react/helpers/tracker.spec.js
@@ -48,10 +48,40 @@ describe('configureTracker', () => {
     trackerFile.getTracker.mockImplementation(() => ({ push: jest.fn() }))
   })
 
-  it('should read the correct values from DOM', () => {
+  it('should read the correct values from DOM (with old data-cozy-* mechanism)', () => {
     const tracker = trackerFile.getTracker()
     trackerFile.setTracker(tracker)
-    const data = { cozyDomain: 'cozy.tools:8080', appName: 'banks' }
+    document.body.innerHTML = `<div role="application" data-cozy-domain='cozy.tools:8080' data-cozy-app-name='banks' />`
+
+    trackerFile.configureTracker()
+    expect(tracker.push).toHaveBeenCalledWith(['enableHeartBeatTimer', 15])
+    expect(tracker.push).toHaveBeenCalledWith(['setUserId', 'cozy.tools'])
+    expect(tracker.push).toHaveBeenCalledWith([
+      'setCustomDimension',
+      1234,
+      'banks'
+    ])
+  })
+
+  it('should read the correct values from DOM (with old data-cozy-* mechanism) and override tracker options', () => {
+    const tracker = trackerFile.getTracker()
+    trackerFile.setTracker(tracker)
+    document.body.innerHTML = `<div role="application" data-cozy-domain='cozy.tools:8080' data-cozy-app-name='banks' />`
+
+    trackerFile.configureTracker({ app: 'banks2' })
+    expect(tracker.push).toHaveBeenCalledWith(['enableHeartBeatTimer', 15])
+    expect(tracker.push).toHaveBeenCalledWith(['setUserId', 'cozy.tools'])
+    expect(tracker.push).toHaveBeenCalledWith([
+      'setCustomDimension',
+      1234,
+      'banks2'
+    ])
+  })
+
+  it('should read the correct values from DOM (with new data-cozy mechanism)', () => {
+    const tracker = trackerFile.getTracker()
+    trackerFile.setTracker(tracker)
+    const data = { domain: 'cozy.tools:8080', app: { name: 'banks' } }
     document.body.innerHTML = `<div role="application" data-cozy='${JSON.stringify(
       data
     )}' />`


### PR DESCRIPTION
This PR is a draft as some questions are still open and those may not be processed in the next few days.

This PR fixe the usage of `data-cozy` to reflect recent changes on how it is injected by the cozy-bar:
- https://github.com/cozy/cozy-store/pull/740
- https://github.com/cozy/cozy-banks/pull/2176
- https://github.com/cozy/cozy-drive/pull/2385

Points to be checked first:
- I'm not sure about the edits on tracker.jsx as I didn't check yet all app that use it and also how userId should be handled
- The fixed code in `AppTile` seems not to be used anymore. It may be used if the caller injects a custom `IconComponent`. As this `IconComponent` may be injected from an App, I should check all Cozy apps first and maybe the solution will be to remove this code instead of fixing it.
  - Cozy Store doest not use this mechanism
  - Other apps should be checked
  
____
  
Todo:
- [x] make code backward compatible
- [ ] create an issue to remove potential dead code