### PR TITLE
fix: Desactivate MUI transition for inverted theme if is testing

### DIFF
--- a/react/MuiCozyTheme/theme.jsx
+++ b/react/MuiCozyTheme/theme.jsx
@@ -684,7 +684,8 @@ const invertedTypography = makeTypography(invertedPalette)
 export const invertedTheme = createMuiTheme({
   palette: invertedPalette,
   typography: invertedTypography,
-  shadows
+  shadows,
+  ...(isTesting() && { transitions: { create: () => 'none' } })
 })
 
 invertedTheme.overrides = {


### PR DESCRIPTION
In testing environment, MUI transitions were disabled for normal theme
but not for inverted one

Related commit: 5dc817a50e4ebb4d612ebc3d0d002de3664a9ce6

This may fix https://github.com/cozy/cozy-ui/issues/1880