### PR TITLE
feat: Add a section divider component

### DIFF
--- a/react/MuiCozyTheme/Divider/Readme.md
+++ b/react/MuiCozyTheme/Divider/Readme.md
@@ -27,3 +27,19 @@ import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid';
   <Typography variant="body1" className="u-ml-1">Right block</Typography>
 </Grid>
 ```
+
+Divider with default textAlign (left)
+
+```jsx
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider';
+
+<Divider>Text Left</Divider>
+```
+
+Divider with textAlign (center)
+
+```jsx
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider';
+
+<Divider textAlign="center">Text Center</Divider>
+```

--- a/react/MuiCozyTheme/Divider/TextDivider/index.jsx
+++ b/react/MuiCozyTheme/Divider/TextDivider/index.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+
+import Typography from '../../../Typography'
+import styles from './styles.styl'
+
+/**
+ * @description This component is composing `<Typography />` and has access to the same props
+ */
+const TextDivider = ({
+  color = 'textPrimary',
+  variant = 'body2',
+  textAlign,
+  children,
+  className,
+  ...props
+}) => (
+  <Typography
+    color={color}
+    variant={variant}
+    className={cx(styles['divider'], styles[textAlign], className)}
+    {...props}
+  >
+    {children}
+  </Typography>
+)
+
+TextDivider.propTypes = {
+  textAlign: PropTypes.oneOf(['center'])
+}
+
+export default TextDivider

--- a/react/MuiCozyTheme/Divider/TextDivider/styles.styl
+++ b/react/MuiCozyTheme/Divider/TextDivider/styles.styl
@@ -1,0 +1,26 @@
+.divider
+  align-items center
+  display flex
+
+  &::after,
+  &::before {
+    content ''
+    height 1px
+    background-color var(--dividerColor)
+  }
+
+  &::before {
+    display none
+    margin-right 0.5rem
+  }
+
+  &::after {
+    flex 1
+    margin-left 0.5rem
+  }
+
+.center
+  &::before {
+    display block
+    flex 1
+  }

--- a/react/MuiCozyTheme/Divider/index.jsx
+++ b/react/MuiCozyTheme/Divider/index.jsx
@@ -1,6 +1,23 @@
-import Divider from '@material-ui/core/Divider'
+import React from 'react'
+import MuiDivider from '@material-ui/core/Divider'
 import { withStyles } from '@material-ui/core/styles'
 import { defaultValues, normalTheme } from '../theme'
+import TextDivider from './TextDivider'
+
+/**
+ * @desc If this component is provided a string children, it will render a `<TextDivider>` component
+ * and will handle the `textAlign` prop that accepts a `"center"` or undefined value
+ */
+const Divider = props =>
+  typeof props.children === 'string' ? (
+    <TextDivider {...props} />
+  ) : (
+    <MuiDivider {...props} />
+  )
+
+Divider.propTypes = {
+  ...TextDivider.propTypes
+}
 
 export default Divider
 


### PR DESCRIPTION
Add a simple divider component to split content sections 
https://acezard.github.io/cozy-ui/react
![localhost_6161_ (1)](https://user-images.githubusercontent.com/12577784/133257396-314a8583-3cd0-4e1d-825a-fc8fd4e51f0e.png)

Used in cozy-home