### PR TITLE
fix: Add scripts to remove empty blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "argos:upload": "argos upload",
     "stylus-build": "stylus -c --include stylus  --use ./node_modules/autoprefixer-stylus",
-    "build:css:all": "yarn build:css && yarn build:css:utils",
+    "build:css:all": "yarn build:css && yarn build:css:utils && yarn run removeEmptyCss",
     "build:css": "env CSSMODULES=false yarn run stylus-build -o dist/cozy-ui.min.css stylus/cozy-ui/build.styl",
     "build:css:utils": "env CSSMODULES=false yarn run stylus-build -o dist/cozy-ui.utils.min.css stylus/cozy-ui/utils.styl",
     "build:css:kss": "env CSSMODULES=false yarn run stylus-build -o build/styleguide/app.css stylus/cozy-ui/build.styl",
@@ -58,7 +58,8 @@
     "prestart:doc": "yarn sprite",
     "start:doc": "env BUILD_ENV=watch-styleguidist styleguidist server --config docs/styleguide.config.js",
     "start:doc:kss": "nodemon --ext styl,md --watch stylus --exec 'yarn build:doc:kss && http-server build/styleguide -p 4242'",
-    "start": "yarn build --watch"
+    "start": "yarn build --watch",
+    "removeEmptyCss": "node scripts/removeEmptyCss.js"
   },
   "sideEffects": [
     "*.css",
@@ -129,6 +130,7 @@
     "remark-cli": "^8.0.1",
     "remark-jscodeshift": "^1.1.0",
     "remark-preset-lint-recommended": "^4.0.1",
+    "replace-in-file": "^6.2.0",
     "semantic-release": "17.3.7",
     "style-loader": "0.23.1",
     "stylint": "1.5.9",

--- a/scripts/removeEmptyCss.js
+++ b/scripts/removeEmptyCss.js
@@ -1,0 +1,16 @@
+const replace = require('replace-in-file')
+
+const REGEX = /[^\};\{\n]+\{\s*\}/gm
+const options = {
+  files: ['dist/cozy-ui.min.css', 'dist/cozy-ui.utils.min.css'],
+  from: REGEX,
+  to: ''
+}
+
+replace(options)
+  .then(results => {
+    console.log('Replacement results:', results)
+  })
+  .catch(error => {
+    console.error('Error occurred:', error)
+  })

--- a/scripts/removeEmptyCss.spec.js
+++ b/scripts/removeEmptyCss.spec.js
@@ -1,0 +1,7 @@
+it('should test the removeEmptyCSS method', () => {
+  const CSS = `.emptyClass{} .emptyClass1 {} .emptyClass2 { } .notEmpty{color: red} .notEmpty1 {color: red} .noteEmpty2 { color: red }`
+  const cleanedCSS = CSS.replace(/[^\};\{\n]+\{\s*\}/gm, '')
+  expect(cleanedCSS).toBe(
+    ' .notEmpty{color: red} .notEmpty1 {color: red} .noteEmpty2 { color: red }'
+  )
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -14895,6 +14895,15 @@ replace-ext@1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
+replace-in-file@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.2.0.tgz#9c0e381b0e02f27f83d5ba500bb4046f63d18566"
+  integrity sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==
+  dependencies:
+    chalk "^4.1.0"
+    glob "^7.1.6"
+    yargs "^16.2.0"
+
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"


### PR DESCRIPTION
see https://github.com/cozy/cozy-ui/issues/1380

We have sometimes empty generated block. So I made a script to remove them. We don't gain a lot... 🤷‍♂️ 

Previously: 
```
-rw-r--r--   1 quentinvalmori  staff  126282 13 sep 18:38 cozy-ui.min.css
-rw-r--r--   1 quentinvalmori  staff   74637 13 sep 18:38 cozy-ui.utils.min.css
```

After: 
```
-rw-r--r--   1 quentinvalmori  staff  125228 13 sep 18:41 cozy-ui.min.css
-rw-r--r--   1 quentinvalmori  staff   74611 13 sep 18:41 cozy-ui.utils.min.css
```

