### PR TITLE
fix: Allow `Radio` to be part of a `RadioGroup`

### DIFF
--- a/react/Radio/Readme.md
+++ b/react/Radio/Readme.md
@@ -1,28 +1,51 @@
 ### Radio
 
-```
-import Radio from 'cozy-ui/transpiled/react/Radio';
-<form>
-  <div>
-    <Radio name="radioForm" value="radioValue1" label="This is a radio button" />
-    <Radio name="radioForm" value="radioValue2" label="This is also a radio button" />
-    <Radio style={{ background: 'cadetblue',  padding: '0.5rem', height: '3rem' }} name="radioForm" value="radioValue2" label="This is a radio button with a custom style" />
-  </div>
-</form>
-```
+```jsx
+import Radio from 'cozy-ui/transpiled/react/Radio'
+import Variants from 'cozy-ui/docs/components/Variants'
 
-### Radio when there's an error
+let initialVariants = [
+  { error: false, disabled: false }
+]
 
-```
-import Radio from 'cozy-ui/transpiled/react/Radio';
-<div><Radio name="radioForm" value="radioValue1" label="This is a radio button" error /></div>
-```
+if (isTesting()) {
+  initialVariants = [
+    ...initialVariants,
+    { error: true, disabled: false },
+    { error: false, disabled: true }
+  ]
+}
 
-### Radio when disabled
-
-```
-import Radio from 'cozy-ui/transpiled/react/Radio';
-<div><Radio name="radioForm"value="radioValue1" label="This is a disabled radio button" disabled /></div>
+<Variants initialVariants={initialVariants}>{
+  variant => (
+    <form>
+      <div>
+        <Radio
+          name="radioForm"
+          value="radioValue1"
+          label="This is a radio button"
+          error={variant.error}
+          disabled={variant.disabled}
+        />
+        <Radio
+          name="radioForm"
+          value="radioValue2"
+          label="This is also a radio button"
+          error={variant.error}
+          disabled={variant.disabled}
+        />
+        <Radio
+          style={{ background: 'cadetblue',  padding: '0.5rem', height: '3rem' }}
+          name="radioForm"
+          value="radioValue3"
+          label="This is a radio button with a custom style"
+          error={variant.error}
+          disabled={variant.disabled}
+        />
+      </div>
+    </form>
+  )
+}</Variants>
 ```
 
 ### No gutter
@@ -31,8 +54,8 @@ By default Radio and Checkbox have a small gutter next to them for their label n
 the edge of the radio/checkbox. This can be cumbersome when aligning horizontally inside a container.
 You can set `gutter` to `false` to cancel the default gutter.
 
-```
-import Radio from 'cozy-ui/transpiled/react/Radio';
+```jsx
+import Radio from 'cozy-ui/transpiled/react/Radio'
 
 const Box = ({ children }) => {
   return   <div style={{ height: '3rem', width: '3rem', border: '2px dashed #CCC', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
@@ -40,7 +63,7 @@ const Box = ({ children }) => {
   </div>
 }
 
-const bboxStyle = { border: '1px solid red' };
+const bboxStyle = { border: '1px solid red' }
 
 initialState.bbox = isTesting();
 

--- a/react/Radio/Readme.md
+++ b/react/Radio/Readme.md
@@ -59,3 +59,44 @@ initialState.bbox = isTesting();
 </>
 
 ```
+
+### In a RadioGroup
+
+```jsx
+import { useCallback, useMemo, useState } from 'react'
+
+import Radio from 'cozy-ui/transpiled/react/Radio'
+import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import uniqueId from 'lodash/uniqueId'
+
+const radioGroupId = uniqueId('radioGroup')
+
+const [radioValue, setRadioValue] = useState('item1')
+
+const onChange = event => {
+  setRadioValue(event.target.value)
+}
+
+<RadioGroup
+  name={radioGroupId}
+  value={radioValue.toString()}
+  onChange={onChange}
+>
+  <FormControlLabel
+    value="item1"
+    control={<Radio />}
+    label="Item 1"
+  />
+  <FormControlLabel
+    value="item2"
+    control={<Radio />}
+    label="Item 2"
+  />
+  <FormControlLabel
+    value="item3"
+    control={<Radio />}
+    label="Item 3"
+  />
+</RadioGroup>
+```

--- a/react/Radio/index.jsx
+++ b/react/Radio/index.jsx
@@ -2,19 +2,39 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
+import { useRadioGroup } from '@material-ui/core/RadioGroup'
 
 const Radio = props => {
   const {
     className,
     value,
-    name,
+    name: nameProp,
     label,
     error,
     disabled,
     style,
     gutter,
+    onChange: onChangeProp,
+    checked: checkedProp,
     ...restProps
   } = props
+  const radioGroup = useRadioGroup()
+
+  let checked = checkedProp
+  let name = nameProp
+
+  if (radioGroup) {
+    if (typeof checked === 'undefined') {
+      checked = radioGroup.value === props.value
+    }
+    if (typeof name === 'undefined') {
+      name = radioGroup.name
+    }
+  }
+
+  const onChange =
+    onChangeProp || (radioGroup && radioGroup.onChange) || (() => {})
+
   return (
     <label
       className={cx(
@@ -33,6 +53,8 @@ const Radio = props => {
         value={value}
         name={name}
         disabled={disabled}
+        onChange={onChange}
+        checked={checked}
         {...restProps}
       />
       <span>{label}</span>

--- a/react/Radio/index.spec.jsx
+++ b/react/Radio/index.spec.jsx
@@ -1,0 +1,174 @@
+import React, { useState } from 'react'
+
+import { render, fireEvent } from '@testing-library/react'
+
+import Radio from './'
+import RadioGroup from '../RadioGroup'
+import FormControlLabel from '../FormControlLabel'
+
+const RadioGroupComponent = ({ radioOnChange, radioName }) => {
+  const [radioValue, setRadioValue] = useState('item1')
+
+  const onChange = event => {
+    setRadioValue(event.target.value)
+  }
+
+  return (
+    <RadioGroup
+      name="RadioGroupName"
+      value={radioValue.toString()}
+      onChange={onChange}
+    >
+      <FormControlLabel
+        value="item1"
+        control={
+          <Radio
+            data-testid="radio1"
+            onChange={radioOnChange}
+            name={radioName}
+          />
+        }
+        label="Item 1"
+      />
+      <FormControlLabel
+        value="item2"
+        control={
+          <Radio
+            data-testid="radio2"
+            onChange={radioOnChange}
+            name={radioName}
+          />
+        }
+        label="Item 2"
+      />
+      <FormControlLabel
+        value="item3"
+        control={
+          <Radio
+            data-testid="radio3"
+            onChange={radioOnChange}
+            name={radioName}
+          />
+        }
+        label="Item 3"
+      />
+    </RadioGroup>
+  )
+}
+
+describe('Radio', () => {
+  it('should render the component', async () => {
+    const { container } = render(<Radio />)
+
+    expect(container.querySelector('input[type=radio]')).toBeInTheDocument()
+  })
+
+  it(`should handle a 'onChange' prop`, async () => {
+    const onChange = jest.fn()
+    const { container } = render(<Radio onChange={onChange} />)
+
+    const input = container.querySelector('input[type=radio]')
+    fireEvent.click(input)
+
+    expect(input).toBeInTheDocument()
+    expect(onChange).toHaveBeenCalled()
+    expect(input.checked).toBeTruthy()
+  })
+
+  it(`should handle a 'name' prop`, async () => {
+    const { container } = render(<Radio name={'hello'} />)
+
+    const input = container.querySelector('input[type=radio]')
+
+    expect(input.name).toBe('hello')
+  })
+
+  it('should handle a disabled prop', async () => {
+    const onClick = jest.fn()
+    const { container } = render(<Radio onClick={onClick} disabled={true} />)
+
+    const input = container.querySelector('input[type=radio]')
+    expect(input.checked).toBeFalsy()
+
+    // here fireEvent.click(input) cannot be used due to a bug on the testing tools
+    // so input.click() is used instead
+    // more info at https://github.com/testing-library/dom-testing-library/issues/92
+    input.click()
+
+    expect(input).toBeInTheDocument()
+    expect(onClick).not.toHaveBeenCalled()
+    expect(input.checked).toBeFalsy()
+  })
+
+  it('should handle being in a RadioGroup', async () => {
+    const { queryByTestId } = render(<RadioGroupComponent />)
+
+    const radio1 = queryByTestId('radio1')
+    const radio2 = queryByTestId('radio2')
+    const radio3 = queryByTestId('radio3')
+
+    fireEvent.click(radio2)
+    expect(radio1.checked).toBeFalsy()
+    expect(radio2.checked).toBeTruthy()
+    expect(radio3.checked).toBeFalsy()
+
+    fireEvent.click(radio3)
+    expect(radio1.checked).toBeFalsy()
+    expect(radio2.checked).toBeFalsy()
+    expect(radio3.checked).toBeTruthy()
+  })
+
+  it(`should get the name of the parent's RadioGroup`, async () => {
+    const { queryByTestId } = render(<RadioGroupComponent />)
+
+    const radio1 = queryByTestId('radio1')
+    const radio2 = queryByTestId('radio2')
+    const radio3 = queryByTestId('radio3')
+
+    expect(radio1.name).toBe('RadioGroupName')
+    expect(radio2.name).toBe('RadioGroupName')
+    expect(radio3.name).toBe('RadioGroupName')
+  })
+
+  it(`should handle 'name' prop over RadioGroup's 'name'`, async () => {
+    const { queryByTestId } = render(
+      <RadioGroupComponent radioName="NameOverride" />
+    )
+
+    const radio1 = queryByTestId('radio1')
+    const radio2 = queryByTestId('radio2')
+    const radio3 = queryByTestId('radio3')
+
+    expect(radio1.name).toBe('NameOverride')
+    expect(radio2.name).toBe('NameOverride')
+    expect(radio3.name).toBe('NameOverride')
+  })
+
+  it(`should handle 'onChange' prop over RadioGroup's 'onChange'`, async () => {
+    const onClick = jest.fn()
+
+    const { queryByTestId } = render(
+      <RadioGroupComponent radioOnChange={onClick} />
+    )
+
+    const radio1 = queryByTestId('radio1')
+    const radio2 = queryByTestId('radio2')
+    const radio3 = queryByTestId('radio3')
+
+    fireEvent.click(radio2)
+    expect(onClick).toHaveBeenCalledTimes(1)
+
+    // expected state is default selection to item1
+    expect(radio1.checked).toBeTruthy()
+    expect(radio2.checked).toBeFalsy()
+    expect(radio3.checked).toBeFalsy()
+
+    fireEvent.click(radio3)
+    expect(onClick).toHaveBeenCalledTimes(2)
+
+    // expected state is default selection to item1
+    expect(radio1.checked).toBeTruthy()
+    expect(radio2.checked).toBeFalsy()
+    expect(radio3.checked).toBeFalsy()
+  })
+})

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -7731,6 +7731,12 @@ exports[`Radio should render examples: Radio 4`] = `
 </div>"
 `;
 
+exports[`Radio should render examples: Radio 5`] = `
+"<div>
+  <div class=\\"MuiFormGroup-root\\" role=\\"radiogroup\\"><label class=\\"MuiFormControlLabel-root\\"><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioGroup1\\" value=\\"item1\\" checked=\\"\\"><span></span></label><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">Item 1</span></label><label class=\\"MuiFormControlLabel-root\\"><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioGroup1\\" value=\\"item2\\"><span></span></label><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">Item 2</span></label><label class=\\"MuiFormControlLabel-root\\"><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioGroup1\\" value=\\"item3\\"><span></span></label><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">Item 3</span></label></div>
+</div>"
+`;
+
 exports[`SelectBox should render examples: SelectBox 1`] = `
 "<div>
   <div style=\\"background: whitesmoke; padding: .5em;\\">

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -7703,25 +7703,28 @@ exports[`QuotaAlert should render examples: QuotaAlert 1`] = `
 
 exports[`Radio should render examples: Radio 1`] = `
 "<div>
+  <div class=\\"MuiPaper-root u-p-1 u-mb-1 MuiPaper-elevation1\\">
+    <h5 class=\\"MuiTypography-root u-mb-1 MuiTypography-h5\\">Variant selector</h5><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">ERROR</span></label><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">DISABLED</span></label>
+  </div>
   <form>
-    <div><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue1\\"><span>This is a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is also a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\" style=\\"background: cadetblue; padding: 0.5rem; height: 3rem;\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is a radio button with a custom style</span></label></div>
+    <div><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"false\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue1\\"><span>This is a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"false\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is also a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"false\\" style=\\"background: cadetblue; padding: 0.5rem; height: 3rem;\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue3\\"><span>This is a radio button with a custom style</span></label></div>
+  </form>
+  <div class=\\"MuiPaper-root u-p-1 u-mb-1 MuiPaper-elevation1\\">
+    <h5 class=\\"MuiTypography-root u-mb-1 MuiTypography-h5\\">Variant selector</h5><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-checked-3 Mui-checked MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\" checked=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">ERROR</span></label><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">DISABLED</span></label>
+  </div>
+  <form>
+    <div><label class=\\"styles__c-input-radio___XJQt1 styles__is-error___2-12P\\" aria-disabled=\\"false\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue1\\"><span>This is a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1 styles__is-error___2-12P\\" aria-disabled=\\"false\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue2\\"><span>This is also a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1 styles__is-error___2-12P\\" aria-disabled=\\"false\\" style=\\"background: cadetblue; padding: 0.5rem; height: 3rem;\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue3\\"><span>This is a radio button with a custom style</span></label></div>
+  </form>
+  <div class=\\"MuiPaper-root u-p-1 u-mb-1 MuiPaper-elevation1\\">
+    <h5 class=\\"MuiTypography-root u-mb-1 MuiTypography-h5\\">Variant selector</h5><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">ERROR</span></label><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-checked-3 Mui-checked MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\" checked=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">DISABLED</span></label>
+  </div>
+  <form>
+    <div><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"true\\"><input type=\\"radio\\" name=\\"radioForm\\" disabled=\\"\\" value=\\"radioValue1\\"><span>This is a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"true\\"><input type=\\"radio\\" name=\\"radioForm\\" disabled=\\"\\" value=\\"radioValue2\\"><span>This is also a radio button</span></label><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"true\\" style=\\"background: cadetblue; padding: 0.5rem; height: 3rem;\\"><input type=\\"radio\\" name=\\"radioForm\\" disabled=\\"\\" value=\\"radioValue3\\"><span>This is a radio button with a custom style</span></label></div>
   </form>
 </div>"
 `;
 
 exports[`Radio should render examples: Radio 2`] = `
-"<div>
-  <div><label class=\\"styles__c-input-radio___XJQt1 styles__is-error___2-12P\\"><input type=\\"radio\\" name=\\"radioForm\\" value=\\"radioValue1\\"><span>This is a radio button</span></label></div>
-</div>"
-`;
-
-exports[`Radio should render examples: Radio 3`] = `
-"<div>
-  <div><label class=\\"styles__c-input-radio___XJQt1\\" aria-disabled=\\"true\\"><input type=\\"radio\\" name=\\"radioForm\\" disabled=\\"\\" value=\\"radioValue1\\"><span>This is a disabled radio button</span></label></div>
-</div>"
-`;
-
-exports[`Radio should render examples: Radio 4`] = `
 "<div>
   <p><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" value=\\"\\" checked=\\"\\"><span>View bounding box</span></label></p>
   <p>Default gutter</p>
@@ -7731,7 +7734,7 @@ exports[`Radio should render examples: Radio 4`] = `
 </div>"
 `;
 
-exports[`Radio should render examples: Radio 5`] = `
+exports[`Radio should render examples: Radio 3`] = `
 "<div>
   <div class=\\"MuiFormGroup-root\\" role=\\"radiogroup\\"><label class=\\"MuiFormControlLabel-root\\"><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioGroup1\\" value=\\"item1\\" checked=\\"\\"><span></span></label><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">Item 1</span></label><label class=\\"MuiFormControlLabel-root\\"><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioGroup1\\" value=\\"item2\\"><span></span></label><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">Item 2</span></label><label class=\\"MuiFormControlLabel-root\\"><label class=\\"styles__c-input-radio___XJQt1\\"><input type=\\"radio\\" name=\\"radioGroup1\\" value=\\"item3\\"><span></span></label><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">Item 3</span></label></div>
 </div>"


### PR DESCRIPTION
When embedded in a RadioGroup, Radio should be able to handle
RadioGroup's `onChange` and `name` props

Fixes cozy/cozy-ui#1901

Demo visible here : https://ldoppea.github.io/cozy-ui/react/#!/Radio