### PR TITLE
fix: Remove export Sprite from Icon (index.jsx)

### DIFF
--- a/docs/components/SectionsRenderer.jsx
+++ b/docs/components/SectionsRenderer.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import DefaultSectionsRenderer from 'react-styleguidist/lib/client/rsg-components/Sections/SectionsRenderer'
-import IconSprite from '../../react/Icon/Sprite'
 
 export default class SectionsRenderer extends Component {
   render() {

--- a/react/Icon/Readme.md
+++ b/react/Icon/Readme.md
@@ -659,7 +659,8 @@ import WarningIcon from "cozy-ui/transpiled/react/Icons/Warning"
 
 ```jsx
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
+// Sprite is necessary in order to add in the html rendering
+import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite' 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 const colors = ['#297EF2', '#08b442', '#B449E7', '#F52D2D', '#FF962F']

--- a/react/Icon/index.jsx
+++ b/react/Icon/index.jsx
@@ -101,4 +101,3 @@ Icon.defaultProps = {
 }
 
 export default Icon
-export { default as Sprite } from './Sprite'


### PR DESCRIPTION
We delete this export in order to optimize the size of the Icon component.

As soon as we imported this Icon component we
embed Sprite which is not necessarily used.
This can increase the size of the
application that uses Cozy UI.

BREAKING CHANGE:
Now Sprite is no longer exported by Icon.
However, you can import it directly with
`import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'`
instead of
`import { Sprite } from 'cozy-ui/transpiled/react/Icon'`