### PR TITLE
fix: Title is not required

### DIFF
--- a/react/Empty/index.jsx
+++ b/react/Empty/index.jsx
@@ -39,7 +39,7 @@ export const Empty = ({
 Empty.propTypes = {
   icon: iconPropType,
   iconSize: PropTypes.oneOf(['normal', 'medium', 'large']),
-  title: PropTypes.node.isRequired,
+  title: PropTypes.node,
   text: PropTypes.node,
   className: PropTypes.string
 }


### PR DESCRIPTION
Remove isRequired from proptypes
There is a check (l.28) if `title` exist.

Looks like this [case](https://github.com/cozy/cozy-ui/commit/1ea8975)