### PR TITLE
feat: Add piwik-react-router package

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "mini-css-extract-plugin": "0.6.0",
     "nodemon": "1.19.4",
     "npm-run-all": "4.1.5",
+    "piwik-react-router": "0.12.1",
     "postcss-cli": "6.1.3",
     "postcss-loader": "2.1.6",
     "pretty": "2.0.0",
@@ -168,7 +169,7 @@
     "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",
     "cozy-sharing": "^3.10.0",
-    "piwik-react-router": "^0.8.2",
+    "piwik-react-router": "0.12.1",
     "puppeteer": "^1.20.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13256,6 +13256,14 @@ pirates@^4.0.0, pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+piwik-react-router@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/piwik-react-router/-/piwik-react-router-0.12.1.tgz#0caf984715a5b22c85610e0c02ae372b1ca37c41"
+  integrity sha512-Ebi7rBKV/S+YJ3UF/6t6n/wRx1/4yilR1caG/JhdefkYHh8gopqy2kxjaaD++LS9tTmtPNfokEHWbXTbw2W7OA==
+  dependencies:
+    url-join "^1.1.0"
+    warning "^3.0.0"
+
 pkg-conf@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-1.1.3.tgz#378e56d6fd13e88bfb6f4a25df7a83faabddba5b"
@@ -18287,6 +18295,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
+  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
 
 url-join@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
Add piwik-react-router package to devDeps
for fix this warning when run build or start doc:
```
WARN  Compiled with warnings
./react/helpers/tracker.jsx
Module not found: Can't resolve 'piwik-react-router'
in '/Users/<user>/workspace/cozy-ui/react/helpers'
```
