### PR TITLE
feat: Add `autoCapitalize` prop in Fields

### DIFF
--- a/react/Field/Readme.md
+++ b/react/Field/Readme.md
@@ -6,7 +6,7 @@ Like `Input` component, it can have the following properties:
 
 ##### Example
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -21,7 +21,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 ##### Inline variant
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -39,7 +39,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 An input is controlled if `props.value` is passed, even if it is empty.
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 
 initialState = { value: '' }
@@ -58,7 +58,7 @@ It gives access to the underlying `<input />` element, for example to give focus
 
 ##### Example
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 import Button from 'cozy-ui/transpiled/react/Button';
 class FieldWithFocus extends React.Component {
@@ -91,7 +91,7 @@ Name of the form field, injected into `Input`, `TextArea` or `SelectBox` compone
 
 ##### Exemple
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -103,7 +103,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Field when there's an error
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -118,7 +118,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Field with SelectBox
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 const options = [
 {
@@ -168,7 +168,7 @@ initialState = { selectedContact: null };
 
 #### Password field with show/hide button
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -185,7 +185,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Password field without show/hide button
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -198,7 +198,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Side element
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -210,7 +210,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Side element with fullwidth element
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -223,7 +223,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Customized label and input
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -240,7 +240,7 @@ import Field from 'cozy-ui/transpiled/react/Field';
 
 #### Password with custom secondaryComponent
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 import MuiButton from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons';
 
@@ -271,7 +271,7 @@ import MuiButton from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons';
 
 #### Controlled Field
 
-```
+```jsx
 import Field from 'cozy-ui/transpiled/react/Field';
 <form>
   <Field
@@ -281,4 +281,30 @@ import Field from 'cozy-ui/transpiled/react/Field';
   />
   Value: { state.value }
 </form>
+```
+
+#### Mobile specific props
+
+On mobile devices, following props may be useful to control on-screen keyboard's behavior
+
+Note that `autoCapitalize` property is not handled by all mobile browsers and it also depends on the on-screen keyboard installed by the user and its configuration (i.e. [Android SwiftKey configuration](https://support.swiftkey.com/hc/en-us/articles/201468481-How-do-I-turn-off-Auto-Capitalize-))
+
+```jsx
+import Field from 'cozy-ui/transpiled/react/Field';
+import Variants from 'cozy-ui/docs/components/Variants';
+
+const initialVariants = [
+  { autoCapitalize: false, autoComplete: false }
+];
+
+<Variants initialVariants={initialVariants}>{
+  variant => (
+    <form>
+      <Field
+        autoCapitalize={variant.autoCapitalize ? 'on' : 'none'}
+        autoComplete={variant.autoComplete ? 'on' : 'off'}
+      />
+    </form>
+  )
+}</Variants>
 ```

--- a/react/Field/index.jsx
+++ b/react/Field/index.jsx
@@ -16,6 +16,7 @@ import ContactPicker from '../ContactPicker'
  * for example
  */
 const inputSpecificPropTypes = {
+  autoCapitalize: PropTypes.string,
   autoComplete: PropTypes.string,
   onKeyUp: PropTypes.func
 }
@@ -102,6 +103,7 @@ const FieldContainer = props => {
 
 const Field = props => {
   const {
+    autoCapitalize,
     autoComplete,
     className,
     disabled,
@@ -146,6 +148,7 @@ const Field = props => {
       case 'textarea':
         return (
           <Textarea
+            autoCapitalize={autoCapitalize}
             disabled={disabled}
             id={id}
             name={name}
@@ -161,6 +164,7 @@ const Field = props => {
       case 'password':
         return (
           <InputPassword
+            autoCapitalize={autoCapitalize}
             autoComplete={autoComplete}
             disabled={disabled}
             fullwidth={fullwidth}
@@ -198,6 +202,7 @@ const Field = props => {
       case 'number':
         return (
           <Input
+            autoCapitalize={autoCapitalize}
             autoComplete={autoComplete}
             disabled={disabled}
             fullwidth={fullwidth}

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2533,6 +2533,17 @@ exports[`Field should render examples: Field 15`] = `
 </div>"
 `;
 
+exports[`Field should render examples: Field 16`] = `
+"<div>
+  <div class=\\"MuiPaper-root u-p-1 u-mb-1 MuiPaper-elevation1\\">
+    <h5 class=\\"MuiTypography-root u-mb-1 MuiTypography-h5\\">Variant selector</h5><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">AUTOCAPITALIZE</span></label><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-5\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">AUTOCOMPLETE</span></label>
+  </div>
+  <form>
+    <div class=\\"styles__o-field___3n5HM\\"><label for=\\"\\" class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\"></label><input autocomplete=\\"off\\" type=\\"text\\" id=\\"\\" class=\\"styles__c-input-text___3TAv1 styles__c-input-text--large___28EaR\\" placeholder=\\"\\" autocapitalize=\\"none\\" value=\\"\\"></div>
+  </form>
+</div>"
+`;
+
 exports[`Hero should render examples: Hero 1`] = `
 "<div>
   <div class=\\"styles__Hero___14z7_\\">


### PR DESCRIPTION
On mobile devices, `autoCapitalize` allows to control on-screen
keyboard's behavior regarding words capitalization inside text inputs

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

Demo: https://ldoppea.github.io/cozy-ui/react/#!/Field
⚠️ only testable on mobile devices. Not compatible with current Firefox version (92) and behavior will depends on your on-screen Keyboard app