### PR TITLE
feat: Add IconContent prop to SquareAppIcon

### DIFF
--- a/react/Icons/LogoutLarge.jsx
+++ b/react/Icons/LogoutLarge.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 function SvgLogoutLarge(props) {
   return (
-    <svg {...props}>
+    <svg viewBox="0 0 44 44" {...props}>
       <g fill="none" fillRule="evenodd">
         <rect
           width={27.5}

--- a/react/SquareAppIcon/Readme.md
+++ b/react/SquareAppIcon/Readme.md
@@ -4,6 +4,8 @@ application.
 ```jsx
 import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid'
 import SquareAppIcon from 'cozy-ui/transpiled/react/SquareAppIcon'
+import CozyIcon from 'cozy-ui/transpiled/react/Icons/Cozy'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 import { useCozyTheme } from 'cozy-ui/transpiled/react/CozyTheme'
 import cloudWallpaper from '../../docs/cloud-wallpaper.jpg'
 
@@ -31,6 +33,27 @@ const theme = useCozyTheme()
   </Grid>
   <Grid item>
     <SquareAppIcon name="Shortcut" variant="shortcut" />
+  </Grid>
+  <Grid item>
+    <SquareAppIcon name="Custom Icon" IconContent={<Icon icon={CozyIcon} size="48" />} />
+  </Grid>
+  <Grid item>
+    <SquareAppIcon name="Icon Grid" IconContent={(
+      <Grid container spacing={0}>
+        <Grid item xs={6}>
+          <Icon icon={CozyIcon} />
+        </Grid>
+        <Grid item xs={6}>
+          <Icon icon={CozyIcon} />
+        </Grid>
+          <Grid item xs={6}>
+            <Icon icon={CozyIcon} />
+          </Grid>
+          <Grid item xs={6}>
+            <Icon icon={CozyIcon} />
+          </Grid>
+        </Grid>
+    )} />
   </Grid>
 </Grid>
 ```

--- a/react/SquareAppIcon/SquareAppIcon.spec.js
+++ b/react/SquareAppIcon/SquareAppIcon.spec.js
@@ -4,6 +4,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import CozyIcon from 'cozy-ui/transpiled/react/Icons/Cozy'
 
 import SquareAppIcon from './index'
 
@@ -64,6 +66,13 @@ describe('SquareAppIcon component', () => {
 
   it('should render correctly an app in shortcut state', () => {
     const root = render(<Wrapper variant="shortcut" name="shortcut" />)
+    expect(root.getByTestId('square-app-icon')).toMatchSnapshot()
+  })
+
+  it('should render correctly an app with custom content', () => {
+    const root = render(
+      <Wrapper name="custom icon" IconContent={<Icon icon={CozyIcon} />} />
+    )
     expect(root.getByTestId('square-app-icon')).toMatchSnapshot()
   })
 })

--- a/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
+++ b/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
@@ -355,3 +355,46 @@ exports[`SquareAppIcon component should render correctly an app in shortcut stat
   </h6>
 </div>
 `;
+
+exports[`SquareAppIcon component should render correctly an app with custom content 1`] = `
+<div
+  class="makeStyles-tileWrapper-53"
+  data-testid="square-app-icon"
+>
+  <span
+    class="MuiBadge-root"
+  >
+    <span
+      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-51"
+    >
+      <div
+        class="styles__SquareAppIcon-icon-container___39MRl"
+      >
+        <svg
+          class="styles__icon___23x3R"
+          height="16"
+          viewBox="0 0 52 52"
+          width="16"
+        >
+          <path
+            d="M38.231 44H13.769C6.175 44 0 37.756 0 30.08c0-3.66 1.394-7.117 3.927-9.733 2.219-2.29 5.093-3.715 8.203-4.086a13.887 13.887 0 014.042-8.292A13.608 13.608 0 0125.801 4c3.62 0 7.04 1.407 9.629 3.968a13.897 13.897 0 014.038 8.25C46.482 16.853 52 22.828 52 30.082 52 37.756 45.82 44 38.23 44h.001zm-.163-3.001h.104c5.97 0 10.828-4.91 10.828-10.947 0-6.035-4.857-10.946-10.828-10.946h-.11c-.779 0-1.417-.627-1.435-1.417C36.492 11.794 31.637 7 25.803 7c-5.835 0-10.692 4.796-10.826 10.69a1.445 1.445 0 01-1.403 1.42C7.744 19.244 3 24.153 3 30.052 3 36.09 7.857 41 13.828 41h.088l.035-.002c.03 0 .062 0 .093.002h24.021l.003-.001zm-4.302-11.776c-.875-.585-.918-1.659-.92-1.706A.52.52 0 0032.32 27a.523.523 0 00-.506.536c.002.039.016.543.251 1.137a7.99 7.99 0 01-11.138.019 3.554 3.554 0 00.257-1.155.523.523 0 00-.503-.536.526.526 0 00-.528.515c0 .043-.042 1.121-.92 1.706a.536.536 0 00-.15.731.51.51 0 00.714.154c.225-.15.414-.322.572-.505a9.006 9.006 0 0012.251-.01c.16.184.35.36.582.515a.503.503 0 00.281.085.516.516 0 00.432-.24.537.537 0 00-.15-.731v.002z"
+            fill="#297EF2"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <span
+        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangle"
+      />
+    </span>
+    <span
+      class="MuiBadge-badge Component-qualifier-54 MuiBadge-anchorOriginBottomRightRectangle MuiBadge-invisible"
+    />
+  </span>
+  <h6
+    class="MuiTypography-root makeStyles-name-49 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+  >
+    custom icon
+  </h6>
+</div>
+`;

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
+export const SquareAppIcon = ({ app, type, name, variant, IconContent }) => {
   const classes = useStyles()
   const appName = name || (app && app.name) || app || ''
   const letter = appName[0] || ''
@@ -119,7 +119,7 @@ export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
               ) : IconContent ? (
                 IconContent
               ) : (
-                <AppIcon app={app} />
+                <AppIcon app={app} type={type} />
               )}
             </div>
           )}
@@ -146,7 +146,8 @@ SquareAppIcon.propTypes = {
     'add',
     'shortcut'
   ]),
-  IconContent: PropTypes.node
+  IconContent: PropTypes.node,
+  type: PropTypes.oneOf(['app', 'konnector'])
 }
 
 export default SquareAppIcon

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export const SquareAppIcon = ({ app, name, variant }) => {
+export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
   const classes = useStyles()
   const appName = name || (app && app.name) || app || ''
   const letter = appName[0] || ''
@@ -116,6 +116,8 @@ export const SquareAppIcon = ({ app, name, variant }) => {
             <div className={styles['SquareAppIcon-icon-container']}>
               {variant === 'add' ? (
                 <Icon icon={iconPlus} color={color} />
+              ) : IconContent ? (
+                IconContent
               ) : (
                 <AppIcon app={app} />
               )}
@@ -137,7 +139,14 @@ export const SquareAppIcon = ({ app, name, variant }) => {
 SquareAppIcon.propTypes = {
   app: PropTypes.oneOfType([AppDoctype, PropTypes.string]),
   name: PropTypes.string,
-  variant: PropTypes.oneOf(['ghost', 'maintenance', 'error', 'add', 'shortcut'])
+  variant: PropTypes.oneOf([
+    'ghost',
+    'maintenance',
+    'error',
+    'add',
+    'shortcut'
+  ]),
+  IconContent: PropTypes.node
 }
 
 export default SquareAppIcon

--- a/react/SquareAppIcon/styles.styl
+++ b/react/SquareAppIcon/styles.styl
@@ -32,14 +32,11 @@ $color = constants['color'] // hard-coded color, because the component is curren
 .SquareAppIcon-wrapper-fx
     background-color alpha($color, .32)
     border 1px dashed var(--white)
-    @supports not (backdrop-filter: blur(48px))
-        background-color alpha($color, .48)
-    .SquareAppIcon-icon-container
-        backdrop-filter blur(48px)
+    background-color alpha($color, .48)
 
 .SquareAppIcon-wrapper-ghost
     .SquareAppIcon-icon-container
-        mix-blend-mode screen // need to apply backdrop-filter and mix blend-mode in a separated element to have the proper effect
+        mix-blend-mode screen
         svg, img
             filter saturate(0%)
 

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -3911,7 +3911,7 @@ exports[`Icon should render examples: Icon 2`] = `
         </svg>
         <p class=\\"MuiTypography-root u-mt-half MuiTypography-body1\\">Google</p>
       </div>
-      <div class=\\"u-ta-center u-mb-1\\"><svg class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
+      <div class=\\"u-ta-center u-mb-1\\"><svg viewBox=\\"0 0 44 44\\" class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
           <g fill=\\"none\\" fill-rule=\\"evenodd\\">
             <rect width=\\"27.5\\" height=\\"32.5\\" x=\\"1.25\\" y=\\"1.25\\" fill=\\"#D9DDE1\\" rx=\\"2\\"></rect>
             <path fill=\\"#95999D\\" d=\\"M4.74 1.45l13.75 5.91A2.5 2.5 0 0120 9.65v27.61a2.5 2.5 0 01-3.49 2.29L2.76 33.64a2.49 2.49 0 01-1.51-2.29V3.74a2.5 2.5 0 013.49-2.29z\\"></path>


### PR DESCRIPTION
To allow a custom icon or even a grid of icon to be displayed

This prop will be used to display category candidates (with a grid of icons) and the exit button with a custom icon on the home application.

![image](https://user-images.githubusercontent.com/228695/141433951-fd1d4326-116d-4f6a-a5e1-c6f5c0f438a9.png)


- [ X] [Deployed the styleguidist](https://refined-github-html-preview.kidonng.workers.dev/doubleface/cozy-ui/raw/gh-pages/react/index.html#!/SquareAppIcon)
- [ ] Did you think of ARIA attributes if you are coding new components ?
