### PR TITLE
feat: Do not use backdrop-filter on SquareAppIcon anymore

### DIFF
--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
+export const SquareAppIcon = ({ app, type, name, variant, IconContent }) => {
   const classes = useStyles()
   const appName = name || (app && app.name) || app || ''
   const letter = appName[0] || ''
@@ -119,7 +119,7 @@ export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
               ) : IconContent ? (
                 IconContent
               ) : (
-                <AppIcon app={app} />
+                <AppIcon app={app} type={type} />
               )}
             </div>
           )}
@@ -146,7 +146,8 @@ SquareAppIcon.propTypes = {
     'add',
     'shortcut'
   ]),
-  IconContent: PropTypes.node
+  IconContent: PropTypes.node,
+  type: PropTypes.oneOf(['app', 'konnector'])
 }
 
 export default SquareAppIcon

--- a/react/SquareAppIcon/styles.styl
+++ b/react/SquareAppIcon/styles.styl
@@ -32,14 +32,11 @@ $color = constants['color'] // hard-coded color, because the component is curren
 .SquareAppIcon-wrapper-fx
     background-color alpha($color, .32)
     border 1px dashed var(--white)
-    @supports not (backdrop-filter: blur(48px))
-        background-color alpha($color, .48)
-    .SquareAppIcon-icon-container
-        backdrop-filter blur(48px)
+    background-color alpha($color, .48)
 
 .SquareAppIcon-wrapper-ghost
     .SquareAppIcon-icon-container
-        mix-blend-mode screen // need to apply backdrop-filter and mix blend-mode in a separated element to have the proper effect
+        mix-blend-mode screen
         svg, img
             filter saturate(0%)
 


### PR DESCRIPTION
This css rule leads to a blurry display on webkit browsers when use
transform: scale on the icon

With use the default behavior instead, which was already used on on
firefox which does not support backdrop-filter yet.

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.