### PR TITLE
feat: Add type prop to SquareAppIcon

### DIFF
--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
+export const SquareAppIcon = ({ app, type, name, variant, IconContent }) => {
   const classes = useStyles()
   const appName = name || (app && app.name) || app || ''
   const letter = appName[0] || ''
@@ -119,7 +119,7 @@ export const SquareAppIcon = ({ app, name, variant, IconContent }) => {
               ) : IconContent ? (
                 IconContent
               ) : (
-                <AppIcon app={app} />
+                <AppIcon app={app} type={type} />
               )}
             </div>
           )}
@@ -146,7 +146,8 @@ SquareAppIcon.propTypes = {
     'add',
     'shortcut'
   ]),
-  IconContent: PropTypes.node
+  IconContent: PropTypes.node,
+  type: PropTypes.oneOf(['app', 'konnector'])
 }
 
 export default SquareAppIcon


### PR DESCRIPTION
This property is based on AppIcon's type property

It is needed to force the type of konnector icons, or else AppIcon will
try to get their icon from the stack first with the wrong app type
This leads to lots of 404 errors in the home application.

Only after that, AppIcon tries to get the icon from the registry and
succeeds.
