### PR TITLE
feat: Add appIconProps to SquareAppIcon

### DIFF
--- a/react/SquareAppIcon/Readme.md
+++ b/react/SquareAppIcon/Readme.md
@@ -10,6 +10,7 @@ import { useCozyTheme } from 'cozy-ui/transpiled/react/CozyTheme'
 import cloudWallpaper from '../../docs/cloud-wallpaper.jpg'
 
 const theme = useCozyTheme()
+const app = { name: "Test App", slug: "testapp", type: "app" }
 
 ;
 
@@ -17,13 +18,13 @@ const theme = useCozyTheme()
 <Grid container spacing={1} style={{ background: `center / cover no-repeat url(${cloudWallpaper})` }}
 >
   <Grid item>
-    <SquareAppIcon app="testapp" name="Normal" />
+    <SquareAppIcon app={app} name="Normal" />
   </Grid>
   <Grid item>
-    <SquareAppIcon app="testapp" name="Maintenance" variant="maintenance" />
+    <SquareAppIcon app={app} name="Maintenance" variant="maintenance" />
   </Grid>
   <Grid item>
-    <SquareAppIcon app="testapp" name="Error" variant="error" />
+    <SquareAppIcon app={app} name="Error" variant="error" />
   </Grid>
   <Grid item>
     <SquareAppIcon name="Add" variant="add" />

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -2,13 +2,13 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/styles'
+import get from 'lodash/get'
 
 import AppIcon from '../AppIcon'
 import Badge from '../Badge'
 import InfosBadge from '../InfosBadge'
 import { nameToColor } from '../Avatar'
 import Typography from '../Typography'
-import { AppDoctype } from '../proptypes'
 import Icon from '../Icon'
 import iconPlus from '../Icons/Plus'
 import iconWarning from '../Icons/WarningCircle'
@@ -61,9 +61,15 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export const SquareAppIcon = ({ app, type, name, variant, IconContent }) => {
+export const SquareAppIcon = ({
+  name,
+  variant,
+  IconContent,
+  ...appIconProps
+}) => {
   const classes = useStyles()
-  const appName = name || (app && app.name) || app || ''
+  const appName =
+    name || get(appIconProps, 'app.name') || get(appIconProps, 'app') || ''
   const letter = appName[0] || ''
 
   return (
@@ -119,7 +125,7 @@ export const SquareAppIcon = ({ app, type, name, variant, IconContent }) => {
               ) : IconContent ? (
                 IconContent
               ) : (
-                <AppIcon app={app} type={type} />
+                <AppIcon {...appIconProps} />
               )}
             </div>
           )}
@@ -137,7 +143,6 @@ export const SquareAppIcon = ({ app, type, name, variant, IconContent }) => {
 }
 
 SquareAppIcon.propTypes = {
-  app: PropTypes.oneOfType([AppDoctype, PropTypes.string]),
   name: PropTypes.string,
   variant: PropTypes.oneOf([
     'ghost',
@@ -146,8 +151,7 @@ SquareAppIcon.propTypes = {
     'add',
     'shortcut'
   ]),
-  IconContent: PropTypes.node,
-  type: PropTypes.oneOf(['app', 'konnector'])
+  IconContent: PropTypes.node
 }
 
 export default SquareAppIcon


### PR DESCRIPTION
To configure to behavior of AppIcon, in SquareAppIcon, we need access to
all AppIcon properties. SquareAppIcon does not have access to the
context of the app enough to make choices regarding :

Ex :
- priority : stack or registry, to avoid too many 404 requests
in the app

Now SquareAppIcon takes it's own properties and forwards the remaining
ones directly to AppIcon

This way, when the AppIcon changes, we do not need to change
SquareAppIcon.