### PR TITLE
fix: Replace jest function in documentation

### DIFF
--- a/react/Viewer/docs/DemoProvider.jsx
+++ b/react/Viewer/docs/DemoProvider.jsx
@@ -20,9 +20,9 @@ const demoFilesByClass = {
 const mockClient = {
   plugins: {
     realtime: {
-      subscribe: jest.fn(),
-      unsubscribe: jest.fn(),
-      unsubscribeAll: jest.fn()
+      subscribe: () => {},
+      unsubscribe: () => {},
+      unsubscribeAll: () => {}
     }
   },
   collection: () => ({


### PR DESCRIPTION
Fix of the documentation following this commit 621fe47