### PR TITLE
fix: BottomSheet no longer opens fully

### DIFF
--- a/react/Viewer/Footer/BottomSheetContent.jsx
+++ b/react/Viewer/Footer/BottomSheetContent.jsx
@@ -20,34 +20,41 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const BottomSheetContent = forwardRef(({ file, disableSharing }, ref) => {
-  const panelBlocks = getPanelBlocks({ panelBlocksSpecs, file })
-  const FileActionButton = isMobileApp() ? ForwardButton : DownloadButton
-  const styles = useStyles()
+const BottomSheetContent = forwardRef(
+  ({ file, disableSharing, contactsFullname }, ref) => {
+    const panelBlocks = getPanelBlocks({ panelBlocksSpecs, file })
+    const FileActionButton = isMobileApp() ? ForwardButton : DownloadButton
+    const styles = useStyles()
 
-  return (
-    <Stack
-      spacing="s"
-      className={cx('u-flex u-flex-column u-ov-hidden', styles.stack)}
-    >
-      <Paper className={'u-flex u-ph-1 u-pb-1'} elevation={2} square ref={ref}>
-        {!disableSharing && <Sharing file={file} />}
-        <FileActionButton file={file} />
-      </Paper>
-      {panelBlocks.map((PanelBlock, index) => (
+    return (
+      <Stack
+        spacing="s"
+        className={cx('u-flex u-flex-column u-ov-hidden', styles.stack)}
+      >
         <Paper
-          key={index}
-          elevation={index === panelBlocks.length - 1 ? 0 : 2}
+          className={'u-flex u-ph-1 u-pb-1'}
+          elevation={2}
           square
+          ref={ref}
         >
-          <Typography variant="h4" className={'u-pv-1 u-ph-1'}>
-            <PanelBlock file={file} />
-          </Typography>
+          {!disableSharing && <Sharing file={file} />}
+          <FileActionButton file={file} />
         </Paper>
-      ))}
-    </Stack>
-  )
-})
+        {panelBlocks.map((PanelBlock, index) => (
+          <Paper
+            key={index}
+            elevation={index === panelBlocks.length - 1 ? 0 : 2}
+            square
+          >
+            <Typography variant="h4" className={'u-pv-1 u-ph-1'}>
+              <PanelBlock file={file} contactsFullname={contactsFullname} />
+            </Typography>
+          </Paper>
+        ))}
+      </Stack>
+    )
+  }
+)
 
 BottomSheetContent.propTypes = {
   file: PropTypes.object.isRequired,

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -3,13 +3,19 @@ import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 
 import { isMobileApp } from 'cozy-device-helper'
+import { getReferencedBy, useQuery, models } from 'cozy-client'
 
+import { buildContactByIdsQuery } from '../queries'
 import { isValidForPanel } from '../helpers'
 import Sharing from './Sharing'
 import ForwardButton from './ForwardButton'
 import DownloadButton from './DownloadButton'
 import BottomSheetWrapper from './BottomSheetWrapper'
 import BottomSheetContent from './BottomSheetContent'
+
+const {
+  contact: { getDisplayName }
+} = models
 
 const useStyles = makeStyles(theme => ({
   footer: {
@@ -28,7 +34,23 @@ const FooterContent = ({ file, toolbarRef, disableSharing }) => {
   const FileActionButton = isMobileApp() ? ForwardButton : DownloadButton
   const actionButtonsRef = useRef()
 
-  if (isValidForPanel({ file })) {
+  const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(
+    ref => ref.id
+  )
+  const contactByIdsQuery = buildContactByIdsQuery(contactIds)
+  const { data: contactList } = useQuery(contactByIdsQuery.definition, {
+    ...contactByIdsQuery.options,
+    enabled: contactIds.length > 0
+  })
+
+  const contactsFullname = Array.isArray(contactList)
+    ? contactList.map(contact => `${getDisplayName(contact)}`).join(', ')
+    : ''
+
+  if (
+    isValidForPanel({ file }) &&
+    (contactsFullname || contactIds.length === 0)
+  ) {
     return (
       <BottomSheetWrapper
         file={file}
@@ -38,6 +60,7 @@ const FooterContent = ({ file, toolbarRef, disableSharing }) => {
         <BottomSheetContent
           file={file}
           disableSharing={disableSharing}
+          contactsFullname={contactsFullname}
           ref={actionButtonsRef}
         />
       </BottomSheetWrapper>

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -1,22 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { useQuery, models, getReferencedBy } from 'cozy-client'
+import { models } from 'cozy-client'
 
 import List from '../../MuiCozyTheme/List'
 import ListItem from '../../MuiCozyTheme/ListItem'
 import QualificationListItemText from './QualificationListItemText'
 import { withViewerLocales } from '../withViewerLocales'
-import { buildContactByIdsQuery } from '../queries'
 
 const {
-  contact: { getDisplayName },
   document: {
     locales: { getBoundT }
   }
 } = models
 
-const Qualification = ({ file = {}, t, f, lang }) => {
+const Qualification = ({ file = {}, contactsFullname, t, f, lang }) => {
   const scannerT = getBoundT(lang)
 
   const { name: filename, metadata = {} } = file
@@ -26,20 +24,6 @@ const Qualification = ({ file = {}, t, f, lang }) => {
     datetime,
     datetimeLabel
   } = metadata
-
-  const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(
-    ref => ref.id
-  )
-
-  const contactByIdsQuery = buildContactByIdsQuery(contactIds)
-  const { data: contactList } = useQuery(
-    contactByIdsQuery.definition,
-    contactByIdsQuery.options
-  )
-
-  const contactsFullname = Array.isArray(contactList)
-    ? contactList.map(contact => `${getDisplayName(contact)}`).join(', ')
-    : ''
 
   return (
     <List>


### PR DESCRIPTION
Moved the contact async fetch in the Qualification Panel to the FooterContent parent, this prevents `mui-bottom-sheet` from miscalculating one of its style variables.

Demo: https://merkur39.github.io/cozy-ui/react/#!/Viewer/1