### PR TITLE
fix: Handle context flow without undefined return

### DIFF
--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -62,13 +62,15 @@ export class AppLinker extends React.Component {
 
     if (isFlagshipApp()) {
       if (!context)
-        return console.warn(
+        console.warn(
           'FlagshipApp detected but no context found. Is the app wrapped in WebviewIntentProvider?'
         )
 
-      return {
-        onClick: () => context.call('openApp', href),
-        href: '#'
+      if (context) {
+        return {
+          onClick: () => context.call('openApp', href),
+          href: '#'
+        }
       }
     }
 


### PR DESCRIPTION
In some cases, the Applinker would throw when we just want a warning