### PR TITLE
Add `disableGutters` prop to CozyDialogs

### DIFF
--- a/react/CozyDialogs/ConfirmDialog.jsx
+++ b/react/CozyDialogs/ConfirmDialog.jsx
@@ -15,7 +15,8 @@ const ConfirmDialog = props => {
     dialogTitleProps,
     fullScreen,
     id,
-    dialogActionsProps
+    dialogActionsProps,
+    dialogContentProps
   } = useCozyDialog({ ...props, isFluidTitle: true })
 
   const onBackOrClose = onBack || onClose
@@ -40,7 +41,7 @@ const ConfirmDialog = props => {
           onClick={onBackOrClose}
         />
       )}
-      <DialogContent>
+      <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
           <div className="dialogTitleFluidContainer">
             <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>

--- a/react/CozyDialogs/ConfirmDialog.jsx
+++ b/react/CozyDialogs/ConfirmDialog.jsx
@@ -43,9 +43,11 @@ const ConfirmDialog = props => {
       )}
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
-          <div className="dialogTitleFluidContainer">
-            <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
-          </div>
+          {title && (
+            <div className="dialogTitleFluidContainer">
+              <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
+            </div>
+          )}
           {content}
           {actions && (
             <DialogActions

--- a/react/CozyDialogs/Dialog.jsx
+++ b/react/CozyDialogs/Dialog.jsx
@@ -42,8 +42,12 @@ const Dialog = props => {
           onClick={onBackOrClose}
         />
       )}
-      <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
-      <Divider />
+      {title && (
+        <>
+          <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
+          <Divider />
+        </>
+      )}
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
           {content}

--- a/react/CozyDialogs/Dialog.jsx
+++ b/react/CozyDialogs/Dialog.jsx
@@ -16,7 +16,8 @@ const Dialog = props => {
     dialogTitleProps,
     fullScreen,
     id,
-    dialogActionsProps
+    dialogActionsProps,
+    dialogContentProps
   } = useCozyDialog(props)
 
   const onBackOrClose = onBack || onClose
@@ -43,7 +44,7 @@ const Dialog = props => {
       )}
       <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
       <Divider />
-      <DialogContent>
+      <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
           {content}
           {actions && (

--- a/react/CozyDialogs/FixedActionsDialog.jsx
+++ b/react/CozyDialogs/FixedActionsDialog.jsx
@@ -16,7 +16,8 @@ const FixedActionsDialog = props => {
     dialogTitleProps,
     fullScreen,
     id,
-    dialogActionsProps
+    dialogActionsProps,
+    dialogContentProps
   } = useCozyDialog({ ...props, isFluidTitle: true })
 
   const onBackOrClose = onBack || onClose
@@ -41,7 +42,7 @@ const FixedActionsDialog = props => {
           onClick={onBackOrClose}
         />
       )}
-      <DialogContent>
+      <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner">
           <div className="dialogTitleFluidContainer">
             <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>

--- a/react/CozyDialogs/FixedActionsDialog.jsx
+++ b/react/CozyDialogs/FixedActionsDialog.jsx
@@ -44,9 +44,11 @@ const FixedActionsDialog = props => {
       )}
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner">
-          <div className="dialogTitleFluidContainer">
-            <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
-          </div>
+          {title && (
+            <div className="dialogTitleFluidContainer">
+              <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
+            </div>
+          )}
           {content}
         </div>
       </DialogContent>

--- a/react/CozyDialogs/FixedDialog.jsx
+++ b/react/CozyDialogs/FixedDialog.jsx
@@ -16,7 +16,8 @@ const FixedDialog = props => {
     dialogTitleProps,
     fullScreen,
     id,
-    dialogActionsProps
+    dialogActionsProps,
+    dialogContentProps
   } = useCozyDialog(props)
 
   const onBackOrClose = onBack || onClose
@@ -43,7 +44,7 @@ const FixedDialog = props => {
       )}
       <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
       <Divider />
-      <DialogContent>
+      <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner">{content}</div>
       </DialogContent>
       <Divider />

--- a/react/CozyDialogs/FixedDialog.jsx
+++ b/react/CozyDialogs/FixedDialog.jsx
@@ -42,8 +42,12 @@ const FixedDialog = props => {
           onClick={onBackOrClose}
         />
       )}
-      <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
-      <Divider />
+      {title && (
+        <>
+          <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
+          <Divider />
+        </>
+      )}
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner">{content}</div>
       </DialogContent>

--- a/react/CozyDialogs/IllustrationDialog.jsx
+++ b/react/CozyDialogs/IllustrationDialog.jsx
@@ -15,7 +15,8 @@ const IllustrationDialog = props => {
     dialogTitleProps,
     id,
     fullScreen,
-    dialogActionsProps
+    dialogActionsProps,
+    dialogContentProps
   } = useCozyDialog({ ...props, isFluidTitle: true })
 
   const onBackOrClose = onBack || onClose
@@ -40,7 +41,7 @@ const IllustrationDialog = props => {
           onClick={onBackOrClose}
         />
       )}
-      <DialogContent>
+      <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
           <DialogTitle {...dialogTitleProps}>
             <div className="u-flex u-flex-justify-center">{title}</div>

--- a/react/CozyDialogs/IllustrationDialog.jsx
+++ b/react/CozyDialogs/IllustrationDialog.jsx
@@ -43,9 +43,11 @@ const IllustrationDialog = props => {
       )}
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
-          <DialogTitle {...dialogTitleProps}>
-            <div className="u-flex u-flex-justify-center">{title}</div>
-          </DialogTitle>
+          {title && (
+            <DialogTitle {...dialogTitleProps}>
+              <div className="u-flex u-flex-justify-center">{title}</div>
+            </DialogTitle>
+          )}
           {content}
           {actions && (
             <DialogActions

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -23,6 +23,7 @@ Will automatically:
 * disableTitleAutoPadding : `<boolean>` (optional) Disable title padding calculation that would prevent overlapping with close and back buttons
   * if set to `true` then you should handle those CSS properties by yourself or title will take 100% of width
   * if set to `false` then title will take only available space between close and back buttons regarding which of `onClose` or `onBack` props are defined or not
+* disableGutters : `<boolean>` To disable the margins and paddings of the inner content
 * title : `<node>` Title of the modal
 * content : `<node>` Content of the modal
 * actions : `<node>` Actions of the modal
@@ -151,7 +152,8 @@ initialState = {
   content: 'default',
   theme: 'normal',
   align: 'middle',
-  showActions: true
+  showActions: true,
+  disableGutters: false
 }
 
 ;
@@ -196,6 +198,10 @@ initialState = {
       <StateRadio value='middle' name='align' /> middle
       <StateRadio value='top' name='align' /> top{' '}
     </p>
+    <p>Disable gutters (inner padding):
+      <StateRadio value={true} name='disableGutters' /> yes
+      <StateRadio value={false} name='disableGutters' /> no{' '}
+    </p>
     <DialogComponent
       size={DialogComponent !== ConfirmDialog ? state.size : undefined}
       open={state.modalOpened}
@@ -207,6 +213,7 @@ initialState = {
         ? `${dialogTitles[DialogComponent.name]} - ${content.ada.short}`
         : dialogTitles[DialogComponent.name]
       }
+      disableGutters={state.disableGutters}
       content={
         <Typography variant='body1' color='textPrimary'>
           { state.content == 'default'

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -1,10 +1,12 @@
 Pre-built modals ready to be directly used in applications, based on MUI Dialog.
 
-* Dialog : default Cozy modal
-* ConfirmDialog : used for confirmation popups
-* IllustrationDialog : used for illustration as title
-* FixedDialog : default one but with both title/actions fixed
-* FixedActionsDialog : default one but with title fluid and actions fixed
+### Usage
+
+* **Dialog** : default Cozy modal
+* **ConfirmDialog** : used for confirmation popups
+* **IllustrationDialog** : used for illustration as title
+* **FixedDialog** : default one but with both title/actions fixed
+* **FixedActionsDialog** : default one but with title fluid and actions fixed
 
 Will automatically:
 
@@ -13,23 +15,25 @@ Will automatically:
 
 ### Props
 
-* size : `<string>` Can be "s", "m" (default) or "l"
-* opened : `<boolean>` (required) To open/close the modal
-* onClose : `<function>` (required) Triggered function on modal close action
-* onBack : `<function>` (optional) Triggered function on modal back action
+* **size** : `<string>` – Can be "s", "m" (default) or "l"
+* **open** : `<boolean>` (required) – To open/close the modal
+* **onClose** : `<function>` (required) – Triggered function on modal close action
+* **onBack** : `<function>` (optional) – Triggered function on modal back action
   * if defined and in desktop mode then a back button is shown in addition to the close button and it will trigger onBack() on click
   * if defined and in mobile mode then the back button will trigger onBack() instead of onClose()
   * if not defined and in mobile mode then the back button will trigger onClose()
-* disableTitleAutoPadding : `<boolean>` (optional) Disable title padding calculation that would prevent overlapping with close and back buttons
+* **disableTitleAutoPadding** : `<boolean>` (optional) – Disable title padding calculation that would prevent overlapping with close and back buttons
   * if set to `true` then you should handle those CSS properties by yourself or title will take 100% of width
   * if set to `false` then title will take only available space between close and back buttons regarding which of `onClose` or `onBack` props are defined or not
-* disableGutters : `<boolean>` To disable the margins and paddings of the inner content
-* title : `<node>` Title of the modal
-* content : `<node>` Content of the modal
-* actions : `<node>` Actions of the modal
-* actionsLayout : `<string>` Can be "row" or "column"
+* **disableGutters** : `<boolean>` – To disable the margins and paddings of the inner content
+* **title** : `<node>` – Title of the modal
+* **content** : `<node>` – Content of the modal
+* **actions** : `<node>` – Actions of the modal
+* **actionsLayout** : `<string>` – Can be "row" or "column"
 
 Additionally, all the CozyDialogs support [MUI Dialog's props](https://v3.material-ui.com/api/dialog/).
+
+### Exemples
 
 ```jsx
 import {

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -153,7 +153,8 @@ initialState = {
   theme: 'normal',
   align: 'middle',
   showActions: true,
-  disableGutters: false
+  disableGutters: false,
+  hideTitle: false
 }
 
 ;
@@ -175,6 +176,10 @@ initialState = {
     <p>Title:
       <StateRadio value='short' name='title' /> short{' '}
       <StateRadio value='long' name='title' /> long
+    </p>
+    <p>Hide title:
+      <StateRadio value={true} name='hideTitle' /> yes{' '}
+      <StateRadio value={false} name='hideTitle' /> no
     </p>
     <p>Content:
       <StateRadio value='default' name='content' /> default{' '}
@@ -209,9 +214,11 @@ initialState = {
       onBack={state.withBackButton ? handleBack : undefined}
       disableTitleAutoPadding={state.disableTitleAutoPadding}
       align={state.align}
-      title={DialogComponent !== IllustrationDialog && state.title === "long"
-        ? `${dialogTitles[DialogComponent.name]} - ${content.ada.short}`
-        : dialogTitles[DialogComponent.name]
+      title={state.hideTitle
+        ? undefined
+        : DialogComponent !== IllustrationDialog && state.title === "long"
+          ? `${dialogTitles[DialogComponent.name]} - ${content.ada.short}`
+          : dialogTitles[DialogComponent.name]
       }
       disableGutters={state.disableGutters}
       content={

--- a/react/CozyDialogs/useCozyDialog.js
+++ b/react/CozyDialogs/useCozyDialog.js
@@ -27,6 +27,7 @@ const useCozyDialog = props => {
     align,
     disableTitleAutoPadding,
     isFluidTitle,
+    disableGutters,
     ...otherProps
   } = props
   const { isMobile } = useBreakpoints()
@@ -91,6 +92,14 @@ const useCozyDialog = props => {
     }
   }
 
+  const dialogContentProps = {
+    classes: {
+      root: cx({
+        disableGutters
+      })
+    }
+  }
+
   return {
     dialogProps,
     dialogTitleProps,
@@ -98,7 +107,8 @@ const useCozyDialog = props => {
     id,
     fullScreen,
     dividerProps,
-    dialogActionsProps
+    dialogActionsProps,
+    dialogContentProps
   }
 }
 

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -442,6 +442,17 @@ const makeOverrides = theme => ({
       [theme.breakpoints.down('sm')]: {
         padding: '24px 16px 0'
       },
+      '&.disableGutters': {
+        padding: 0,
+        '& .dialogContentInner': {
+          marginBottom: 0
+        },
+        '& .dialogTitleFluidContainer': {
+          marginLeft: 0,
+          marginRight: 0,
+          marginTop: 0
+        }
+      },
       '& .dialogContentInner': {
         marginBottom: '24px',
         '&.withFluidActions': {


### PR DESCRIPTION
to be able to disable inner padding and margin
and then show content fullwidth for exemple.
The name 'disableGutters' comes from Mui