### PR TITLE
feat: Add `titleRef` on CozyDialogs

### DIFF
--- a/react/CozyDialogs/useCozyDialog.js
+++ b/react/CozyDialogs/useCozyDialog.js
@@ -28,6 +28,7 @@ const useCozyDialog = props => {
     disableTitleAutoPadding,
     isFluidTitle,
     disableGutters,
+    titleRef,
     ...otherProps
   } = props
   const { isMobile } = useBreakpoints()
@@ -62,6 +63,7 @@ const useCozyDialog = props => {
 
   const dialogTitleProps = {
     id: `modal-title-${id}`,
+    ref: titleRef,
     disableTypography: true,
     className: cx({
       'u-ellipsis': !isFluidTitle,


### PR DESCRIPTION
to be able to catch dialogTitle ref, in order to compute its height for exemple. Could be useful to determine the maximum height of a bottomSheet inside the dialog