### PR TITLE
fix: Bump cozy-device-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
   "peerDependencies": {
     "@material-ui/core": "4",
     "cozy-client": ">=27.5.1",
-    "cozy-device-helper": "^1.10.0",
+    "cozy-device-helper": "^1.16.0",
     "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",
     "cozy-intent": ">=1.3.0",


### PR DESCRIPTION
Version 1.16.0 is required for cozy-intent and other contexts when requiring information about the presence of a
in-webview render. DevDependencies were up-to-date but peerDependencies were not updated at the time