### PR TITLE
fix: PreventDefault on cozy-intent event

### DIFF
--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -85,7 +85,10 @@ export class AppLinker extends React.Component {
 
       if (context) {
         return {
-          onClick: () => context.call('openApp', href, app),
+          onClick: event => {
+            event.preventDefault()
+            context.call('openApp', href, app)
+          },
           href: '#'
         }
       }


### PR DESCRIPTION
We had unwanted rerenders on HomeView in AA application. It was pretty hard to pinpoint the source of the bug because I was looking in the wrong direction, eg React Native. The issue was caused by a simple e.preventDefault() missing in AppLinker. Indeed, without this, each time we sent a message we also refreshed the page (default behavior of `#` href).