### PR TITLE
feat: Add WebviewProvider in BarProvider

### DIFF
--- a/react/BarContextProvider/index.jsx
+++ b/react/BarContextProvider/index.jsx
@@ -4,6 +4,7 @@ import { BreakpointsProvider } from '../hooks/useBreakpoints'
 
 import { CozyProvider } from 'cozy-client'
 import { Provider } from 'react-redux'
+import { WebviewIntentProvider } from 'cozy-intent'
 
 const BarContextProvider = props => {
   if (!props.children) return null
@@ -13,7 +14,9 @@ const BarContextProvider = props => {
         <I18nContext.Provider
           value={{ f: props.f, t: props.t, lang: props.lang }}
         >
-          <BreakpointsProvider>{props.children}</BreakpointsProvider>
+          <BreakpointsProvider>
+            <WebviewIntentProvider>{props.children}</WebviewIntentProvider>
+          </BreakpointsProvider>
         </I18nContext.Provider>
       </CozyProvider>
     </Provider>

--- a/react/BarContextProvider/index.spec.jsx
+++ b/react/BarContextProvider/index.spec.jsx
@@ -7,9 +7,14 @@ import CozyClient, {
 } from 'cozy-client'
 import configureStore from 'redux-mock-store'
 import { Provider, useStore } from 'react-redux'
+import { isFlagshipApp } from 'cozy-device-helper'
 
 import BarContextProvider from '.'
 import I18n, { useI18n, translate } from '../I18n'
+
+jest.mock('cozy-device-helper', () => ({
+  isFlagshipApp: jest.fn()
+}))
 
 const locales = { helloworld: 'Hello World !' }
 const localesBar = { a: 'b' }
@@ -63,5 +68,25 @@ describe('BarContextProvider', () => {
       </Provider>
     )
     expect(root.html()).toBe('<div>Hello World !<br>6 Jan<br>en</div>')
+  })
+
+  it('should try to provide a cozy-intent context', async () => {
+    const client = createMockClient({})
+    const mockStore = configureStore()
+    const store = mockStore(x => x)
+    mount(
+      <Provider store={store}>
+        <CozyProvider client={client}>
+          <I18n lang="en" dictRequire={() => locales}>
+            <App />
+          </I18n>
+        </CozyProvider>
+      </Provider>
+    )
+
+    // Currently only the WebviewProvider should call this function in BarContext
+    // This is an easy way to test that the provider is working, albeit brittle
+    // A full test would need to mock cozy-intent, post-me and react-native
+    expect(isFlagshipApp).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Simply wrap BarContext children with WebviewIntentProvider. This will not break apps not rendered in a webview, as per the test ensures.