### PR TITLE
feat: BottomSheet settings accept `mediumHeight` new prop

### DIFF
--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -37,7 +37,8 @@ export const defaultBottomSheetSpringConfig = {
 }
 
 const defaultSettings = {
-  mediumHeightRatio: 0.33
+  mediumHeightRatio: 0.33,
+  mediumHeight: null
 }
 
 const computeMaxHeight = toolbarProps => {
@@ -54,17 +55,22 @@ const computeMaxHeight = toolbarProps => {
 }
 
 const BottomSheet = ({ toolbarProps, settings, children }) => {
+  const { mediumHeightRatio, mediumHeight } = useMemo(
+    () => ({
+      ...defaultSettings,
+      ...settings
+    }),
+    [settings]
+  )
+
   const innerContentRef = useRef()
   const headerRef = useRef()
   const headerContentRef = useRef()
   const [isTopPosition, setIsTopPosition] = useState(false)
   const [peekHeights, setPeekHeights] = useState(null)
-  const [initPos, setInitPos] = useState(null)
   const [bottomSpacerHeight, setBottomSpacerHeight] = useState(0)
+  const [initPos, setInitPos] = useState(mediumHeight)
 
-  const { mediumHeightRatio } = useMemo(() => settings || defaultSettings, [
-    settings
-  ])
   const styles = useMemo(() => makeStyles({ isTopPosition }), [isTopPosition])
 
   // hack to prevent pull-down-to-refresh behavior when dragging down the bottom sheet.
@@ -79,7 +85,8 @@ const BottomSheet = ({ toolbarProps, settings, children }) => {
   useEffect(() => {
     const headerContent = headerContentRef.current
     const maxHeight = computeMaxHeight(toolbarProps)
-    const mediumHeight = Math.round(maxHeight * mediumHeightRatio)
+    const computedMediumHeight =
+      mediumHeight || Math.round(maxHeight * mediumHeightRatio)
 
     const actionButtonsHeight = headerContent
       ? parseFloat(getComputedStyle(headerContent).getPropertyValue('height'))
@@ -98,14 +105,15 @@ const BottomSheet = ({ toolbarProps, settings, children }) => {
     // without stopping at the content height
     const bottomSpacerHeight = maxHeight - innerContentRef.current.offsetHeight
 
-    setPeekHeights([minHeight, mediumHeight, maxHeight])
-    setInitPos(mediumHeight)
+    setPeekHeights([minHeight, computedMediumHeight, maxHeight])
+    setInitPos(computedMediumHeight)
     setBottomSpacerHeight(bottomSpacerHeight)
   }, [
     innerContentRef,
     headerContentRef.current,
     toolbarProps,
-    mediumHeightRatio
+    mediumHeightRatio,
+    mediumHeight
   ])
 
   const handleOnIndexChange = snapIndex => {

--- a/react/BottomSheet/README.md
+++ b/react/BottomSheet/README.md
@@ -1,4 +1,4 @@
-Displays content coming up from the bottom of the screen. The pane can be swiped to the top of the screen.
+Displays content coming up from the bottom of the screen. The pane can be swiped to the top of the screen. [API documentation is here](https://github.com/cozy/mui-bottom-sheet#props-options)
 
 ```jsx
 import BottomSheet, { BottomSheetItem, BottomSheetHeader } from 'cozy-ui/transpiled/react/BottomSheet'
@@ -8,7 +8,7 @@ import Button from 'cozy-ui/transpiled/react/Buttons'
 initialState = { isBottomSheetDisplayed: isTesting() }
 const showBottomSheet = () => setState({ isBottomSheetDisplayed: true })
 
-const settings = { mediumHeightRatio: isTesting() ? 0.90 : 0.33 }
+const settings = isTesting() ? { mediumHeight: 450 } : undefined
 // -->
 
 ;


### PR DESCRIPTION
To set the height of the middle snap point

Ca permet de forcer une hauteur spécifique pour le point d'ancrage du milieu.

En settant une valeur, il n'y a plus l'effet d'animation car le premier render n'est plus fait avec une hauteur null. Et comme il n'y a plus d'animation, les screenshot argos seront toujours les mêmes.

fix https://github.com/cozy/cozy-ui/issues/2023

=> https://jf-cozy.github.io/cozy-ui/react/#!/BottomSheet