### PR TITLE
fix(UploadQueue): UploadQueue manage internationalized progress message

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,9 @@ When sending a PR, if your changes have graphic impacts, it is useful for the re
 you have deployed a version of the styleguidist containing your changes to your fork's repository.
 
 ```bash
-yarn build:doc:react
+yarn build
+yarn build:css:all
+yarn build:doc
 yarn deploy:doc --repo git@github.com:USERNAME/cozy-ui.git
 ```
 

--- a/react/I18n/format.jsx
+++ b/react/I18n/format.jsx
@@ -1,12 +1,15 @@
 import format from 'date-fns/format'
 import { DEFAULT_LANG } from '.'
+import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
+
+const locales = {}
+let lang = DEFAULT_LANG
 
 const getWarningMessage = lang =>
   `The "${lang}" locale isn't supported by date-fns. or has not been included in the build. Check if you have configured a ContextReplacementPlugin that is too restrictive.`
 
-export const initFormat = (lang, defaultLang = DEFAULT_LANG) => {
-  const locales = {}
-
+export const provideDateFnsLocale = (userLang, defaultLang = DEFAULT_LANG) => {
+  lang = userLang
   try {
     locales[defaultLang] = require(`date-fns/locale/${defaultLang}/index.js`)
   } catch (err) {
@@ -20,5 +23,16 @@ export const initFormat = (lang, defaultLang = DEFAULT_LANG) => {
       console.warn(getWarningMessage(lang))
     }
   }
-  return (date, formatStr) => format(date, formatStr, { locale: locales[lang] })
+  return locales[lang]
 }
+
+export const initFormat = (userLang, defaultLang = DEFAULT_LANG) => (
+  date,
+  formatStr
+) => {
+  const locale = provideDateFnsLocale(userLang, defaultLang)
+  return format(date, formatStr, { locale })
+}
+
+export const formatLocallyDistanceToNow = date =>
+  formatDistanceToNow(date, { locale: locales[lang] })

--- a/react/I18n/format.spec.jsx
+++ b/react/I18n/format.spec.jsx
@@ -1,4 +1,4 @@
-import { initFormat } from './format'
+import { initFormat, formatLocallyDistanceToNow } from './format'
 
 describe('initFormat', () => {
   beforeEach(() => {
@@ -9,5 +9,39 @@ describe('initFormat', () => {
   })
   it('should not throw if a date-fns locale can not be found', () => {
     expect(() => initFormat('unknown-lang', 'unknown-default')).not.toThrow()
+  })
+})
+
+describe('formatLocallyDistanceToNow', () => {
+  it('should formatDistanceToNow with small value', () => {
+    const date = Date.now() + 29 * 1000
+
+    const result = formatLocallyDistanceToNow(date)
+
+    expect(result).toEqual('less than a minute')
+  })
+
+  it('should formatDistanceToNow with medium value', () => {
+    const date = Date.now() + 2671 * 1000
+
+    const result = formatLocallyDistanceToNow(date)
+
+    expect(result).toEqual('about 1 hour')
+  })
+
+  it('should formatDistanceToNow with high value', () => {
+    const date = Date.now() + 5371 * 1000
+
+    const result = formatLocallyDistanceToNow(date)
+
+    expect(result).toEqual('about 2 hours')
+  })
+
+  it('should not throw if a date-fns locale can not be found', () => {
+    jest.spyOn(console, 'warn').mockImplementation()
+
+    expect(() => formatLocallyDistanceToNow('unknown-lang')).not.toThrow()
+
+    console.warn.mockRestore()
   })
 })

--- a/react/UploadQueue/Readme.md
+++ b/react/UploadQueue/Readme.md
@@ -12,6 +12,7 @@ the upload queue:
 ```jsx
 import isTesting from '../helpers/isTesting'
 import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
+import UploadQueue from 'cozy-ui/transpiled/react/UploadQueue';
 
 const initialState = {
   popover: false
@@ -51,7 +52,7 @@ const data = {
 };
 
 <>
-  popover: <input type="checkbox" value={state.popover} onChange={() => setState({ popover: !state.popover })} />
+  popover: <input type="checkbox" value={state.popover} onChange={() => setState({ popover: !state.popover })}/>
   <UploadQueue
     lang='fr'
     app='Cozy Drive'

--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import cx from 'classnames'
 import { withStyles } from '@material-ui/core/styles'
 import LinearProgress from '@material-ui/core/LinearProgress'
-import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
 
 import { splitFilename } from 'cozy-client/dist/models/file'
 
@@ -25,6 +24,7 @@ import styles from './styles.styl'
 import localeEn from './locales/en.json'
 import localeEs from './locales/es.json'
 import localeFr from './locales/fr.json'
+import { formatLocallyDistanceToNow } from '../I18n/format'
 
 const locales = {
   en: localeEn,
@@ -64,20 +64,26 @@ const Pending = translate()(props => (
   </Typography>
 ))
 
-const formatRemainingTime = durationInSec => {
+export const formatRemainingTime = durationInSec => {
   const later = Date.now() + durationInSec * 1000
-  return formatDistanceToNow(later)
+  return formatLocallyDistanceToNow(later)
 }
+
+// https://date-fns.org/v2.28.0/docs/formatDistanceToNow
+const numberOfReferencesForPluralForm = durationInSec =>
+  durationInSec < 90 || (durationInSec > 2670 && durationInSec < 5370) ? 1 : 2
 
 const RemainingTime = ({ durationInSec }) => {
   const { t } = useI18n()
+
   return (
     <Typography
       variant="caption"
       className={cx(styles['upload-queue__progress-caption'], 'u-ellipsis')}
     >
       {t('item.remainingTime', {
-        time: formatRemainingTime(durationInSec)
+        time: formatRemainingTime(durationInSec),
+        smart_count: numberOfReferencesForPluralForm(durationInSec)
       })}
     </Typography>
   )
@@ -127,7 +133,7 @@ const Item = translate()(
     let done = false
     let error = false
     /**
-     * Status cames from the Upload Queue, but sometimes we're using
+     * Status came from the Upload Queue, but sometimes we're using
      * manual upload without using the Upload Queue system but we're still
      * using the UI component. When this is the case, the file handles on
      * his own its status.
@@ -210,7 +216,7 @@ const Item = translate()(
   }
 )
 
-class UploadQueue extends Component {
+export class UploadQueue extends Component {
   state = {
     collapsed: false
   }
@@ -256,7 +262,7 @@ class UploadQueue extends Component {
               >
                 {t('header_mobile', {
                   done: doneCount,
-                  total: queue.length
+                  smart_count: queue.length
                 })}
               </Typography>
             </div>
@@ -269,7 +275,7 @@ class UploadQueue extends Component {
               <Typography variant="h6">
                 {t('header_done', {
                   done: successCount,
-                  total: queue.length
+                  smart_count: queue.length
                 })}
               </Typography>
               <Button

--- a/react/UploadQueue/index.spec.jsx
+++ b/react/UploadQueue/index.spec.jsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { UploadQueue, formatRemainingTime } from './index'
+import { render } from '@testing-library/react'
+import { useI18n } from '../I18n'
+
+jest.mock('../I18n/withLocales', () =>
+  jest.fn().mockImplementation(() => x => x)
+)
+
+jest.mock('../I18n', () => ({
+  translate: jest.fn().mockImplementation(() => x => x),
+  useI18n: jest.fn(),
+  DEFAULT_LANG: 'en'
+}))
+
+describe('UploadQueue', () => {
+  describe('formatRemainingTime', () => {
+    it('should return correct remaining time', () => {
+      const time = formatRemainingTime(29)
+
+      expect(time).toEqual('less than a minute')
+    })
+  })
+
+  describe('UploadQueue', () => {
+    beforeEach(() => {
+      useI18n.mockReturnValue({
+        t: (key, format) =>
+          format ? `${key} ${format.time} ${format.smart_count}` : key
+      })
+    })
+    it('should set singular value when "1 minute remaining"', () => {
+      const item = {
+        file: { name: 'file' },
+        status: 'status',
+        isDirectory: 'isDirectory',
+        progress: { loaded: 1234, total: 5678, remainingTime: 89 },
+        getMimeTypeIcon: 'getMimeTypeIcon'
+      }
+
+      const { container } = render(<UploadQueue queue={[item]} />)
+
+      expect(
+        container.getElementsByClassName('u-flex-shrink')[0]
+      ).toHaveTextContent('item.remainingTime 1 minute 1')
+    })
+
+    it('should set singular value when "moins d 1 minute remaining"', () => {
+      const item = {
+        file: { name: 'file' },
+        status: 'status',
+        isDirectory: 'isDirectory',
+        progress: { loaded: 1234, total: 5678, remainingTime: 29 },
+        getMimeTypeIcon: 'getMimeTypeIcon'
+      }
+
+      const { container } = render(<UploadQueue queue={[item]} />)
+
+      expect(
+        container.getElementsByClassName('u-flex-shrink')[0]
+      ).toHaveTextContent('item.remainingTime less than a minute 1')
+    })
+
+    it('should set plural value when "44 minutes remainings"', () => {
+      const item = {
+        file: { name: 'file' },
+        status: 'status',
+        isDirectory: 'isDirectory',
+        progress: { loaded: 1234, total: 5678, remainingTime: 2669 },
+        getMimeTypeIcon: 'getMimeTypeIcon'
+      }
+
+      const { container } = render(<UploadQueue queue={[item]} />)
+
+      expect(
+        container.getElementsByClassName('u-flex-shrink')[0]
+      ).toHaveTextContent('item.remainingTime 44 minutes 2')
+    })
+
+    it('should set singular value when "1 hour remaining" - low limit', () => {
+      const item = {
+        file: { name: 'file' },
+        status: 'status',
+        isDirectory: 'isDirectory',
+        progress: { loaded: 1234, total: 5678, remainingTime: 2671 },
+        getMimeTypeIcon: 'getMimeTypeIcon'
+      }
+
+      const { container } = render(<UploadQueue queue={[item]} />)
+
+      expect(
+        container.getElementsByClassName('u-flex-shrink')[0]
+      ).toHaveTextContent('item.remainingTime about 1 hour 1')
+    })
+
+    it('should set singular value when "about 1 hour remaining" - high limit', () => {
+      const item = {
+        file: { name: 'file' },
+        status: 'status',
+        isDirectory: 'isDirectory',
+        progress: { loaded: 1234, total: 5678, remainingTime: 5369 },
+        getMimeTypeIcon: 'getMimeTypeIcon'
+      }
+
+      const { container } = render(<UploadQueue queue={[item]} />)
+
+      expect(
+        container.getElementsByClassName('u-flex-shrink')[0]
+      ).toHaveTextContent('item.remainingTime about 1 hour 1')
+    })
+
+    it('should set plural value when more than "2 hours remainings"', () => {
+      const item = {
+        file: { name: 'file' },
+        status: 'status',
+        isDirectory: 'isDirectory',
+        progress: { loaded: 1234, total: 5678, remainingTime: 5371 },
+        getMimeTypeIcon: 'getMimeTypeIcon'
+      }
+
+      const { container } = render(<UploadQueue queue={[item]} />)
+
+      expect(
+        container.getElementsByClassName('u-flex-shrink')[0]
+      ).toHaveTextContent('item.remainingTime about 2 hours 2')
+    })
+  })
+})

--- a/react/UploadQueue/locales/en.json
+++ b/react/UploadQueue/locales/en.json
@@ -1,7 +1,7 @@
 {
   "header": "Uploading %{smart_count} photo to %{app} |||| Uploading %{smart_count} photos to %{app}",
-  "header_mobile": "Uploading %{done} of %{total}",
-  "header_done": "Uploaded %{done} out of %{total} successfully",
+  "header_mobile": "Uploading %{done} of %{smart_count}",
+  "header_done": "Uploaded %{done} out of %{smart_count} successfully",
   "close": "close",
   "item": {
     "pending": "Pending",

--- a/react/UploadQueue/locales/es.json
+++ b/react/UploadQueue/locales/es.json
@@ -1,9 +1,10 @@
 {
   "header": "Subiendo %{smart_count} foto a %{app} |||| Subiendo %{smart_count} fotos a %{app}",
-  "header_mobile": "Subiendo %{done} de %{total}",
-  "header_done": "Subidos %{done} de %{total} con éxito",
+  "header_mobile": "Subiendo %{done} de %{smart_count}",
+  "header_done": "Subidos %{done} de %{smart_count} con éxito",
   "close": "cerrar",
   "item": {
-    "pending": "Pendiente"
+    "pending": "Pendiente",
+    "remainingTime": "%{time} restante |||| %{time} restantes"
   }
 }

--- a/react/UploadQueue/locales/fr.json
+++ b/react/UploadQueue/locales/fr.json
@@ -1,10 +1,10 @@
 {
   "header": "Import de %{smart_count} fichier dans votre Cozy |||| Import de %{smart_count} fichiers dans votre Cozy",
-  "header_mobile": "Import de %{done} sur %{total}",
-  "header_done": "%{done} sur %{total} élément(s) importé(s)",
+  "header_mobile": "Import de %{done} sur %{smart_count}",
+  "header_done": "%{done} sur %{smart_count} élément importé |||| %{done} sur %{smart_count} éléments importés",
   "close": "Fermer",
   "item": {
     "pending": "En attente",
-    "remainingTime": "%{time} restantes"
+    "remainingTime": "%{time} restante |||| %{time} restantes"
   }
 }


### PR DESCRIPTION
`initFormat` used to specify the language for the `format` method of date-fns.
however `formatDistanceToNow` needs also to specify the lang to correctly translate.
That's why the `initFormat` method has been split in order to init the locale first inside a singleton, and then provide to any format of date-fns a locale.