### PR TITLE
fix(upload): Make progress bar size fixed

### DIFF
--- a/react/UploadQueue/index.jsx
+++ b/react/UploadQueue/index.jsx
@@ -110,7 +110,7 @@ const QueueLinearProgress = withStyles({
 const FileUploadProgress = ({ progress }) => {
   return (
     <div className={styles['upload-queue__upload-progress']}>
-      <div className="u-flex-grow-1 u-pr-1">
+      <div className={styles['upload-queue__progress-container']}>
         <FileLinearProgress
           variant="determinate"
           value={(progress.loaded / progress.total) * 100}

--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -25,11 +25,15 @@ $coz-bar-size=3rem
     line-height $caption-font-size
     height 1rem
 
+.upload-queue__progress-container
+    min-width       14rem
+    flex-grow       1
+    padding-right   1rem
+
 .upload-queue__upload-progress
-    align-items center
+    align-items     center
     display flex
     margin-top 0.125rem // Must tweak a bit the margin-top
-
 
 .upload-queue--popover
     z-index           $popover-index


### PR DESCRIPTION
Remaining time changes regularly
that used to impact size of progress bar

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.

https://trollepierre.github.io/cozy-ui/react/#!/UploadQueue
