### PR TITLE
fix(Grid): Use justifyContent props inside Grid component

### DIFF
--- a/react/Banner/index.jsx
+++ b/react/Banner/index.jsx
@@ -34,7 +34,7 @@ const Banner = ({
           className={cx(styles['c-banner-wrapper'], className)}
           style={bgcolor && { backgroundColor: bgcolor }}
         >
-          <Grid container justify="space-between">
+          <Grid container justifyContent="space-between">
             <Grid
               container
               item

--- a/react/Banner/index.spec.jsx
+++ b/react/Banner/index.spec.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Banner from './index'
+
+describe('Grid', () => {
+  it('should render correctly justify content', () => {
+    // Given
+    console.error = jest.fn()
+
+    // When
+    const { container } = render(<Banner />)
+
+    // Then
+    expect(console.error).not.toHaveBeenCalled()
+    expect(
+      container.querySelector('.MuiGrid-justify-content-xs-space-between')
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This triggers a lot of warnings in our application

cozy-sharing Banner is waiting for that change

It's just a renamed props
https://mui.com/components/grid/