### PR TITLE
feat: Handle FlagshipUI for cozy-drive cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "cozy-device-helper": "^1.16.1",
     "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",
-    "cozy-intent": "^1.6.0",
+    "cozy-intent": "^1.13.0",
     "cozy-sharing": "^3.10.0",
     "cozy-stack-client": "27.19.1",
     "css-loader": "0.28.11",

--- a/react/ActionMenu/index.jsx
+++ b/react/ActionMenu/index.jsx
@@ -11,6 +11,7 @@ import Radio from '../Radio'
 import { spacingProp } from '../Stack'
 import { usePopper } from 'react-popper'
 import createDepreciationLogger from '../helpers/createDepreciationLogger'
+import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 
 const ActionMenuWrapper = ({
   inline,
@@ -101,6 +102,23 @@ const ActionMenu = ({
   anchorElRef,
   containerElRef
 }) => {
+  useSetFlagshipUI(
+    {
+      bottomBackground: 'background.paper',
+      bottomTheme: 'dark',
+      topOverlay: getCssVariableValue('overlay'),
+      topBackground: 'background.paper',
+      topTheme: 'light'
+    },
+    {
+      bottomBackground: 'background.default',
+      bottomTheme: 'dark',
+      topOverlay: 'transparent',
+      topBackground: 'background.paper',
+      topTheme: 'dark'
+    }
+  )
+
   if (placement)
     logDepecratedPlacement(
       '<ActionMenu placement /> is deprecated, use <ActionMenu popperOptions={{ placement }} /> instead'

--- a/react/BarContextProvider/index.spec.jsx
+++ b/react/BarContextProvider/index.spec.jsx
@@ -172,27 +172,4 @@ describe('BarContextProvider', () => {
 
     expect(queryByText(mockVoidWebviewService)).toBeInTheDocument()
   })
-
-  it('should not try to provide a cozy-intent context if one is provided', () => {
-    // Set Web context
-    window.cozy.isFlagshipApp = false
-
-    const client = createMockClient({})
-    const mockStore = configureStore()
-    const store = mockStore(x => x)
-
-    const { queryByText } = render(
-      <Provider store={store}>
-        <CozyProvider client={client}>
-          <I18n lang="en" dictRequire={() => locales}>
-            <App webviewService={mockWebviewService}>
-              <IntentComponent />
-            </App>
-          </I18n>
-        </CozyProvider>
-      </Provider>
-    )
-
-    expect(queryByText(mockWebviewService.foo)).not.toBeInTheDocument()
-  })
 })

--- a/react/Dialog/index.jsx
+++ b/react/Dialog/index.jsx
@@ -4,6 +4,7 @@ import { RemoveScroll } from 'react-remove-scroll'
 import useBreakpoints from '../hooks/useBreakpoints'
 import { useCozyTheme } from '../CozyTheme'
 import themesStyles from '../../stylus/settings/palette.styl'
+import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 
 const Dialog = props => {
   const { isMobile, isTablet } = useBreakpoints()
@@ -23,6 +24,32 @@ const Dialog = props => {
       : React.Fragment
 
   const theme = useCozyTheme()
+
+  useSetFlagshipUI(
+    props.fullScreen
+      ? {
+          bottomBackground: 'background.paper',
+          bottomTheme: 'dark',
+          topBackground: 'background.paper',
+          topTheme: 'dark'
+        }
+      : {
+          bottomBackground: 'background.default',
+          bottomTheme: 'light',
+          bottomOverlay: 'rgba(0, 0, 0, 0.5)',
+          topOverlay: 'rgba(0, 0, 0, 0.5)',
+          topBackground: 'background.paper',
+          topTheme: 'light'
+        },
+    {
+      bottomBackground: 'background.default',
+      bottomTheme: 'dark',
+      bottomOverlay: 'transparent',
+      topOverlay: 'transparent',
+      topBackground: 'background.paper',
+      topTheme: 'dark'
+    }
+  )
 
   return (
     <Wrapper>

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -11,6 +11,8 @@ import useBreakpoints from '../hooks/useBreakpoints'
 import styles from './styles.styl'
 
 import CrossIcon from 'cozy-ui/transpiled/react/Icons/Cross'
+import { useWebviewIntent } from 'cozy-intent'
+import { useTheme } from '@material-ui/core'
 
 /*
 
@@ -39,6 +41,35 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
       action.displayCondition === undefined || action.displayCondition(selected)
     )
   })
+  const webviewIntent = useWebviewIntent()
+  const theme = useTheme()
+
+  useEffect(() => {
+    if (!webviewIntent || !theme) return
+
+    selectedCount === 0 &&
+      webviewIntent &&
+      webviewIntent.call('setFlagshipUI', {
+        bottomBackground: theme.palette.background.default,
+        bottomTheme: 'dark'
+      })
+
+    selectedCount > 0 &&
+      webviewIntent &&
+      webviewIntent.call('setFlagshipUI', {
+        bottomBackground: theme.palette.grey[700],
+        bottomTheme: 'light'
+      })
+
+    return () =>
+      webviewIntent &&
+      theme &&
+      webviewIntent.call('setFlagshipUI', {
+        bottomBackground: theme.palette.background.default,
+        bottomTheme: 'dark'
+      })
+  }, [selectedCount, webviewIntent])
+
   return (
     <div
       data-testid="selectionBar"

--- a/react/Sidebar/index.jsx
+++ b/react/Sidebar/index.jsx
@@ -2,12 +2,25 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
+import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 
-const Sidebar = ({ children, className, ...restProps }) => (
-  <aside className={cx(styles['o-sidebar'], className)} {...restProps}>
-    {children}
-  </aside>
-)
+const Sidebar = ({ children, className, ...restProps }) => {
+  useSetFlagshipUI(
+    {
+      bottomBackground: 'background.default',
+      bottomTheme: 'dark'
+    },
+    {
+      bottomBackground: 'background.paper'
+    }
+  )
+
+  return (
+    <aside className={cx(styles['o-sidebar'], className)} {...restProps}>
+      {children}
+    </aside>
+  )
+}
 
 Sidebar.propTypes = {
   children: PropTypes.node,

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -12,6 +12,7 @@ import ViewerByFile from './ViewerByFile'
 import { isValidForPanel } from './helpers'
 import PanelContent from './Panel/PanelContent'
 import FooterContent from './Footer/FooterContent'
+import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 
 const KEY_CODE_LEFT = 37
 const KEY_CODE_RIGHT = 39
@@ -149,6 +150,16 @@ const ViewerInformationsWrapper = ({
   validForPanel,
   toolbarRef
 }) => {
+  useSetFlagshipUI(
+    {
+      bottomBackground: 'background.paper',
+      bottomTheme: 'dark'
+    },
+    {
+      bottomBackground: 'background.default'
+    }
+  )
+
   return (
     <>
       {!disableFooter && (

--- a/react/hooks/useSetFlagshipUi/useSetFlagshipUI.js
+++ b/react/hooks/useSetFlagshipUi/useSetFlagshipUI.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { useTheme } from '@material-ui/core'
+import { get } from 'lodash'
+
+import { useWebviewIntent } from 'cozy-intent'
+
+const formatArg = (obj, theme) =>
+  Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [
+      k,
+      k.includes('Background') ? get(theme.palette, v) : v
+    ])
+  )
+
+export const useSetFlagshipUI = (onMount, onUnmount) => {
+  const webviewIntent = useWebviewIntent()
+  const theme = useTheme()
+
+  useEffect(() => {
+    if (theme && webviewIntent)
+      webviewIntent.call('setFlagshipUI', formatArg(onMount, theme))
+
+    return () => {
+      if (theme && webviewIntent)
+        webviewIntent.call('setFlagshipUI', formatArg(onUnmount, theme))
+    }
+  }, [theme, webviewIntent])
+}

--- a/react/hooks/useSetFlagshipUi/useSetFlagshipUI.spec.js
+++ b/react/hooks/useSetFlagshipUi/useSetFlagshipUI.spec.js
@@ -1,0 +1,135 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { useSetFlagshipUI } from './useSetFlagshipUI'
+import { useTheme } from '@material-ui/core'
+import { useWebviewIntent } from 'cozy-intent'
+
+jest.mock('@material-ui/core')
+jest.mock('cozy-intent')
+
+const mockCall = jest.fn()
+const mockCSSValue = '#fff'
+
+beforeEach(() => {
+  useWebviewIntent.mockImplementation(() => ({ call: mockCall }))
+  useTheme.mockImplementation(() => ({
+    palette: { foo: { bar: mockCSSValue } }
+  }))
+})
+
+afterEach(() => {
+  mockCall.mockClear()
+})
+
+it('should call webviewIntent with the correct params, once at mount and once at unmount', () => {
+  const { unmount } = renderHook(() =>
+    useSetFlagshipUI(
+      {
+        bottomBackground: 'foo.bar',
+        bottomOverlay: 'transparent',
+        bottomTheme: 'dark',
+        topBackground: 'foo.bar',
+        topOverlay: 'transparent',
+        topTheme: 'dark'
+      },
+      {
+        bottomBackground: 'foo.bar',
+        bottomOverlay: 'transparent',
+        bottomTheme: 'light',
+        topBackground: 'foo.bar',
+        topOverlay: 'transparent',
+        topTheme: 'light'
+      }
+    )
+  )
+
+  expect(mockCall).toHaveBeenNthCalledWith(1, 'setFlagshipUI', {
+    bottomBackground: mockCSSValue,
+    bottomOverlay: 'transparent',
+    bottomTheme: 'dark',
+    topBackground: mockCSSValue,
+    topOverlay: 'transparent',
+    topTheme: 'dark'
+  })
+
+  unmount()
+
+  expect(mockCall).toHaveBeenNthCalledWith(2, 'setFlagshipUI', {
+    bottomBackground: mockCSSValue,
+    bottomOverlay: 'transparent',
+    bottomTheme: 'light',
+    topBackground: mockCSSValue,
+    topOverlay: 'transparent',
+    topTheme: 'light'
+  })
+})
+
+it('should call webviewIntent with the correct params with few args, once at mount and once at unmount', () => {
+  const { unmount } = renderHook(() =>
+    useSetFlagshipUI(
+      { bottomBackground: 'foo.bar' },
+      { bottomBackground: 'foo.bar' }
+    )
+  )
+
+  expect(mockCall).toHaveBeenNthCalledWith(1, 'setFlagshipUI', {
+    bottomBackground: mockCSSValue
+  })
+
+  unmount()
+
+  expect(mockCall).toHaveBeenNthCalledWith(2, 'setFlagshipUI', {
+    bottomBackground: mockCSSValue
+  })
+})
+
+it('should call nothing with no webviewIntent and not throw', () => {
+  useWebviewIntent.mockImplementation(() => undefined)
+
+  const { unmount } = renderHook(() =>
+    useSetFlagshipUI(
+      { bottomBackground: 'foo.bar' },
+      { bottomBackground: 'foo.bar' }
+    )
+  )
+
+  expect(mockCall).not.toHaveBeenCalled()
+
+  unmount()
+
+  expect(mockCall).not.toHaveBeenCalled()
+})
+
+it('should call nothing with no theme present and not throw', () => {
+  useTheme.mockImplementation(() => undefined)
+
+  const { unmount } = renderHook(() =>
+    useSetFlagshipUI(
+      { bottomBackground: 'foo.bar' },
+      { bottomBackground: 'foo.bar' }
+    )
+  )
+
+  expect(mockCall).not.toHaveBeenCalled()
+
+  unmount()
+
+  expect(mockCall).not.toHaveBeenCalled()
+})
+
+it('should call nothing with no theme and no webviewintent and not throw', () => {
+  useTheme.mockImplementation(() => undefined)
+  useWebviewIntent.mockImplementation(() => undefined)
+
+  const { unmount } = renderHook(() =>
+    useSetFlagshipUI(
+      { bottomBackground: 'foo.bar' },
+      { bottomBackground: 'foo.bar' }
+    )
+  )
+
+  expect(mockCall).not.toHaveBeenCalled()
+
+  unmount()
+
+  expect(mockCall).not.toHaveBeenCalled()
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5201,12 +5201,11 @@ cozy-harvest-lib@^6.7.3:
     react-markdown "^4.2.2"
     uuid "^3.3.2"
 
-cozy-intent@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.6.0.tgz#0fb0bd941219abc905121db8016a72f4f05aa258"
-  integrity sha512-HccShcWnG2jpoCnfbviUtImqLAkYHS9nB+rXyJ1rC+vkeQkY4Wo24EG98A8QIz0oXWCxOcYefbsR1l+7ogapOQ==
+cozy-intent@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.13.0.tgz#73912a524984f82fe691c871c4f02c4f10937acb"
+  integrity sha512-/pbHly+Up+l/f7pAD359Kopn7v63Tmj/gIdgFaSiXVs0pJjgXwpMREtDtUgpc25A0LeZaDxfShLf740NFK3MfQ==
   dependencies:
-    cozy-device-helper "^1.16.1"
     post-me "0.4.5"
 
 cozy-interapp@^0.5.4:


### PR DESCRIPTION
Linked to the react-native feature https://trello.com/c/KWxWhWBK/274-gestion-des-navbar-et-statusbar-dans-lensemble-de-laa-4-jh

This PR will handle react-native UI changes (statusbar, navbar) according to UI changes in the webapp rendered in the webview. This is done by calling cozy-intent to send the UI to display to react-native. There is last-state persistence so it is not strictly necessary to send a full object in the message, it is possible to only set the values that we want to be changed

### Dialog
✅ Create shortcut
✅ Share
✅ Move to
✅ Categorize
✅ History
✅ Delete element confirmation

### ActionMenu
✅ Sort files
✅ Cozy-bar "More" button
✅ FileAction button
✅ Upload file from OS

### Viewer
✅ FileViewer
✅ FileViewer bottom drawer

### Sidebar
✅ Mobile view

### SelectionBar
✅ Delete element after selection

Issues:

- TopBackground can't be determined with runtime palette (cozy-bar is different context)