### PR TITLE
feat: Add tiny size for FileImageLoader

### DIFF
--- a/react/FileImageLoader/index.jsx
+++ b/react/FileImageLoader/index.jsx
@@ -160,7 +160,14 @@ export class FileImageLoader extends Component {
 FileImageLoader.propTypes = {
   file: PropTypes.object.isRequired,
   render: PropTypes.func.isRequired,
-  linkType: PropTypes.oneOf(['small', 'medium', 'large', 'preview', 'icon']),
+  linkType: PropTypes.oneOf([
+    'tiny',
+    'small',
+    'medium',
+    'large',
+    'preview',
+    'icon'
+  ]),
   onError: PropTypes.func,
   renderFallback: PropTypes.func
 }


### PR DESCRIPTION
Since https://github.com/cozy/cozy-stack/pull/3315 we can
now request a "tiny" thumbnail aka 96x96 px.

Will be useful for list's item
