### PR TITLE
fix: Propagate the ref on the MUIButton

### DIFF
--- a/react/Buttons/Readme.md
+++ b/react/Buttons/Readme.md
@@ -1,3 +1,5 @@
+The `ref` is forwarded to the root element
+
 ### Default
 
 ```jsx

--- a/react/Buttons/index.jsx
+++ b/react/Buttons/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -7,58 +7,62 @@ import MuiButton from '@material-ui/core/Button'
 import Icon from '../Icon'
 import SpinnerIcon from '../Icons/Spinner'
 
-const DefaultButton = ({
-  className,
-  color,
-  label,
-  busy,
-  disabled,
-  endIcon,
-  ...props
-}) => {
-  return (
-    <MuiButton
-      {...props}
-      className={cx({ [`customColor-${color}`]: color }, className)}
-      color="primary"
-      disabled={disabled || busy}
-      endIcon={
-        busy ? (
-          <Icon icon={SpinnerIcon} spin aria-hidden focusable="false" />
-        ) : (
-          endIcon
-        )
-      }
-      disableElevation={true}
-    >
-      {label}
-    </MuiButton>
-  )
-}
+const DefaultButton = forwardRef(
+  ({ className, color, label, busy, disabled, endIcon, ...props }, ref) => {
+    return (
+      <MuiButton
+        {...props}
+        ref={ref}
+        className={cx({ [`customColor-${color}`]: color }, className)}
+        color="primary"
+        disabled={disabled || busy}
+        endIcon={
+          busy ? (
+            <Icon icon={SpinnerIcon} spin aria-hidden focusable="false" />
+          ) : (
+            endIcon
+          )
+        }
+        disableElevation={true}
+      >
+        {label}
+      </MuiButton>
+    )
+  }
+)
+DefaultButton.displayName = 'DefaultButton'
 
 DefaultButton.defaultProps = {
   variant: 'contained',
   color: 'primary'
 }
 
-const Buttons = ({ variant, ...props }) => {
+const Buttons = forwardRef(({ variant, ...props }, ref) => {
   switch (variant) {
     case 'ghost':
-      return <DefaultButton className="ghost" variant="outlined" {...props} />
+      return (
+        <DefaultButton
+          className="ghost"
+          variant="outlined"
+          {...props}
+          ref={ref}
+        />
+      )
 
     case 'secondary':
-      return <DefaultButton variant="outlined" {...props} />
+      return <DefaultButton variant="outlined" {...props} ref={ref} />
 
     case 'text':
-      return <DefaultButton variant="text" {...props} />
+      return <DefaultButton variant="text" {...props} ref={ref} />
 
     case 'primary':
-      return <DefaultButton {...props} />
+      return <DefaultButton {...props} ref={ref} />
 
     default:
-      return <DefaultButton {...props} />
+      return <DefaultButton {...props} ref={ref} />
   }
-}
+})
+Buttons.displayName = 'Buttons'
 
 Buttons.propTypes = {
   variant: PropTypes.oneOf(['primary', 'secondary', 'ghost', 'text']),


### PR DESCRIPTION
In order to reference the MUI button from an application, we need the passed reference to be propagated
