### PR TITLE
feat: Improve FilePicker component

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "filesize": "8.0.7",
     "hammerjs": "^2.0.8",
     "intersection-observer": "0.11.0",
+    "mime-types": "2.1.35",
     "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6",
     "node-polyglot": "^2.2.2",
     "normalize.css": "^8.0.0",

--- a/react/FilePicker/FilePickerBody.jsx
+++ b/react/FilePicker/FilePickerBody.jsx
@@ -16,9 +16,9 @@ const {
 const FilePickerBody = ({
   navigateTo,
   folderId,
-  onSelectFileId,
-  filesIdsSelected,
-  fileTypesAccepted,
+  onSelectItemId,
+  itemsIdsSelected,
+  itemTypesAccepted,
   multiple
 }) => {
   const contentFolderQuery = buildContentFolderQuery(folderId)
@@ -28,68 +28,68 @@ const FilePickerBody = ({
   )
 
   const onCheck = useCallback(
-    fileId => {
-      const isChecked = filesIdsSelected.some(
-        fileIdSelected => fileIdSelected === fileId
+    itemId => {
+      const isChecked = itemsIdsSelected.some(
+        fileIdSelected => fileIdSelected === itemId
       )
       if (isChecked) {
-        onSelectFileId(
-          filesIdsSelected.filter(fileIdSelected => fileIdSelected !== fileId)
+        onSelectItemId(
+          itemsIdsSelected.filter(fileIdSelected => fileIdSelected !== itemId)
         )
-      } else onSelectFileId(prev => [...prev, fileId])
+      } else onSelectItemId(prev => [...prev, itemId])
     },
-    [filesIdsSelected, onSelectFileId]
+    [itemsIdsSelected, onSelectItemId]
   )
 
   // When click on checkbox/radio area...
   const handleChoiceClick = useCallback(
-    file => () => {
-      if (multiple) onCheck(file._id)
-      else onSelectFileId(file._id)
+    item => () => {
+      if (multiple) onCheck(item._id)
+      else onSelectItemId(item._id)
     },
-    [multiple, onCheck, onSelectFileId]
+    [multiple, onCheck, onSelectItemId]
   )
 
   // ...when click anywhere on the rest of the line
   const handleListItemClick = useCallback(
-    file => () => {
-      if (isDirectory(file)) {
-        navigateTo(contentFolder.find(f => f._id === file._id))
+    item => () => {
+      if (isDirectory(item)) {
+        navigateTo(contentFolder.find(it => it._id === item._id))
       }
 
-      if (isValidFile(file, fileTypesAccepted)) {
-        if (multiple) onCheck(file._id)
-        else onSelectFileId(file._id)
+      if (isValidFile(item, itemTypesAccepted)) {
+        if (multiple) onCheck(item._id)
+        else onSelectItemId(item._id)
       }
     },
     [
       contentFolder,
-      fileTypesAccepted,
+      itemTypesAccepted,
       multiple,
       navigateTo,
       onCheck,
-      onSelectFileId
+      onSelectItemId
     ]
   )
 
   return (
     <List>
       {contentFolder &&
-        contentFolder.map((file, idx) => {
+        contentFolder.map((item, idx) => {
           const hasDivider = contentFolder
             ? idx !== contentFolder.length - 1
             : false
 
           return (
             <FilePickerBodyItem
-              key={file._id}
-              file={file}
-              fileTypesAccepted={fileTypesAccepted}
+              key={item._id}
+              item={item}
+              itemTypesAccepted={itemTypesAccepted}
               multiple={multiple}
               handleChoiceClick={handleChoiceClick}
               handleListItemClick={handleListItemClick}
               onCheck={onCheck}
-              filesIdsSelected={filesIdsSelected}
+              itemsIdsSelected={itemsIdsSelected}
               hasDivider={hasDivider}
             />
           )
@@ -100,11 +100,11 @@ const FilePickerBody = ({
 }
 
 FilePickerBody.propTypes = {
-  onSelectFileId: PropTypes.func.isRequired,
-  filesIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onSelectItemId: PropTypes.func.isRequired,
+  itemsIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
   folderId: PropTypes.string.isRequired,
   navigateTo: PropTypes.func.isRequired,
-  fileTypesAccepted: PropTypes.arrayOf(PropTypes.string).isRequired
+  itemTypesAccepted: PropTypes.arrayOf(PropTypes.string).isRequired
 }
 
 export default FilePickerBody

--- a/react/FilePicker/FilePickerBody.jsx
+++ b/react/FilePicker/FilePickerBody.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, memo } from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 
 import { models, useQuery } from 'cozy-client'
@@ -7,9 +7,10 @@ import LoadMore from '../LoadMore'
 
 import { buildContentFolderQuery } from './queries'
 import FilePickerBodyItem from './FilePickerBodyItem'
+import { isValidFile } from '../helpers/acceptedTypes'
 
 const {
-  file: { isDirectory, isFile }
+  file: { isDirectory }
 } = models
 
 const FilePickerBody = ({
@@ -56,14 +57,14 @@ const FilePickerBody = ({
         navigateTo(contentFolder.find(f => f._id === file._id))
       }
 
-      if (isFile(file) && fileTypesAccepted.file) {
+      if (isValidFile(file, fileTypesAccepted)) {
         if (multiple) onCheck(file._id)
         else onSelectFileId(file._id)
       }
     },
     [
       contentFolder,
-      fileTypesAccepted.file,
+      fileTypesAccepted,
       multiple,
       navigateTo,
       onCheck,
@@ -103,10 +104,7 @@ FilePickerBody.propTypes = {
   filesIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
   folderId: PropTypes.string.isRequired,
   navigateTo: PropTypes.func.isRequired,
-  fileTypesAccepted: PropTypes.exact({
-    file: PropTypes.bool,
-    folder: PropTypes.bool
-  })
+  fileTypesAccepted: PropTypes.arrayOf(PropTypes.string).isRequired
 }
 
-export default memo(FilePickerBody)
+export default FilePickerBody

--- a/react/FilePicker/FilePickerBodyItem.jsx
+++ b/react/FilePicker/FilePickerBodyItem.jsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import filesize from 'filesize'
@@ -16,6 +16,8 @@ import FileTypeFolder from '../Icons/FileTypeFolder'
 import Checkbox from '../Checkbox'
 import Radio from '../Radios'
 import { useI18n } from '../I18n'
+
+import { isValidFile, isValidFolder } from '../helpers/acceptedTypes'
 
 import styles from './styles.styl'
 
@@ -48,8 +50,8 @@ const FilePickerBodyItem = ({
   const classes = useStyles()
   const { f } = useI18n()
   const hasChoice =
-    (fileTypesAccepted.file && isFile(file)) ||
-    (fileTypesAccepted.folder && isDirectory(file))
+    isValidFile(item, itemTypesAccepted) ||
+    isValidFolder(item, itemTypesAccepted)
 
   const Input = multiple ? Checkbox : Radio
 
@@ -61,7 +63,12 @@ const FilePickerBodyItem = ({
 
   return (
     <>
-      <ListItem button className="u-p-0">
+      <ListItem
+        disabled={!hasChoice && isFile(file)}
+        button
+        className="u-p-0"
+        data-testid="list-item"
+      >
         <div
           data-testid="listitem-onclick"
           className={styles['filePickerBreadcrumb-wrapper']}
@@ -113,10 +120,7 @@ const FilePickerBodyItem = ({
 
 FilePickerBodyItem.propTypes = {
   file: PropTypes.object.isRequired,
-  fileTypesAccepted: PropTypes.exact({
-    file: PropTypes.bool,
-    folder: PropTypes.bool
-  }),
+  fileTypesAccepted: PropTypes.arrayOf(PropTypes.string).isRequired,
   multiple: PropTypes.bool,
   handleChoiceClick: PropTypes.func.isRequired,
   handleListItemClick: PropTypes.func.isRequired,
@@ -124,4 +128,4 @@ FilePickerBodyItem.propTypes = {
   hasDivider: PropTypes.bool.isRequired
 }
 
-export default memo(FilePickerBodyItem)
+export default FilePickerBodyItem

--- a/react/FilePicker/FilePickerBodyItem.jsx
+++ b/react/FilePicker/FilePickerBodyItem.jsx
@@ -39,12 +39,12 @@ const useStyles = makeStyles(() => ({
 }))
 
 const FilePickerBodyItem = ({
-  file,
-  fileTypesAccepted,
+  item,
+  itemTypesAccepted,
   multiple,
   handleChoiceClick,
   handleListItemClick,
-  filesIdsSelected,
+  itemsIdsSelected,
   hasDivider
 }) => {
   const classes = useStyles()
@@ -55,8 +55,8 @@ const FilePickerBodyItem = ({
 
   const Input = multiple ? Checkbox : Radio
 
-  const listItemSecondaryContent = isFile(file)
-    ? `${f(file.updated_at, 'DD MMM YYYY')} - ${filesize(file.size, {
+  const listItemSecondaryContent = isFile(item)
+    ? `${f(item.updated_at, 'DD MMM YYYY')} - ${filesize(item.size, {
         base: 10
       })}`
     : null
@@ -64,7 +64,7 @@ const FilePickerBodyItem = ({
   return (
     <>
       <ListItem
-        disabled={!hasChoice && isFile(file)}
+        disabled={!hasChoice && isFile(item)}
         button
         className="u-p-0"
         data-testid="list-item"
@@ -72,21 +72,21 @@ const FilePickerBodyItem = ({
         <div
           data-testid="listitem-onclick"
           className={styles['filePickerBreadcrumb-wrapper']}
-          onClick={handleListItemClick(file)}
+          onClick={handleListItemClick(item)}
         >
           <ListItemIcon className={classes.listItemIcon}>
             <Icon
-              icon={isDirectory(file) ? FileTypeFolder : FileTypeText}
+              icon={isDirectory(item) ? FileTypeFolder : FileTypeText}
               width="32"
               height="32"
             />
           </ListItemIcon>
           <ListItemText
-            primary={file.name}
+            primary={item.name}
             secondary={listItemSecondaryContent}
           />
         </div>
-        {isDirectory(file) && hasChoice && (
+        {isDirectory(item) && hasChoice && (
           <Divider
             orientation="vertical"
             flexItem
@@ -96,15 +96,15 @@ const FilePickerBodyItem = ({
         <div
           data-testid="choice-onclick"
           className="u-ph-1 u-pv-half u-h-2 u-flex u-flex-items-center"
-          onClick={hasChoice ? handleChoiceClick(file) : undefined}
+          onClick={hasChoice ? handleChoiceClick(item) : undefined}
         >
           <Input
             data-testid={multiple ? 'checkbox-btn' : 'radio-btn'}
             onChange={() => {
               // handled by onClick on the container
             }}
-            checked={filesIdsSelected.includes(file._id)}
-            value={file._id}
+            checked={itemsIdsSelected.includes(item._id)}
+            value={item._id}
             className={cx('u-p-0', {
               'u-o-100': hasChoice,
               'u-o-0': !hasChoice
@@ -119,12 +119,12 @@ const FilePickerBodyItem = ({
 }
 
 FilePickerBodyItem.propTypes = {
-  file: PropTypes.object.isRequired,
-  fileTypesAccepted: PropTypes.arrayOf(PropTypes.string).isRequired,
+  item: PropTypes.object.isRequired,
+  itemTypesAccepted: PropTypes.arrayOf(PropTypes.string).isRequired,
   multiple: PropTypes.bool,
   handleChoiceClick: PropTypes.func.isRequired,
   handleListItemClick: PropTypes.func.isRequired,
-  filesIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
+  itemsIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
   hasDivider: PropTypes.bool.isRequired
 }
 

--- a/react/FilePicker/FilePickerBodyItem.spec.jsx
+++ b/react/FilePicker/FilePickerBodyItem.spec.jsx
@@ -33,7 +33,7 @@ describe('FilePickerBodyItem components:', () => {
   filesize.mockReturnValue('111Ko')
 
   const setup = ({
-    file = mockFile01,
+    item = mockFile01,
     multiple = false,
     validFile = false,
     validFolder = false
@@ -44,12 +44,12 @@ describe('FilePickerBodyItem components:', () => {
     return render(
       <DemoProvider>
         <FilePickerBodyItem
-          file={file}
-          fileTypesAccepted={[]}
+          item={item}
+          itemTypesAccepted={[]}
           multiple={multiple}
           handleChoiceClick={mockHandleChoiceClick}
           handleListItemClick={mockHandleListItemClick}
-          filesIdsSelected={[]}
+          itemsIdsSelected={[]}
           hasDivider={false}
         />
       </DemoProvider>
@@ -73,14 +73,14 @@ describe('FilePickerBodyItem components:', () => {
   })
 
   it('should display foldername', () => {
-    const { getByText } = setup({ file: mockFolder01 })
+    const { getByText } = setup({ item: mockFolder01 })
 
     expect(getByText('Foldername'))
   })
 
   it("should item's line is not disabled when has not valid type & is File", () => {
     const { getByTestId } = setup({
-      file: mockFile01,
+      item: mockFile01,
       validFile: false,
       validFolder: false
     })
@@ -91,7 +91,7 @@ describe('FilePickerBodyItem components:', () => {
 
   it("should item's line is not disabled when has not valid type & is Folder", () => {
     const { getByTestId } = setup({
-      file: mockFolder01,
+      item: mockFolder01,
       validFile: false,
       validFolder: false
     })
@@ -110,7 +110,7 @@ describe('FilePickerBodyItem components:', () => {
 
     it('should NOT call "handleChoiceClick" function when click on checkbox/radio area, if is Folder & not accepted', () => {
       const { getByTestId } = setup({
-        file: mockFolder01,
+        item: mockFolder01,
         validFolder: false
       })
       fireEvent.click(getByTestId('choice-onclick'))
@@ -155,7 +155,7 @@ describe('FilePickerBodyItem components:', () => {
     })
 
     it('should disable and not display the Radio button if it is a Folder and is not accepted', () => {
-      const { getByTestId } = setup({ file: mockFolder01 })
+      const { getByTestId } = setup({ item: mockFolder01 })
       const radioBtn = getByTestId('radio-btn')
 
       expect(radioBtn.getAttribute('disabled')).toBe(null)

--- a/react/FilePicker/Readme.md
+++ b/react/FilePicker/Readme.md
@@ -12,7 +12,7 @@ initialState = {
 };
 
 const initialVariants = [
-  { acceptFile: true, acceptFolder: false, multiple: false }
+  { acceptFileTXT: false, acceptFileMD: false, acceptFolder: false, multiple: false }
 ];
 
 const toggleFilePicker = () => setState({ filePickerOpened: !state.filePickerOpened });
@@ -20,18 +20,15 @@ const onChange = (fileId) => alert(`ID of file selected : [${fileId}]`);
 <DemoProvider>
   <Variants initialVariants={initialVariants} screenshotAllVariants>
     {variant => {
-      let acceptRule = ''
-      if (variant.acceptFile) {
-        acceptRule = 'file'
-        if (variant.acceptFolder) {
-          acceptRule = 'file,folder'
-        }
+      const acceptRule = []
+      if (variant.acceptFileMD) {
+        acceptRule.push('.md')
+      }
+      if (variant.acceptFileTXT) {
+        acceptRule.push('.txt')
       }
       if (variant.acceptFolder) {
-        acceptRule = 'folder'
-        if (variant.acceptFile) {
-          acceptRule = 'folder,file'
-        }
+        acceptRule.push('folder')
       }
 
       return (
@@ -41,7 +38,7 @@ const onChange = (fileId) => alert(`ID of file selected : [${fileId}]`);
             <FilePicker
               onClose={toggleFilePicker}
               onChange={onChange}
-              accept={acceptRule}
+              accept={acceptRule.toString()}
               multiple={variant.multiple}
             />
           )}

--- a/react/FilePicker/docs/DemoProvider.jsx
+++ b/react/FilePicker/docs/DemoProvider.jsx
@@ -98,7 +98,7 @@ const setupClient = () => {
             _type: 'io.cozy.files',
             type: 'file',
             dir_id: 'io.cozy.files.root-dir',
-            name: 'File A',
+            name: 'File A.md',
             updated_at: '2021-01-01T12:00:00.000000+01:00',
             size: '111609'
           },
@@ -108,7 +108,7 @@ const setupClient = () => {
             _type: 'io.cozy.files',
             type: 'file',
             dir_id: 'io.cozy.files.root-dir',
-            name: 'File B',
+            name: 'File B.png',
             updated_at: '2021-01-01T12:00:00.000000+01:00',
             size: '11160963'
           }
@@ -157,7 +157,7 @@ const setupClient = () => {
             _type: 'io.cozy.files',
             type: 'file',
             dir_id: 'folder.01.id',
-            name: 'File C',
+            name: 'File C.txt',
             updated_at: '2021-01-01T12:00:00.000000+01:00',
             size: '111609'
           }
@@ -197,7 +197,7 @@ const setupClient = () => {
             _type: 'io.cozy.files',
             type: 'file',
             dir_id: 'folder.02.id',
-            name: 'File D',
+            name: 'File D.jpg',
             updated_at: '2021-01-01T12:00:00.000000+01:00',
             size: '222111'
           }
@@ -237,7 +237,7 @@ const setupClient = () => {
             _type: 'io.cozy.files',
             type: 'file',
             dir_id: 'folder.03.id',
-            name: 'File E',
+            name: 'File E.doc',
             updated_at: '2021-01-01T12:00:00.000000+01:00',
             size: '222111'
           }

--- a/react/FilePicker/index.jsx
+++ b/react/FilePicker/index.jsx
@@ -7,22 +7,7 @@ import FilePickerHeader from './FilePickerHeader'
 import FilePickerFooter from './FilePickerFooter'
 import FilePickerBody from './FilePickerBody'
 import useBreakpoints from '../hooks/useBreakpoints'
-
-/**
- * @param {string} fileType - Defines the file types that should be accepted ("file" and/or "folder"), separated by commas
- * @returns {{ file: boolean, folder: boolean }}
- */
-const getFileTypesAccepted = fileType => {
-  // If accept is falsy, set default to file
-  const acceptedFileType = fileType
-    ? fileType.replaceAll(' ', '').split(',')
-    : ['file']
-
-  return {
-    file: acceptedFileType.includes('file'),
-    folder: acceptedFileType.includes('folder')
-  }
-}
+import { getCompliantTypes } from '../helpers/acceptedTypes'
 
 const useStyles = makeStyles(() => ({
   paper: {
@@ -52,7 +37,7 @@ const FilePicker = ({ onClose, onChange, accept, multiple }) => {
     onChange(fileId ? fileId : filesIdsSelected)
     onClose()
   }
-  const fileTypesAccepted = getFileTypesAccepted(accept)
+  const itemTypesAccepted = getCompliantTypes(accept)
 
   return (
     <FixedDialog
@@ -101,7 +86,7 @@ FilePicker.propTypes = {
 }
 
 FilePicker.defaultProps = {
-  accept: 'file',
+  accept: '',
   multiple: false
 }
 

--- a/react/FilePicker/index.jsx
+++ b/react/FilePicker/index.jsx
@@ -21,20 +21,20 @@ const FilePicker = ({ onClose, onChange, accept, multiple }) => {
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
   const [folderId, setFolderId] = useState(ROOT_DIR_ID)
-  const [filesIdsSelected, setFilesIdsSelected] = useState([])
+  const [itemsIdsSelected, setItemsIdsSelected] = useState([])
 
-  const onSelectFileId = fileId => {
+  const onSelectItemId = fileId => {
     if (!multiple) {
       handleConfirm(null, fileId)
     } else {
-      setFilesIdsSelected(fileId)
+      setItemsIdsSelected(fileId)
     }
   }
 
   const navigateTo = folder => setFolderId(folder.id)
 
   const handleConfirm = (_, fileId) => {
-    onChange(fileId ? fileId : filesIdsSelected)
+    onChange(fileId ? fileId : itemsIdsSelected)
     onClose()
   }
   const itemTypesAccepted = getCompliantTypes(accept)
@@ -58,10 +58,10 @@ const FilePicker = ({ onClose, onChange, accept, multiple }) => {
       content={
         <FilePickerBody
           navigateTo={navigateTo}
-          onSelectFileId={onSelectFileId}
-          filesIdsSelected={filesIdsSelected}
+          onSelectItemId={onSelectItemId}
+          itemsIdsSelected={itemsIdsSelected}
           folderId={folderId}
-          fileTypesAccepted={fileTypesAccepted}
+          itemTypesAccepted={itemTypesAccepted}
           multiple={multiple}
         />
       }
@@ -70,7 +70,7 @@ const FilePicker = ({ onClose, onChange, accept, multiple }) => {
           <FilePickerFooter
             onClose={onClose}
             onConfirm={handleConfirm}
-            disabledConfirm={filesIdsSelected.length === 0}
+            disabledConfirm={itemsIdsSelected.length === 0}
           />
         ) : null
       }

--- a/react/helpers/acceptedTypes.js
+++ b/react/helpers/acceptedTypes.js
@@ -1,0 +1,50 @@
+import mimeTypes from 'mime-types'
+
+import { models } from 'cozy-client'
+
+const {
+  file: { isDirectory, isFile }
+} = models
+
+/**
+ * @param {string} types - Types we wish to accept ("folder" and/or "extensions/mime" of file), separated by commas
+ * @returns {string[]} All the valid types, if the parameter is undefined or if no type is valid, return an empty array
+ */
+export const getCompliantTypes = types => {
+  if (types) {
+    return types
+      .replaceAll(' ', '')
+      .split(',')
+      .filter(type =>
+        type !== 'folder' ? !!mimeTypes.contentType(type) : true
+      )
+  }
+
+  return []
+}
+
+/**
+ * Check if Item is a file with accepted extension/mime
+ *
+ * @param {object} item - file or folder
+ * @param {string[]} validTypes - List of accepted types
+ * @returns {boolean}
+ */
+export const isValidFile = (item, validTypes) => {
+  const fileTypesAccepted =
+    validTypes.includes(`.${item.name.split('.').pop()}`) ||
+    validTypes.includes(item.mime)
+
+  return isFile(item) && (fileTypesAccepted || validTypes.length === 0)
+}
+
+/**
+ * Check if Item is a folder with accepted type
+ *
+ * @param {object} item - file or folder
+ * @param {string[]} validTypes - List of accepted types
+ * @returns {boolean}
+ */
+export const isValidFolder = (item, validTypes) => {
+  return isDirectory(item) && validTypes.includes(`folder`)
+}

--- a/react/helpers/acceptedTypes.spec.js
+++ b/react/helpers/acceptedTypes.spec.js
@@ -1,0 +1,86 @@
+import { isValidFile, isValidFolder, getCompliantTypes } from './acceptedTypes'
+
+const makeMockFile = ({
+  extension = '.pdf',
+  mime = 'application/pdf'
+} = {}) => ({
+  _id: '123',
+  type: 'file',
+  mime: mime,
+  name: `mockFile${extension}`
+})
+const makeMockFolder = () => ({
+  _id: '789',
+  type: 'directory',
+  name: 'mockDir'
+})
+
+describe('acceptedTypes', () => {
+  describe('getCompliantTypes', () => {
+    it('should an array with all valid types', () => {
+      const res = getCompliantTypes('.pdf, text/plain, .not')
+
+      expect(res).toStrictEqual(['.pdf', 'text/plain'])
+    })
+  })
+
+  describe('isValidFile', () => {
+    it('should be valid when item has no type providen', () => {
+      const item = makeMockFile()
+      const validTypesAccepted = []
+
+      expect(isValidFile(item, validTypesAccepted)).toBe(true)
+    })
+
+    it('should be valid when item has an accepted extension', () => {
+      const item = makeMockFile({ extension: '.png' })
+      const validTypesAccepted = ['.png', '.pdf']
+
+      expect(isValidFile(item, validTypesAccepted)).toBe(true)
+    })
+
+    it('should not be valid when item has not an accepted extension', () => {
+      const item = makeMockFile({ extension: '.png' })
+      const validTypesAccepted = ['.pdf']
+
+      expect(isValidFile(item, validTypesAccepted)).toBe(false)
+    })
+
+    it('should be valid when item has an accepted mime', () => {
+      const item = makeMockFile({ mime: 'image/png' })
+      const validTypesAccepted = ['application/pdf', 'image/png']
+
+      expect(isValidFile(item, validTypesAccepted)).toBe(true)
+    })
+
+    it('should not be valid when item has not an accepted mime', () => {
+      const item = makeMockFile({ mime: 'image/png' })
+      const validTypesAccepted = ['application/pdf']
+
+      expect(isValidFile(item, validTypesAccepted)).toBe(false)
+    })
+
+    it('should not be valid when item is not an file', () => {
+      const item = makeMockFolder()
+      const validTypesAccepted = []
+
+      expect(isValidFile(item, validTypesAccepted)).toBe(false)
+    })
+  })
+
+  describe('isValidFolder', () => {
+    it('should be valid when item is an folder', () => {
+      const item = makeMockFolder()
+      const validTypesAccepted = ['folder']
+
+      expect(isValidFolder(item, validTypesAccepted)).toBe(true)
+    })
+
+    it('should not be valid when item is not an folder', () => {
+      const item = makeMockFile()
+      const validTypesAccepted = ['folder']
+
+      expect(isValidFolder(item, validTypesAccepted)).toBe(false)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -13126,6 +13126,18 @@ mime-db@1.43.0, "mime-db@>= 1.40.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"


### PR DESCRIPTION
Added the possibility to accept files with their extensions or their mime type.
related: #2026

Today, the FilePicker is only used on the MyPapers application.
On this application we need to be able to authorize only certain types of files.

For the size of the bundle (in App):
Before:
`cozy-ui@62.2.0`: 123.08 ko

After (without FilePicker): 
`cozy-ui@62.6.0`: 123.17 ko

After (with FilePicker):
`cozy-ui@62.6.0`: 126.54 ko

Démo: https://merkur39.github.io/cozy-ui/react/#!/FilePicker/1