### PR TITLE
fix(deps):  Define puppeteer as optional peer dependencies + piwik-react-router as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },
+  "peerDependenciesMeta ": {
+    "puppeteer": {
+      "optional": true
+    }
+  },
   "eslintConfig": {
     "extends": [
       "eslint-config-cozy-app"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "mini-css-extract-plugin": "0.6.0",
     "nodemon": "1.19.4",
     "npm-run-all": "4.1.5",
-    "piwik-react-router": "0.12.1",
     "postcss-cli": "6.1.3",
     "postcss-loader": "2.1.6",
     "pretty": "2.0.0",
@@ -162,6 +161,7 @@
     "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6",
     "node-polyglot": "^2.2.2",
     "normalize.css": "^8.0.0",
+    "piwik-react-router": "0.12.1",
     "react-markdown": "^4.0.8",
     "react-pdf": "^4.0.5",
     "react-popper": "^2.2.3",
@@ -177,7 +177,6 @@
     "cozy-harvest-lib": "^6.7.3",
     "cozy-intent": ">=1.3.0",
     "cozy-sharing": "^3.10.0",
-    "piwik-react-router": "0.12.1",
     "puppeteer": "^1.20.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
Following our guideline, inside any Cozy library,
we expect peerDependency to be either react, react-dom
or other Cozy-library.

As piwik-react-router is not following this case, it should
come as a dependency of Cozy-UI

__

Few projects use regression testing of Cozy-UI: 
https://github.com/cozy/cozy-ui/blob/master/docs/README.md#ui-regression-testing= 

That is why we can be using [peerDependenciesMeta]
(https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependenciesmeta) 
that will consider this dependency as optional.