### PR TITLE
test: Use app object instead of slug

### DIFF
--- a/react/ContactsListModal/AddContactButton.jsx
+++ b/react/ContactsListModal/AddContactButton.jsx
@@ -40,7 +40,9 @@ const DumbAddContactButton = props => {
 
   return (
     <AppLinker
-      slug={installedApp ? installedApp.attributes.slug : 'store'}
+      app={{
+        slug: installedApp ? installedApp.attributes.slug : 'store'
+      }}
       href={href}
     >
       {({ onClick, href }) => (


### PR DESCRIPTION
Let's remove this warning. AppLinker now uses `app` props instead of `slug` 