### PR TITLE
Fix/viewer forward button

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "commitlint": "7.6.1",
     "commitlint-config-cozy": "0.6.0",
     "copyfiles": "2.4.1",
-    "cozy-client": "27.19.1",
+    "cozy-client": "28.1.0",
     "cozy-device-helper": "1.18.0",
     "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",
@@ -175,7 +175,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": ">=4.12",
-    "cozy-client": ">=27.19.1",
+    "cozy-client": ">=28.1.0",
     "cozy-device-helper": "^1.16.0",
     "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -2,8 +2,7 @@ import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 
-import { isMobileApp } from 'cozy-device-helper'
-import { getReferencedBy, useQuery, models } from 'cozy-client'
+import { getReferencedBy, useQuery, models, useClient } from 'cozy-client'
 
 import BottomSheet, { BottomSheetHeader } from '../../BottomSheet'
 
@@ -13,6 +12,7 @@ import Sharing from './Sharing'
 import ForwardButton from './ForwardButton'
 import DownloadButton from './DownloadButton'
 import BottomSheetContent from './BottomSheetContent'
+import { shouldBeForwardButton } from './helpers'
 
 const {
   contact: { getDisplayName }
@@ -32,7 +32,10 @@ const useStyles = makeStyles(theme => ({
 
 const FooterContent = ({ file, toolbarRef, disableSharing }) => {
   const styles = useStyles()
-  const FileActionButton = isMobileApp() ? ForwardButton : DownloadButton
+  const client = useClient()
+  const FileActionButton = shouldBeForwardButton(client)
+    ? ForwardButton
+    : DownloadButton
   const toolbarProps = useMemo(() => ({ ref: toolbarRef }), [toolbarRef])
 
   const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(

--- a/react/Viewer/Footer/ForwardButton.jsx
+++ b/react/Viewer/Footer/ForwardButton.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { useClient } from 'cozy-client'
-import { isIOS } from 'cozy-device-helper'
+import { useClient, useCapabilities, models } from 'cozy-client'
+import { isIOS, isMobileApp } from 'cozy-device-helper'
 
 import { useI18n } from '../../I18n'
 import Button from '../../Button'
@@ -12,23 +12,44 @@ import Alerter from '../../Alerter'
 import { withViewerLocales } from '../withViewerLocales'
 import { exportFilesNative } from './helpers'
 
+const {
+  sharing: { getSharingLink }
+} = models
+
 const ForwardIcon = isIOS() ? ShareIosIcon : ReplyIcon
 
 const ForwardButton = ({ file }) => {
   const { t } = useI18n()
   const client = useClient()
+  const { capabilities } = useCapabilities(client)
 
   const onFileOpen = async file => {
-    try {
-      await exportFilesNative(client, [file])
-    } catch (error) {
-      Alerter.info(`Viewer.error.${error}`, { fileMime: file.mime })
+    if (isMobileApp()) {
+      try {
+        await exportFilesNative(client, [file])
+      } catch (error) {
+        Alerter.info(`Viewer.error.${error}`, { fileMime: file.mime })
+      }
+    } else {
+      try {
+        const isFlatDomain = capabilities?.data?.attributes?.flat_subdomains
+        const url = await getSharingLink(client, file, isFlatDomain)
+        const shareData = {
+          title: t('Viewer.share.title', { name: file.name }),
+          text: t('Viewer.share.text', { name: file.name }),
+          url
+        }
+        navigator.share(shareData)
+      } catch (error) {
+        Alerter.error('Viewer.share.error', { error: error })
+      }
     }
   }
 
   return (
     <Button
       extension="full"
+      data-testid="openFileButton"
       theme="secondary"
       icon={ForwardIcon}
       label={t('Viewer.actions.forward')}

--- a/react/Viewer/Footer/ForwardButton.jsx
+++ b/react/Viewer/Footer/ForwardButton.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
-import { saveFileWithCordova } from 'cozy-client/dist/models/fsnative'
 import { isIOS } from 'cozy-device-helper'
 
 import { useI18n } from '../../I18n'
@@ -11,70 +10,7 @@ import ReplyIcon from '../../Icons/Reply'
 import ShareIosIcon from '../../Icons/ShareIos'
 import Alerter from '../../Alerter'
 import { withViewerLocales } from '../withViewerLocales'
-
-const isMissingFileError = error => error.status === 404
-const downloadFileError = error => {
-  return isMissingFileError(error)
-    ? 'Viewer.error.downloadFile.missing'
-    : 'Viewer.error.missing'
-}
-/**
- * exportFilesNative - Triggers a prompt to download a file on mobile devices
- *
- * @param {CozyClient} client
- * @param {array} files    One or more files to download
- * @param {string} filename The name of the file that will be saved
- */
-export const exportFilesNative = async (client, files, filename) => {
-  const downloadAllFiles = files.map(async file => {
-    const response = await client
-      .collection('io.cozy.files')
-      .fetchFileContentById(file.id)
-
-    const blob = await response.blob()
-    const filenameToUse = filename ? filename : file.name
-    const localFile = await saveFileWithCordova(blob, filenameToUse)
-    return localFile.nativeURL
-  })
-
-  try {
-    Alerter.info('Viewer.alert.preparing', {
-      duration: Math.min(downloadAllFiles.length * 2000, 6000)
-    })
-
-    const urls = await Promise.all(downloadAllFiles)
-    if (urls.length === 1 && isIOS()) {
-      // TODO
-      // It seems that files: is not well supported on iOS. url seems to work well
-      // at with one file. Need to check when severals
-      window.plugins.socialsharing.shareWithOptions(
-        {
-          url: urls[0]
-        },
-        result => {
-          if (result.completed === true) {
-            Alerter.success('Viewer.share.success')
-          }
-        },
-        error => {
-          throw error
-        }
-      )
-    } else {
-      window.plugins.socialsharing.shareWithOptions(
-        {
-          files: urls
-        },
-        null,
-        error => {
-          throw error
-        }
-      )
-    }
-  } catch (error) {
-    Alerter.error(downloadFileError(error))
-  }
-}
+import { exportFilesNative } from './helpers'
 
 const ForwardIcon = isIOS() ? ShareIosIcon : ReplyIcon
 
@@ -105,4 +41,5 @@ ForwardButton.propTypes = {
   file: PropTypes.object.isRequired
 }
 
+export { exportFilesNative }
 export default withViewerLocales(ForwardButton)

--- a/react/Viewer/Footer/ForwardButton.spec.jsx
+++ b/react/Viewer/Footer/ForwardButton.spec.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import { isMobileApp } from 'cozy-device-helper'
+import { models } from 'cozy-client'
+const {
+  sharing: { getSharingLink }
+} = models
+
+import DemoProvider from '../docs/DemoProvider'
+import ForwardButton from './ForwardButton'
+import { exportFilesNative } from './helpers'
+
+jest.mock('cozy-device-helper')
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  models: {
+    sharing: {
+      getSharingLink: jest.fn()
+    }
+  }
+}))
+jest.mock('./helpers')
+
+const file = {
+  _id: '123',
+  name: 'filename.pdf'
+}
+
+const setup = ({ isMobileApplication }) => {
+  isMobileApp.mockReturnValue(isMobileApplication)
+  return render(
+    <DemoProvider>
+      <ForwardButton file={file} />
+    </DemoProvider>
+  )
+}
+
+describe('ForwardButton', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('exportFilesNative', () => {
+    it('should call it if is on native app', async () => {
+      const { findByTestId } = setup({ isMobileApplication: true })
+
+      const btn = await findByTestId('openFileButton')
+      fireEvent.click(btn)
+
+      expect(exportFilesNative).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not call it if is on web app', async () => {
+      const { findByTestId } = setup({ isMobileApplication: false })
+
+      const btn = await findByTestId('openFileButton')
+      fireEvent.click(btn)
+
+      expect(exportFilesNative).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('getSharingLink', () => {
+    it('should not call it if is on native app', async () => {
+      const { findByTestId } = setup({ isMobileApplication: true })
+
+      const btn = await findByTestId('openFileButton')
+      fireEvent.click(btn)
+
+      expect(getSharingLink).toHaveBeenCalledTimes(0)
+    })
+
+    it('should call it if is on web app', async () => {
+      const { findByTestId } = setup({ isMobileApplication: false })
+
+      const btn = await findByTestId('openFileButton')
+      fireEvent.click(btn)
+
+      expect(getSharingLink).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/react/Viewer/Footer/helpers.js
+++ b/react/Viewer/Footer/helpers.js
@@ -1,0 +1,69 @@
+import { saveFileWithCordova } from 'cozy-client/dist/models/fsnative'
+import { isIOS } from 'cozy-device-helper'
+
+import Alerter from '../../Alerter'
+
+const isMissingFileError = error => error.status === 404
+const downloadFileError = error => {
+  return isMissingFileError(error)
+    ? 'Viewer.error.downloadFile.missing'
+    : 'Viewer.error.missing'
+}
+
+/**
+ * exportFilesNative - Triggers a prompt to download a file on mobile devices
+ *
+ * @param {CozyClient} client
+ * @param {array} files    One or more files to download
+ * @param {string} filename The name of the file that will be saved
+ */
+export const exportFilesNative = async (client, files, filename) => {
+  const downloadAllFiles = files.map(async file => {
+    const response = await client
+      .collection('io.cozy.files')
+      .fetchFileContentById(file.id)
+
+    const blob = await response.blob()
+    const filenameToUse = filename ? filename : file.name
+    const localFile = await saveFileWithCordova(blob, filenameToUse)
+    return localFile.nativeURL
+  })
+
+  try {
+    Alerter.info('Viewer.alert.preparing', {
+      duration: Math.min(downloadAllFiles.length * 2000, 6000)
+    })
+
+    const urls = await Promise.all(downloadAllFiles)
+    if (urls.length === 1 && isIOS()) {
+      // TODO
+      // It seems that files: is not well supported on iOS. url seems to work well
+      // at with one file. Need to check when severals
+      window.plugins.socialsharing.shareWithOptions(
+        {
+          url: urls[0]
+        },
+        result => {
+          if (result.completed === true) {
+            Alerter.success('Viewer.share.success')
+          }
+        },
+        error => {
+          throw error
+        }
+      )
+    } else {
+      window.plugins.socialsharing.shareWithOptions(
+        {
+          files: urls
+        },
+        null,
+        error => {
+          throw error
+        }
+      )
+    }
+  } catch (error) {
+    Alerter.error(downloadFileError(error))
+  }
+}

--- a/react/Viewer/Footer/helpers.js
+++ b/react/Viewer/Footer/helpers.js
@@ -1,7 +1,13 @@
 import { saveFileWithCordova } from 'cozy-client/dist/models/fsnative'
-import { isIOS } from 'cozy-device-helper'
+import { isIOS, isMobileApp } from 'cozy-device-helper'
 
 import Alerter from '../../Alerter'
+
+export const shouldBeForwardButton = client => {
+  const isDrive = client?.appMetadata?.slug === 'drive'
+  if (isMobileApp() || (navigator.share && !isDrive)) return true
+  return false
+}
 
 const isMissingFileError = error => error.status === 404
 const downloadFileError = error => {

--- a/react/Viewer/Footer/helpers.spec.js
+++ b/react/Viewer/Footer/helpers.spec.js
@@ -1,0 +1,77 @@
+import { isMobileApp } from 'cozy-device-helper'
+
+import { shouldBeForwardButton } from './helpers'
+
+jest.mock('cozy-device-helper')
+
+describe('shouldBeForwardButton', () => {
+  const setup = ({ isMobileApplication = false, appSlug = '' }) => {
+    const mockClient = { appMetadata: { slug: appSlug } }
+    isMobileApp.mockReturnValue(isMobileApplication)
+
+    return mockClient
+  }
+
+  describe('Mobile native', () => {
+    it('should be true if the mobile native application is "Drive"', () => {
+      global.navigator.share = null
+      const mockClient = setup({
+        appSlug: 'drive',
+        isMobileApplication: true
+      })
+
+      expect(shouldBeForwardButton(mockClient)).toBe(true)
+    })
+    it('should be true if the mobile native application is not "Drive"', () => {
+      global.navigator.share = null
+      const mockClient = setup({
+        appSlug: 'other',
+        isMobileApplication: true
+      })
+
+      expect(shouldBeForwardButton(mockClient)).toBe(true)
+    })
+  })
+
+  describe('Mobile web', () => {
+    it('should be false if the mobile web application is "Drive"', () => {
+      global.navigator.share = () => {}
+      const mockClient = setup({
+        appSlug: 'drive',
+        isMobileApplication: false
+      })
+
+      expect(shouldBeForwardButton(mockClient)).toBe(false)
+    })
+    it('should be true if the mobile web application is not "Drive"', () => {
+      global.navigator.share = () => {}
+      const mockClient = setup({
+        appSlug: 'other',
+        isMobileApplication: false
+      })
+
+      expect(shouldBeForwardButton(mockClient)).toBe(true)
+    })
+  })
+
+  describe('Desktop', () => {
+    it('should be false if the desktop application is "Drive"', () => {
+      global.navigator.share = null
+      const mockClient = setup({
+        appSlug: 'drive',
+        isMobileApplication: false
+      })
+
+      expect(shouldBeForwardButton(mockClient)).toBe(false)
+    })
+    it('should be false if the desktop application is not "Drive"', () => {
+      global.navigator.share = null
+      const mockClient = setup({
+        appSlug: 'other',
+        isMobileApplication: false
+      })
+
+      expect(shouldBeForwardButton(mockClient)).toBe(false)
+    })
+  })
+})

--- a/react/Viewer/locales/en.json
+++ b/react/Viewer/locales/en.json
@@ -60,6 +60,9 @@
     "scaledown": "Zoom out",
     "scaleup": "Zoom in",
     "share": {
+      "title": "Link to my document %{name}",
+      "text": "Here is a link to my document %{name}: ",
+      "error": "Problem with link recovery: %{error}",
       "success": "Your file has been shared with success"
     }
   }

--- a/react/Viewer/locales/fr.json
+++ b/react/Viewer/locales/fr.json
@@ -60,6 +60,9 @@
     "scaledown": "Zoom arrière",
     "scaleup": "Zoom avant",
     "share": {
+      "title": "Lien vers mon document %{name}",
+      "text": "Voici un lien vers mon document %{name} : ",
+      "error": "Problème avec la récupération du lien : %{error}",
       "success": "Votre fichier a été partagé avec succès"
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,19 +5991,16 @@ cozy-bi-auth@0.0.23:
     lodash "^4.17.20"
     node-jose "^1.1.4"
 
-cozy-client@27.19.1:
-  version "27.19.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-27.19.1.tgz#f7cab0257e290118e295d29436dd4731c014c7fc"
-  integrity sha512-kqDzQ/qgqwGBW6KTBppCxc1d00DEV1i0c7YpQXSAylTTXMk/FW6GF2Y51RJaESLYrTBJcLKmfkP79G/x0kQtrA==
+cozy-client@28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-28.1.0.tgz#2863dfd64fd7e61e3a3fd0efba291e7ae9ca0590"
+  integrity sha512-rIsaQaQjazNaQqXxO4JYRx6s9dJEGkN9nofaKfFZDwb+kuGZ555+qq+5jNR0PQHKFshy+eiI2mSh2RVw0Ag9QQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-device-helper "^1.12.0"
-    cozy-flags "2.7.1"
-    cozy-logger "^1.6.0"
-    cozy-stack-client "^27.19.1"
+    cozy-stack-client "^28.0.1"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -6124,12 +6121,21 @@ cozy-sharing@^3.10.0:
     react-tooltip "^3.11.1"
     snarkdown "^2.0.0"
 
-cozy-stack-client@27.19.1, cozy-stack-client@^27.19.1:
+cozy-stack-client@27.19.1:
   version "27.19.1"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-27.19.1.tgz#679253c6e028273b480b350583627389d98c6a69"
   integrity sha512-DdJCi0lHofWsnT4ZvX02uaELsvgNquuPFPaXulo8gw1x/mVoHsPn+Lpt9xCw35CvhJm3ajJQ709f7JT4lPbCSQ==
   dependencies:
     cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^28.0.1:
+  version "28.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-28.0.1.tgz#736cd74bdfe8e96d70b9b5f4ca35c922fe48553e"
+  integrity sha512-DBu3uWkoVLW0cbPv7H6U1vFQ1DNbe5oOZLr6yJGBOp/s/MrAzflqvM2pN0khpBtnSIm9KTwNzqRn4oOHRpagGg==
+  dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"


### PR DESCRIPTION
BREAKING CHANGE: You need to update `cozy-client` to `>28.1.0`.

We want to replace the "Download" button by a " Forward" button in the web applications in mobile mode (except the "Drive" application).

For the moment, we don't want to change the behavior on the "Drive" application, which has in web or native mode the "Share" & "Download" buttons.

Démo: https://merkur39.github.io/cozy-ui/react/#!/Viewer/1