### PR TITLE
fix: Upgrade cozy-device-helper in peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   "peerDependencies": {
     "@material-ui/core": ">=4.12",
     "cozy-client": ">=28.1.0",
-    "cozy-device-helper": "^1.16.0",
+    "cozy-device-helper": "^1.18.0",
     "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",
     "cozy-intent": ">=1.3.0",


### PR DESCRIPTION
BREAKING CHANGE: cozy-ui needs this updated version
The Flagship App API changed in cozy-device-helper.
Some components will break if the parent app does not have
cozy-device-helper at ^1.18.0