### PR TITLE
fix: `--iconColor` value for inverted theme

### DIFF
--- a/react/DateMonthPicker/styles.styl
+++ b/react/DateMonthPicker/styles.styl
@@ -4,12 +4,11 @@
 buttonHeight=3rem
 
 $buttonHover
-  background var(--paleGrey)
-  color var(--charcoalGrey)
+  background var(--defaultBackgroundColor)
+  color var(--primaryTextColor)
 
 $buttonActive
-  background-color var(--silver)
-  color var(--charcoalGrey)
+  background-color var(--actionColorFocus)
   font-weight bold
   outline 0
 
@@ -19,7 +18,7 @@ $button
   min-width 3rem
   display inline-block
   border-width 0
-  color var(--coolGrey)
+  color var(--secondaryTextColor)
   cursor pointer
 
   &:hover
@@ -36,7 +35,7 @@ $select
   display flex
   align-items center
   border-radius radius-8
-  border 1px solid var(--silver)
+  border 1px solid var(--borderMainColor)
   overflow hidden
 
 .DateMonthPicker__YearControls

--- a/react/DropdownButton/styles.styl
+++ b/react/DropdownButton/styles.styl
@@ -8,7 +8,9 @@
     border 0
     cursor pointer
     padding spacing_values.xs spacing_values.m
-  
+    color var(--primaryTextColor)
+
 .c-DropdownButton-Icon
+    color var(--iconTextColor)
     margin-top rem(4)
     margin-left rem(4)

--- a/react/Icon/Readme.md
+++ b/react/Icon/Readme.md
@@ -450,8 +450,7 @@ const icons = [
 const wrapperStyle = {
   fontSize: '2rem',
   display: 'grid',
-  gridTemplateColumns: 'repeat(6, 1fr)',
-  color: '#444'
+  gridTemplateColumns: 'repeat(6, 1fr)'
 }
 
 initialState = { size: 16 };

--- a/react/Infos/index.jsx
+++ b/react/Infos/index.jsx
@@ -32,7 +32,7 @@ export const Infos = ({
       {dismissAction && (
         <div className={styles['Info-close']}>
           <IconButton onClick={dismissAction} {...dismissButtonProps}>
-            <Icon icon={CrossIcon} size="12" className="u-coolGrey" />
+            <Icon icon={CrossIcon} size="12" />
           </IconButton>
         </div>
       )}

--- a/react/InfosCarrousel/styles.styl
+++ b/react/InfosCarrousel/styles.styl
@@ -27,6 +27,6 @@
 
 
 .InfosCarrousel-separator
-    border-left 1px solid var(--silver)
+    border-left 1px solid var(--dividerColor)
     height rem(16)
     margin 0 (spacing_values.xs)

--- a/react/Menu/styles.styl
+++ b/react/Menu/styles.styl
@@ -16,7 +16,7 @@
     // cuts the hover background properly (border-radius)
     overflow   hidden
     border     0
-    color      var(--charcoalGrey)
+    color      var(--primaryTextColor)
 
 .c-menu--left
     .c-menu__inner
@@ -45,7 +45,7 @@ $paddingItem = rem(8)
     cursor pointer
     padding   $paddingItem
     line-height 1.15
-    color var(--charcoalGrey)
+    color var(--primaryTextColor)
 
 .c-menu__item-icon
     $marginIcon = rem(12)
@@ -53,7 +53,6 @@ $paddingItem = rem(8)
     margin-right $marginIcon
     // we need to compensate for the already present margin
     margin-left $marginIcon - $paddingItem
-    color var(--slateGrey)
 
     svg
         width 1em
@@ -61,7 +60,7 @@ $paddingItem = rem(8)
 
 .c-menu__item:hover
 .c-menu__item:focus
-    background-color var(--paleGrey)
+    background-color var(--actionColorHover)
     outline          none
 
 .c-menu__item--disabled

--- a/react/NavigationList/Readme.md
+++ b/react/NavigationList/Readme.md
@@ -40,7 +40,7 @@ const NavigationListExample = ({ style }) => {
             <Icon
               icon={RightIcon}
               size={smallSize}
-              className="u-mr-1 u-coolGrey"
+              className="u-mr-1"
             />
           </ListItemSecondaryAction>
         </ListItem>
@@ -54,10 +54,10 @@ const NavigationListExample = ({ style }) => {
             <Icon
               icon={RightIcon}
               size={smallSize}
-              className="u-mr-1 u-coolGrey"
+              className="u-mr-1"
             />
           </ListItemSecondaryAction>
-        </ListItem>        
+        </ListItem>
         <Divider variant="inset" />
         <ListItem>
           <ListItemIcon>
@@ -71,7 +71,7 @@ const NavigationListExample = ({ style }) => {
             <Icon
               icon={RightIcon}
               size={smallSize}
-              className="u-mr-1 u-coolGrey"
+              className="u-mr-1"
             />
           </ListItemSecondaryAction>
         </ListItem>
@@ -99,7 +99,7 @@ const NavigationListExample = ({ style }) => {
             <Icon
               icon={RightIcon}
               size={smallSize}
-              className="u-mr-1 u-coolGrey"
+              className="u-mr-1"
             />
           </ListItemSecondaryAction>
         </ListItem>
@@ -130,7 +130,7 @@ const TabsExample = () => {
       <Divider className='u-mb-1' />
       { tab == 'nav' ?
         <NavigationListExample /> : null }
-      { tab == 'details' ? 
+      { tab == 'details' ?
         <Typography variant='body1'>
           { content.ada.short }
         </Typography> : null

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2855,7 +2855,7 @@ exports[`HistoryRow should render examples: HistoryRow 1`] = `
 exports[`Icon should render examples: Icon 1`] = `
 "<div>
   <p class=\\"MuiTypography-root u-mb-1 MuiTypography-body1\\">Font size: <input type=\\"range\\" min=\\"8\\" max=\\"48\\" value=\\"16\\"> 16px</p>
-  <div style=\\"font-size: 2rem; display: grid; grid-template-columns: repeat(6, 1fr); color: rgb(68, 68, 68);\\">
+  <div style=\\"font-size: 2rem; display: grid; grid-template-columns: repeat(6, 1fr);\\">
     <div class=\\"makeStyles-iconTile-36 u-ta-center u-mb-1\\"><svg viewBox=\\"0 0 16 16\\" class=\\"styles__icon___23x3R\\" width=\\"16\\" height=\\"16\\">
         <path fill-rule=\\"evenodd\\" d=\\"M1 3.01A3.005 3.005 0 014.003 0h9.99C14.55 0 15 .444 15 1c0 .552-.456 1-1.002 1H4.002a1 1 0 00-.012 2H8.51C8.78 4 9 4.228 9 4.491V10l1.5-1 1.5 1V4.491A.49.49 0 0112.495 4h1.506c.552 0 .999.456.999 1.002v9.996C15 15.55 14.55 16 13.993 16h-9.99A3 3 0 011 12.99V3.01z\\"></path>
       </svg>
@@ -7391,7 +7391,7 @@ exports[`Infos should render examples: Infos 1`] = `
         </div>
         <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>one</span></span></button><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>two</span></span></button><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--center___16_Xh\\"><span><span>three</span></span></button></div>
       </div>
-      <div class=\\"styles__Info-close___1RVQP\\"><button class=\\"MuiButtonBase-root MuiIconButton-root\\" tabindex=\\"0\\" type=\\"button\\"><span class=\\"MuiIconButton-label\\"><svg viewBox=\\"0 0 24 24\\" class=\\"u-coolGrey styles__icon___23x3R\\" width=\\"12\\" height=\\"12\\"><path fill-rule=\\"evenodd\\" d=\\"M10.586 12L.293 1.707A1 1 0 011.707.293L12 10.586 22.293.293a1 1 0 011.414 1.414L13.414 12l10.293 10.293a1 1 0 01-1.414 1.414L12 13.414 1.707 23.707a1 1 0 01-1.414-1.414L10.586 12z\\"></path></svg></span></button></div>
+      <div class=\\"styles__Info-close___1RVQP\\"><button class=\\"MuiButtonBase-root MuiIconButton-root\\" tabindex=\\"0\\" type=\\"button\\"><span class=\\"MuiIconButton-label\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" width=\\"12\\" height=\\"12\\"><path fill-rule=\\"evenodd\\" d=\\"M10.586 12L.293 1.707A1 1 0 011.707.293L12 10.586 22.293.293a1 1 0 011.414 1.414L13.414 12l10.293 10.293a1 1 0 01-1.414 1.414L12 13.414 1.707 23.707a1 1 0 01-1.414-1.414L10.586 12z\\"></path></svg></span></button></div>
     </div>
   </div>
 </div>"
@@ -7414,7 +7414,7 @@ exports[`InfosCarrousel should render examples: InfosCarrousel 1`] = `
                 </div>
                 <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--center___16_Xh\\"><span><span>A CTA button</span></span></button></div>
               </div>
-              <div class=\\"styles__Info-close___1RVQP\\"><button class=\\"MuiButtonBase-root MuiIconButton-root\\" tabindex=\\"0\\" type=\\"button\\"><span class=\\"MuiIconButton-label\\"><svg viewBox=\\"0 0 24 24\\" class=\\"u-coolGrey styles__icon___23x3R\\" width=\\"12\\" height=\\"12\\"><path fill-rule=\\"evenodd\\" d=\\"M10.586 12L.293 1.707A1 1 0 011.707.293L12 10.586 22.293.293a1 1 0 011.414 1.414L13.414 12l10.293 10.293a1 1 0 01-1.414 1.414L12 13.414 1.707 23.707a1 1 0 01-1.414-1.414L10.586 12z\\"></path></svg></span></button></div>
+              <div class=\\"styles__Info-close___1RVQP\\"><button class=\\"MuiButtonBase-root MuiIconButton-root\\" tabindex=\\"0\\" type=\\"button\\"><span class=\\"MuiIconButton-label\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" width=\\"12\\" height=\\"12\\"><path fill-rule=\\"evenodd\\" d=\\"M10.586 12L.293 1.707A1 1 0 011.707.293L12 10.586 22.293.293a1 1 0 011.414 1.414L13.414 12l10.293 10.293a1 1 0 01-1.414 1.414L12 13.414 1.707 23.707a1 1 0 01-1.414-1.414L10.586 12z\\"></path></svg></span></button></div>
             </div>
           </div>
           <div style=\\"width: 100%; flex-shrink: 0; overflow: auto; overflow-y: hidden;\\" aria-hidden=\\"true\\" data-swipeable=\\"true\\">
@@ -7428,7 +7428,7 @@ exports[`InfosCarrousel should render examples: InfosCarrousel 1`] = `
                 </div>
                 <div><button type=\\"submit\\" class=\\"styles__c-btn___-2Vnj styles__c-btn--secondary___3Br_N styles__c-btn--center___16_Xh\\"><span><span>A CTA button</span></span></button></div>
               </div>
-              <div class=\\"styles__Info-close___1RVQP\\"><button class=\\"MuiButtonBase-root MuiIconButton-root\\" tabindex=\\"0\\" type=\\"button\\"><span class=\\"MuiIconButton-label\\"><svg viewBox=\\"0 0 24 24\\" class=\\"u-coolGrey styles__icon___23x3R\\" width=\\"12\\" height=\\"12\\"><path fill-rule=\\"evenodd\\" d=\\"M10.586 12L.293 1.707A1 1 0 011.707.293L12 10.586 22.293.293a1 1 0 011.414 1.414L13.414 12l10.293 10.293a1 1 0 01-1.414 1.414L12 13.414 1.707 23.707a1 1 0 01-1.414-1.414L10.586 12z\\"></path></svg></span></button></div>
+              <div class=\\"styles__Info-close___1RVQP\\"><button class=\\"MuiButtonBase-root MuiIconButton-root\\" tabindex=\\"0\\" type=\\"button\\"><span class=\\"MuiIconButton-label\\"><svg viewBox=\\"0 0 24 24\\" class=\\"styles__icon___23x3R\\" width=\\"12\\" height=\\"12\\"><path fill-rule=\\"evenodd\\" d=\\"M10.586 12L.293 1.707A1 1 0 011.707.293L12 10.586 22.293.293a1 1 0 011.414 1.414L13.414 12l10.293 10.293a1 1 0 01-1.414 1.414L12 13.414 1.707 23.707a1 1 0 01-1.414-1.414L10.586 12z\\"></path></svg></span></button></div>
             </div>
           </div>
         </div>

--- a/stylus/components/action-menu.styl
+++ b/stylus/components/action-menu.styl
@@ -11,7 +11,7 @@ $actionmenu
     --iconColor: var(--actionMenuIconColor)
     padding-bottom rem(9)
     padding-bottom env(safe-area-inset-bottom)
-    
+
     hr
         margin-top 0
 
@@ -36,7 +36,7 @@ $actionmenu-item
     cursor pointer
 
     &:hover
-        background-color var(--paleGrey)
+        background-color var(--actionColorHover)
 
 $actionmenu-radio
     height 1rem

--- a/stylus/settings/themes/inverted.styl
+++ b/stylus/settings/themes/inverted.styl
@@ -70,7 +70,7 @@ palette=json('../../../theme/palette.json', { hash: true })
     The CSS variables below are historic and we should strive not to
     use them. Prefer to use directly semantic colors above.
     */
-    --iconColor var(--secondaryTextColor)
+    --iconColor currentColor
     --textIconColor palette.Common['white']
     --barIconColor palette.Common['white']
     --barIconColorDisabled rgba(255, 255, 255, 0.88)

--- a/stylus/settings/themes/inverted.styl
+++ b/stylus/settings/themes/inverted.styl
@@ -72,6 +72,7 @@ palette=json('../../../theme/palette.json', { hash: true })
     */
     --iconColor currentColor
     --textIconColor palette.Common['white']
+    --actionMenuIconColor palette.Common['white']
     --barIconColor palette.Common['white']
     --barIconColorDisabled rgba(255, 255, 255, 0.88)
 


### PR DESCRIPTION
`--iconColor` est utilisé pour remplir la couleur du svg d'une icône https://github.com/cozy/cozy-ui/blob/master/react/Icon/styles.styl#L4 or cette couleur devrait être un héritage de la couleur définie dans le composant, et non une valeur en dur comme c'était le cas jusqu'à aujourd'hui.

On corrige au passage les erreurs de couleur qu'on avait à droite à gauche, en grande majorité pour le theme inversé, oh yeah 🎉 