### PR TITLE
fix: Export toolbarPropsPropType correctly

### DIFF
--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -2,7 +2,7 @@ import ViewerContainer from './ViewerContainer'
 
 export { default as Viewer } from './Viewer'
 export { default as ViewerContainer } from './ViewerContainer'
-export { toolbarPropsPropType } from './proptypes'
+export * as toolbarPropsPropType from './proptypes'
 export {
   default as ViewerWithCustomPanelAndFooter
 } from './ViewerWithCustomPanelAndFooter'


### PR DESCRIPTION
to be able to `import { toolbarPropsPropType } from
'cozy-ui/transpiled/react/Viewer'`

Vu avec @paultranvan sur Drive, ça posait souci sur les tests qui font des imports non profonds du style `{ xxx } from cozy-ui/transpiled/react`