### PR TITLE
fix(IconButton): Implementation of forwardRef

### DIFF
--- a/react/IconButton/index.jsx
+++ b/react/IconButton/index.jsx
@@ -3,20 +3,21 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import MuiIconButton from '@material-ui/core/IconButton'
 
-const IconButton = (
-  { size = 'medium', className, children, ...props },
-  ref
-) => {
-  return (
-    <MuiIconButton ref={ref} className={cx(className, size)} {...props}>
-      {children}
-    </MuiIconButton>
-  )
-}
+const IconButton = forwardRef(
+  ({ size = 'medium', className, children, ...props }, ref) => {
+    return (
+      <MuiIconButton ref={ref} className={cx(className, size)} {...props}>
+        {children}
+      </MuiIconButton>
+    )
+  }
+)
+
+IconButton.displayName = 'IconButton'
 
 IconButton.propTypes = {
   className: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large'])
 }
 
-export default forwardRef(IconButton)
+export default IconButton


### PR DESCRIPTION
By wrapping the component when exporting it, propTypes can't work anymore and we get this kind of warning in console:

```
Warning: forwardRef render functions do not support propTypes or defaultProps. Did you accidentally pass a React component?
```

We need to use the forwardRef as implemented on this PR or as here: https://bit.ly/3ykcWZx

More info: https://github.com/facebook/react/issues/16653