### PR TITLE
Fix hover on mobile for CircleButton and Buttons

### DIFF
--- a/react/CircleButton/index.jsx
+++ b/react/CircleButton/index.jsx
@@ -18,7 +18,11 @@ const useStyles = makeStyles(theme => ({
       active ? theme.palette.primary.contrastText : theme.palette.text.icon,
     '&:hover': {
       backgroundColor: ({ active }) =>
-        active ? theme.palette.primary.dark : theme.palette.action.hover
+        active ? theme.palette.primary.dark : theme.palette.action.hover,
+      '@media (hover: none)': {
+        backgroundColor: ({ active }) =>
+          active ? theme.palette.primary.main : 'transparent'
+      }
     }
   },
   typography: {

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -106,7 +106,10 @@ const makeSecondaryButtonStyle = (theme, color) => ({
     backgroundColor: alpha(
       theme.palette[color].main,
       theme.palette.action.hoverOpacity
-    )
+    ),
+    '@media (hover: none)': {
+      backgroundColor: 'transparent'
+    }
   },
   '&.ghost': {
     backgroundColor: alpha(
@@ -117,7 +120,13 @@ const makeSecondaryButtonStyle = (theme, color) => ({
       backgroundColor: alpha(
         theme.palette[color].main,
         theme.palette.action.hoverGhostOpacity
-      )
+      ),
+      '@media (hover: none)': {
+        backgroundColor: alpha(
+          theme.palette[color].main,
+          theme.palette.action.ghostOpacity
+        )
+      }
     }
   }
 })
@@ -128,7 +137,10 @@ const makeTextButtonStyle = (theme, color) => ({
     backgroundColor: alpha(
       theme.palette[color].main,
       theme.palette.action.hoverOpacity
-    )
+    ),
+    '@media (hover: none)': {
+      backgroundColor: 'transparent'
+    }
   }
 })
 
@@ -136,7 +148,10 @@ const makeContainedButtonStyle = (theme, color) => ({
   color: theme.palette[color].contrastText,
   backgroundColor: theme.palette[color].main,
   '&:hover': {
-    backgroundColor: theme.palette[color].dark
+    backgroundColor: theme.palette[color].dark,
+    '@media (hover: none)': {
+      backgroundColor: theme.palette[color].main
+    }
   }
 })
 
@@ -207,7 +222,13 @@ const makeOverrides = theme => ({
             backgroundColor: alpha(
               theme.palette.primary.main,
               theme.palette.action.hoverGhostOpacity
-            )
+            ),
+            '@media (hover: none)': {
+              backgroundColor: alpha(
+                theme.palette.primary.main,
+                theme.palette.action.ghostOpacity
+              )
+            }
           }
         },
         '&.customColor': {
@@ -215,7 +236,10 @@ const makeOverrides = theme => ({
             color: theme.palette.text.primary,
             borderColor: theme.palette.border.main,
             '&:hover': {
-              backgroundColor: theme.palette.action.hover
+              backgroundColor: theme.palette.action.hover,
+              '@media (hover: none)': {
+                backgroundColor: 'transparent'
+              }
             },
             '&.ghost': {
               color: theme.palette.primary.main,


### PR DESCRIPTION
Permet de corriger le fait que l'effet hover s'affiche au clic sur le bouton, alors que ça ne devrait pas

Utilisation de la même approche que Mui : 
https://github.com/mui/material-ui/blob/v4.x/packages/material-ui/src/Button/Button.js#L117

Pour reproduire le souci sur la doc qu'on a en prod : passer en vue mobile, cliquer sur le bouton : on constate que l'effet hover reste actif.

demo : https://jf-cozy.github.io/cozy-ui/react/#!/CircleButton
https://jf-cozy.github.io/cozy-ui/react/#!/Buttons