### PR TITLE
fix(viewer): Amiral displays PDF without enough margin-top

### DIFF
--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -103,8 +103,8 @@ $viewerMarginTopMedium = $toolbarHeightMedium - $footerHeight
 
 .viewer-pdfMobile
     width 100%
-    height 'calc(100% - %s)' % $viewerHeightMedium
-    margin-top $viewerMarginTopMedium
+    height 'calc(100% - %s - var(--flagship-top-height))' % $viewerHeightMedium
+    margin-top 'calc(var(--flagship-top-height) + %s)' % $viewerMarginTopMedium
 
     &--image
         width 100%


### PR DESCRIPTION
This is dued to viewer-toolbar padding-top set to flagship-top-height

Adding only top-height was not enough, the best optimization found, is x2

Before:
![Capture d’écran 2022-05-11 à 12 04 32](https://user-images.githubusercontent.com/8363334/167824973-08ecc8e1-fba0-473e-8827-aec34b0bb69b.png)

After:
![Capture d’écran 2022-05-11 à 12 05 30](https://user-images.githubusercontent.com/8363334/167825130-d088d4a9-7a4f-4b39-bf08-3d9c0472333e.png)

