### PR TITLE
fix: Matomo tracking

### DIFF
--- a/react/helpers/tracker.jsx
+++ b/react/helpers/tracker.jsx
@@ -81,40 +81,26 @@ export const configureTracker = (options = {}) => {
   }
 
   let appName
-  let cozyDomain
-  let userIdFromCozyDomain
 
   const root = document.querySelector('[role=application]')
 
   if (root && root.dataset) {
-    appName = readCozyDataFromDOM('appName')
-    cozyDomain = readCozyDataFromDOM('cozyDomain')
+    appName = readCozyDataFromDOM('appName') || readCozyDataFromDOM('app').name
   }
-
-  if (cozyDomain) {
-    userIdFromCozyDomain = cozyDomain
-    let indexOfPort = cozyDomain.indexOf(':')
-    if (indexOfPort >= 0) {
-      userIdFromCozyDomain = userIdFromCozyDomain.substring(0, indexOfPort)
-    }
-  }
-
   // merge default options with what has been provided
-  const { heartbeat, userId, app, appDimensionId } = Object.assign(
+  const { app, appDimensionId } = Object.assign(
     {
-      userId: userIdFromCozyDomain,
       appDimensionId: __PIWIK_DIMENSION_ID_APP__,
-      app: appName,
-      heartbeat: 15
+      app: appName
     },
     options
   )
 
-  // apply them
-  if (parseInt(heartbeat) > 0)
-    trackerInstance.push(['enableHeartBeatTimer', parseInt(heartbeat, 10)])
-  trackerInstance.push(['setUserId', userId])
   trackerInstance.push(['setCustomDimension', appDimensionId, app])
+  trackerInstance.push([
+    'setCustomUrl',
+    window.location.pathname.substr(1) + location.search
+  ])
 }
 
 /**

--- a/react/helpers/tracker.spec.js
+++ b/react/helpers/tracker.spec.js
@@ -57,8 +57,6 @@ describe('configureTracker', () => {
     )}' />`
 
     trackerFile.configureTracker({ app: 'banks2' })
-    expect(tracker.push).toHaveBeenCalledWith(['enableHeartBeatTimer', 15])
-    expect(tracker.push).toHaveBeenCalledWith(['setUserId', 'cozy.tools'])
     expect(tracker.push).toHaveBeenCalledWith([
       'setCustomDimension',
       1234,


### PR DESCRIPTION
Can read appName with both cozy-data={} and
cozy-data-appname to support all our apps.

We do not want to use the userID, and we
and to  remove the tracked domain
or hostname from all page URLs.

(fix a small part of https://github.com/cozy/cozy-ui/pull/1888/files) 