### PR TITLE
fix(npmignore): Reduce npm size of the package by ignoring /react files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,12 +1,24 @@
 test
 build
-
+react
+scripts
+.bundlemonrc
+.nvmrc
 .editorconfig
 .eslintignore
 .eslintrc.json
+.nvmrc
 .stylintrc
 .travis.yml
+babel.config.js
+CODEOWNERS
+index.js
+preprocess.js
+release.config.js
 renovate.json
+rsgscreenshots.json
+svgo.config.js
+tsconfig.json
 yarn.lock
 
 .changelog


### PR DESCRIPTION
BREAKING CHANGE: any import of @cozy-ui/react will fail
replace @cozy-ui/react by @cozy-ui/transpiled/react


While analysing @cozy-ui folder in node_modules I realized, a lot of useless file were present.
The .npmignore file will prevent those files to be present in the npm package.
More info: https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package