### PR TITLE
fix: Action buttons at the bottom of Dialog/IllustrationDialog on mobile

### DIFF
--- a/react/CozyDialogs/ConfirmDialog.jsx
+++ b/react/CozyDialogs/ConfirmDialog.jsx
@@ -48,7 +48,13 @@ const ConfirmDialog = props => {
               <DialogTitle {...dialogTitleProps}>{title}</DialogTitle>
             </div>
           )}
-          {content}
+          <div
+            className={cx('dialogContentWrapper', {
+              withActions: Boolean(actions)
+            })}
+          >
+            {content}
+          </div>
           {actions && (
             <DialogActions
               {...dialogActionsProps}

--- a/react/CozyDialogs/Dialog.jsx
+++ b/react/CozyDialogs/Dialog.jsx
@@ -50,7 +50,13 @@ const Dialog = props => {
       )}
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
-          {content}
+          <div
+            className={cx('dialogContentWrapper', {
+              withActions: Boolean(actions)
+            })}
+          >
+            {content}
+          </div>
           {actions && (
             <DialogActions
               {...dialogActionsProps}

--- a/react/CozyDialogs/IllustrationDialog.jsx
+++ b/react/CozyDialogs/IllustrationDialog.jsx
@@ -48,7 +48,13 @@ const IllustrationDialog = props => {
               <div className="u-flex u-flex-justify-center">{title}</div>
             </DialogTitle>
           )}
-          {content}
+          <div
+            className={cx('dialogContentWrapper', {
+              withActions: Boolean(actions)
+            })}
+          >
+            {content}
+          </div>
           {actions && (
             <DialogActions
               {...dialogActionsProps}

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -577,7 +577,19 @@ const makeOverrides = theme => ({
         marginBottom: '24px',
         '&.withFluidActions': {
           [theme.breakpoints.down('sm')]: {
-            marginBottom: '16px'
+            marginBottom: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            '& .dialogContentWrapper': {
+              flexGrow: 1,
+              '&:not(.withActions)': {
+                paddingBottom: '16px'
+              }
+            },
+            '& .cozyDialogActions': {
+              paddingBottom: '16px'
+            }
           }
         },
         '& .dialogTitleFluidContainer': {


### PR DESCRIPTION
fix https://github.com/cozy/cozy-ui/issues/1868

pas de modif sur desktop.

Sur mobile, pas de modif non plus pour les dialogs avec un long content, cela ne concerne donc que les dialog avec un short content. J'ai également vérifié, lorsqu'il n'y a pas d'action button, qu'on ait bien les mêmes marges bottom qu'avant.

demo : https://jf-cozy.github.io/cozy-ui/react/#!/CozyDialogs