### PR TITLE
test: Add getPanelBlocks from Drive

### DIFF
--- a/react/Viewer/Panel/getPanelBlocks.spec.jsx
+++ b/react/Viewer/Panel/getPanelBlocks.spec.jsx
@@ -1,0 +1,60 @@
+import getPanelBlocks from './getPanelBlocks'
+
+jest.mock('cozy-harvest-lib/dist/components/KonnectorBlock', () => jest.fn())
+const block1Component = jest.fn()
+const block2Component = jest.fn()
+
+describe('getPanelBlocks', () => {
+  it('should return only blocks with truthy condition', () => {
+    // with two truthy component
+    expect(
+      getPanelBlocks({
+        panelBlocksSpecs: {
+          block1: {
+            condition: () => true,
+            component: block1Component
+          },
+          block2: {
+            condition: () => true,
+            component: block2Component
+          }
+        }
+      })
+    ).toMatchObject([block1Component, block2Component])
+
+    // with one truthy component
+    expect(
+      getPanelBlocks({
+        panelBlocksSpecs: {
+          block1: {
+            condition: () => false,
+            component: block1Component
+          },
+          block2: {
+            condition: () => true,
+            component: block2Component
+          }
+        }
+      })
+    ).toMatchObject([block2Component])
+
+    // with no truthy component
+    expect(
+      getPanelBlocks({
+        panelBlocksSpecs: {
+          block1: {
+            condition: () => false,
+            component: block1Component
+          },
+          block2: {
+            condition: () => false,
+            component: block2Component
+          }
+        }
+      })
+    ).toMatchObject([])
+
+    // with no specs
+    expect(getPanelBlocks({ panelBlocksSpecs: {} })).toMatchObject([])
+  })
+})


### PR DESCRIPTION
we removed it in Drive because no longer required, so moved it in cozy-ui
See https://github.com/cozy/cozy-drive/pull/2607