### PR TITLE
Make the Viewer Footer composable

### DIFF
--- a/react/Viewer/Footer.jsx
+++ b/react/Viewer/Footer.jsx
@@ -1,12 +1,14 @@
 import React from 'react'
 
-import withBreakpoints from '../helpers/withBreakpoints'
+import useBreakpoints from '../hooks/useBreakpoints'
 
 import styles from './styles.styl'
 
-const Footer = ({ children, breakpoints: { isDesktop } }) => {
+const Footer = ({ children }) => {
+  const { isDesktop } = useBreakpoints()
+
   if (isDesktop) return null
   return <div className={styles['viewer-footer']}>{children}</div>
 }
 
-export default withBreakpoints()(Footer)
+export default Footer

--- a/react/Viewer/Footer/DownloadButton.jsx
+++ b/react/Viewer/Footer/DownloadButton.jsx
@@ -31,7 +31,7 @@ const DownloadButton = ({ file, t }) => {
 }
 
 DownloadButton.propTypes = {
-  file: PropTypes.object.isRequired
+  file: PropTypes.object
 }
 
 export default withViewerLocales(DownloadButton)

--- a/react/Viewer/Footer/FooterActionButtons.jsx
+++ b/react/Viewer/Footer/FooterActionButtons.jsx
@@ -1,0 +1,20 @@
+import { cloneElement } from 'react'
+import PropTypes from 'prop-types'
+
+import { mapToAllChildren } from './helpers'
+
+const FooterActionButtons = ({ children, file }) => {
+  if (!children) return null
+
+  return mapToAllChildren(children, child => cloneElement(child, { file }))
+}
+
+FooterActionButtons.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node)
+  ]),
+  file: PropTypes.object
+}
+
+export default FooterActionButtons

--- a/react/Viewer/Footer/FooterActionButtons.spec.jsx
+++ b/react/Viewer/Footer/FooterActionButtons.spec.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import FooterActionButtons from './FooterActionButtons'
+
+describe('FooterActionButtons', () => {
+  it('should not return children', () => {
+    const { container } = render(<FooterActionButtons />)
+
+    expect(container).toMatchInlineSnapshot('<div />')
+  })
+
+  it('should render all childrens', () => {
+    const { getByText } = render(
+      <FooterActionButtons>
+        <div>
+          <p>First child</p>
+          <div>
+            <p>Sub first children</p>
+          </div>
+        </div>
+        <div>Second child</div>
+      </FooterActionButtons>
+    )
+
+    expect(getByText('First child'))
+    expect(getByText('Sub first children'))
+    expect(getByText('Second child'))
+  })
+})

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -2,17 +2,11 @@ import React, { useMemo, Children, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 
-import { getReferencedBy, useQuery, models } from 'cozy-client'
-
 import BottomSheet, { BottomSheetHeader } from '../../BottomSheet'
 
-import { buildContactByIdsQuery } from '../queries'
 import { isValidForPanel } from '../helpers'
 import BottomSheetContent from './BottomSheetContent'
-
-const {
-  contact: { getDisplayName }
-} = models
+import useReferencedContactName from './useReferencedContactName'
 
 const useStyles = makeStyles(theme => ({
   footer: {
@@ -31,18 +25,7 @@ const FooterContent = ({ file, toolbarRef, children }) => {
 
   const toolbarProps = useMemo(() => ({ ref: toolbarRef }), [toolbarRef])
 
-  const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(
-    ref => ref.id
-  )
-  const contactByIdsQuery = buildContactByIdsQuery(contactIds)
-  const { data: contactList } = useQuery(contactByIdsQuery.definition, {
-    ...contactByIdsQuery.options,
-    enabled: contactIds.length > 0
-  })
-
-  const contactsFullname = Array.isArray(contactList)
-    ? contactList.map(contact => `${getDisplayName(contact)}`).join(', ')
-    : ''
+  const { contactName, isLoadingContacts } = useReferencedContactName(file)
 
   const FooterActionButtons = Children.toArray(children).find(child => {
     return (
@@ -55,16 +38,14 @@ const FooterContent = ({ file, toolbarRef, children }) => {
     file
   })
 
-  if (
-    isValidForPanel({ file }) &&
-    (contactsFullname || contactIds.length === 0)
-  ) {
+  // We have to wait for the Contact request to finish before rendering `BottomSheet`, because it doesn't handle async well.
+  if (isValidForPanel({ file }) && !isLoadingContacts) {
     return (
       <BottomSheet toolbarProps={toolbarProps}>
         <BottomSheetHeader className="u-ph-1 u-pb-1">
           {FooterActionButtonsWithFile}
         </BottomSheetHeader>
-        <BottomSheetContent file={file} contactsFullname={contactsFullname} />
+        <BottomSheetContent file={file} contactsFullname={contactName} />
       </BottomSheet>
     )
   }

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -9,10 +9,8 @@ import BottomSheet, { BottomSheetHeader } from '../../BottomSheet'
 import { buildContactByIdsQuery } from '../queries'
 import { isValidForPanel } from '../helpers'
 import Sharing from './Sharing'
-import ForwardButton from './ForwardButton'
-import DownloadButton from './DownloadButton'
 import BottomSheetContent from './BottomSheetContent'
-import { shouldBeForwardButton } from './helpers'
+import ForwardOrDownloadButton from './ForwardOrDownloadButton'
 
 const {
   contact: { getDisplayName }
@@ -33,9 +31,6 @@ const useStyles = makeStyles(theme => ({
 const FooterContent = ({ file, toolbarRef, disableSharing }) => {
   const styles = useStyles()
   const client = useClient()
-  const FileActionButton = shouldBeForwardButton(client)
-    ? ForwardButton
-    : DownloadButton
   const toolbarProps = useMemo(() => ({ ref: toolbarRef }), [toolbarRef])
 
   const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(
@@ -59,7 +54,7 @@ const FooterContent = ({ file, toolbarRef, disableSharing }) => {
       <BottomSheet toolbarProps={toolbarProps}>
         <BottomSheetHeader className="u-ph-1 u-pb-1">
           {!disableSharing && <Sharing file={file} />}
-          <FileActionButton file={file} />
+          <ForwardOrDownloadButton file={file} />
         </BottomSheetHeader>
         <BottomSheetContent file={file} contactsFullname={contactsFullname} />
       </BottomSheet>

--- a/react/Viewer/Footer/ForwardOrDownloadButton.jsx
+++ b/react/Viewer/Footer/ForwardOrDownloadButton.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+
+import ForwardButton from './ForwardButton'
+import DownloadButton from './DownloadButton'
+import { shouldBeForwardButton } from './helpers'
+
+const ForwardOrDownloadButton = ({ file }) => {
+  const client = useClient()
+
+  const FileActionButton = shouldBeForwardButton(client)
+    ? ForwardButton
+    : DownloadButton
+
+  return <FileActionButton file={file} />
+}
+
+ForwardOrDownloadButton.propTypes = {
+  file: PropTypes.object
+}
+
+export default ForwardOrDownloadButton

--- a/react/Viewer/Footer/Sharing.jsx
+++ b/react/Viewer/Footer/Sharing.jsx
@@ -37,7 +37,7 @@ const Sharing = ({ file }) => {
 }
 
 Sharing.propTypes = {
-  file: PropTypes.object.isRequired
+  file: PropTypes.object
 }
 
 export default Sharing

--- a/react/Viewer/Footer/helpers.js
+++ b/react/Viewer/Footer/helpers.js
@@ -1,3 +1,4 @@
+import { isValidElement, Children, cloneElement } from 'react'
 import { saveFileWithCordova } from 'cozy-client/dist/models/fsnative'
 import { isIOS, isMobileApp } from 'cozy-device-helper'
 
@@ -72,4 +73,19 @@ export const exportFilesNative = async (client, files, filename) => {
   } catch (error) {
     Alerter.error(downloadFileError(error))
   }
+}
+
+export const mapToAllChildren = (children, cb) => {
+  return Children.map(children, child => {
+    if (!isValidElement(child)) return child
+
+    const grandchildren = child.props.children
+    if (grandchildren) {
+      return cloneElement(child, {
+        children: mapToAllChildren(grandchildren, cb)
+      })
+    }
+
+    return cb(child)
+  })
 }

--- a/react/Viewer/Footer/useReferencedContactName.jsx
+++ b/react/Viewer/Footer/useReferencedContactName.jsx
@@ -1,0 +1,32 @@
+import { getReferencedBy, useQuery, models, isQueryLoading } from 'cozy-client'
+
+import { buildContactByIdsQuery } from '../queries'
+
+const {
+  contact: { getDisplayName }
+} = models
+
+const useReferencedContactName = file => {
+  const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(
+    ref => ref.id
+  )
+  const contactByIdsQuery = buildContactByIdsQuery(contactIds)
+  const { data: contacts, ...contactsQueryResult } = useQuery(
+    contactByIdsQuery.definition,
+    {
+      ...contactByIdsQuery.options,
+      enabled: contactIds.length > 0
+    }
+  )
+
+  const isLoadingContacts =
+    isQueryLoading(contactsQueryResult) || contactsQueryResult.hasMore
+
+  const contactName =
+    contacts && contacts.length > 0
+      ? contacts.map(contact => `${getDisplayName(contact)}`).join(', ')
+      : ''
+
+  return { contactName, isLoadingContacts }
+}
+export default useReferencedContactName

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -28,11 +28,14 @@ import CarbonCopyIcon from 'cozy-ui/transpiled/react/Icons/CarbonCopy';
 // The DemoProvider inserts a fake cozy-client in the React context.
 import DemoProvider from './docs/DemoProvider';
 import Overlay from 'cozy-ui/transpiled/react/Overlay';
-import Button from 'cozy-ui/transpiled/react/Button';
+import Button from 'cozy-ui/transpiled/react/Buttons';
 import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download';
 import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share';
 import { isValidForPanel } from 'cozy-ui/transpiled/react/Viewer/helpers';
 import getPanelBlocks, { panelBlocksSpecs } from 'cozy-ui/transpiled/react/Viewer/Panel/getPanelBlocks';
+import FooterActionButtons from 'cozy-ui/transpiled/react/Viewer/Footer/FooterActionButtons';
+import ForwardOrDownloadButton from 'cozy-ui/transpiled/react/Viewer/Footer/ForwardOrDownloadButton';
+
 
 // We provide a collection of (fake) io.cozy.files to be rendered
 const files = [
@@ -95,6 +98,20 @@ const files = [
   }
 ];
 
+const ShareButtonFake = () => {
+  return (
+    <Button
+      label="Share"
+      className="u-w-100 u-ml-0 u-mr-half"
+      variant="secondary"
+      startIcon={<Icon icon={ShareIcon} />}
+      onClick={() => {
+        return alert("This is a demo, there's no actual Cozy to share the file from ¯\\_(ツ)_/¯")
+      }}
+    />
+  )
+};
+
 // The host app will usually need a small wrapper to display the Viewer. This is a very small example of such a wrapper that handles opening, closing, and navigating between files.
 initialState = {
   viewerOpened: isTesting(),
@@ -136,7 +153,7 @@ const onFileChange = (file, nextIndex) => setState({ currentIndex: nextIndex, cu
               />
             </Card>
           )}
-          <button onClick={toggleViewer}>Open viewer</button>
+          <Button label="Open viewer" variant="ghost" size="small" onClick={toggleViewer} />
           {state.viewerOpened && (
             <Overlay>
               <Viewer
@@ -154,7 +171,12 @@ const onFileChange = (file, nextIndex) => setState({ currentIndex: nextIndex, cu
                   showToolbar: variant.toolbar,
                   showClose: state.showToolbarCloseButton
                 }}
-              />
+              >
+                <FooterActionButtons>
+                  <ShareButtonFake />
+                  <ForwardOrDownloadButton />
+                </FooterActionButtons>
+              </Viewer>
             </Overlay>
           )}
         </>

--- a/react/Viewer/ViewerContainer.jsx
+++ b/react/Viewer/ViewerContainer.jsx
@@ -12,13 +12,7 @@ import ViewerInformationsWrapper from './ViewerInformationsWrapper'
 import EncryptedProvider from './EncryptedProvider'
 
 const ViewerContainer = props => {
-  const {
-    className,
-    disableFooter,
-    disablePanel,
-    disableSharing,
-    ...rest
-  } = props
+  const { className, disableFooter, disablePanel, children, ...rest } = props
   const { currentIndex, files, currentURL } = props
   const toolbarRef = createRef()
   const { isDesktop } = useBreakpoints()
@@ -43,11 +37,12 @@ const ViewerContainer = props => {
       </EncryptedProvider>
       <ViewerInformationsWrapper
         disableFooter={disableFooter}
-        disableSharing={disableSharing}
         validForPanel={validForPanel}
         currentFile={currentFile}
         toolbarRef={toolbarRef}
-      />
+      >
+        {children}
+      </ViewerInformationsWrapper>
     </ViewerWrapper>
   )
 }
@@ -79,9 +74,7 @@ ViewerContainer.propTypes = {
   /** Show/Hide the panel containing more information about the file only on Desktop */
   disablePanel: PropTypes.bool,
   /** Show/Hide the panel containing more information about the file only on Phone & Tablet devices */
-  disableFooter: PropTypes.bool,
-  /** Show/Hide cozy share button  */
-  disableSharing: PropTypes.bool
+  disableFooter: PropTypes.bool
 }
 
 ViewerContainer.defaultProps = {

--- a/react/Viewer/ViewerInformationsWrapper.jsx
+++ b/react/Viewer/ViewerInformationsWrapper.jsx
@@ -13,9 +13,9 @@ import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 const ViewerInformationsWrapper = ({
   currentFile,
   disableFooter,
-  disableSharing,
   validForPanel,
-  toolbarRef
+  toolbarRef,
+  children
 }) => {
   const theme = useTheme()
   const sidebar = document.querySelector('[class*="sidebar"]')
@@ -34,11 +34,9 @@ const ViewerInformationsWrapper = ({
     <>
       {!disableFooter && (
         <Footer>
-          <FooterContent
-            file={currentFile}
-            toolbarRef={toolbarRef}
-            disableSharing={disableSharing}
-          />
+          <FooterContent file={currentFile} toolbarRef={toolbarRef}>
+            {children}
+          </FooterContent>
         </Footer>
       )}
       {validForPanel && (
@@ -53,9 +51,12 @@ const ViewerInformationsWrapper = ({
 ViewerInformationsWrapper.propTypes = {
   currentFile: FileDoctype.isRequired,
   disableFooter: PropTypes.bool,
-  disableSharing: PropTypes.bool,
   validForPanel: PropTypes.bool,
-  toolbarRef: PropTypes.object
+  toolbarRef: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node)
+  ])
 }
 
 export default ViewerInformationsWrapper

--- a/react/Viewer/ViewerInformationsWrapper.spec.jsx
+++ b/react/Viewer/ViewerInformationsWrapper.spec.jsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import ViewerInformationsWrapper from './ViewerInformationsWrapper'
+
+/* eslint-disable react/display-name */
+jest.mock('./Footer', () => ({ children }) => (
+  <div data-testid="Footer">{children}</div>
+))
+jest.mock('./InformationPanel', () => ({ children }) => (
+  <div data-testid="InformationPanel">{children}</div>
+))
+jest.mock('./Panel/PanelContent', () => () => (
+  <div data-testid="PanelContent" />
+))
+jest.mock('./Footer/FooterContent', () => () => (
+  <div data-testid="FooterContent" />
+))
+/* eslint-enable react/display-name */
+
+const setup = ({ validForPanel, disableFooter } = {}) => {
+  return render(
+    <ViewerInformationsWrapper
+      currentFile={{}}
+      disableFooter={disableFooter}
+      validForPanel={validForPanel}
+    />
+  )
+}
+
+describe('ViewerInformationsWrapper', () => {
+  describe('disableFooter', () => {
+    it('should render FooterContent components', () => {
+      const { getByTestId } = setup({ disableFooter: false })
+
+      expect(getByTestId('Footer'))
+      expect(getByTestId('FooterContent'))
+    })
+
+    it('should not render FooterContent components', () => {
+      const { queryByTestId } = setup({ disableFooter: true })
+
+      expect(queryByTestId('Footer')).toBeNull()
+      expect(queryByTestId('FooterContent')).toBeNull()
+    })
+  })
+
+  describe('validForPanel', () => {
+    it('should render InformationPanel & PanelContent components', () => {
+      const { getByTestId } = setup({ validForPanel: true })
+
+      expect(getByTestId('InformationPanel'))
+      expect(getByTestId('PanelContent'))
+    })
+
+    it('should not render InformationPanel & PanelContent components', () => {
+      const { queryByTestId } = setup({ validForPanel: false })
+
+      expect(queryByTestId('InformationPanel')).toBeNull()
+      expect(queryByTestId('PanelContent')).toBeNull()
+    })
+  })
+})

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -27,6 +27,16 @@ export const isFromKonnector = ({ file }) => {
   return has(file, 'cozyMetadata.sourceAccount')
 }
 
+/**
+ * Checks if the file matches one of the following conditions:
+ * - Is certified
+ * - Is Qualified
+ * - From a Connector
+ *
+ * @param {object} param
+ * @param {IOCozyFile} param.file
+ * @returns {boolean}
+ */
 export const isValidForPanel = ({ file }) => {
   return (
     hasCertifications({ file }) ||


### PR DESCRIPTION
Refactor the viewer to let the app handle the action buttons.

BREAKING CHANGE: The management of action buttons should now be handled on the application side via the `FooterActionButtons` component

Example:
```
<Viewer {...props}>
   <FooterActionButtons>
      <SharingButton />
      <ForwardOrDownloadButton />
   </FooterActionButtons>
</Viewer>
```
You can use a codemods `transform-viewer.js` to automatically handle this breaking change.
[See the codemods documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-codemods).
Using linter js auto-correction can be a good idea after that.
Here a common example (don't forget to change `src` value):
```
jscodeshift -t $(yarn global dir)/node_modules/@cozy/codemods/src/transforms/transform-viewer.js src --parser babel --extensions js,jsx && yarn lint:js --fix
```

Demo: https://merkur39.github.io/cozy-ui/react/#!/Viewer