### PR TITLE
Fix/footer action buttons display name

### DIFF
--- a/react/Viewer/Footer/FooterActionButtons.jsx
+++ b/react/Viewer/Footer/FooterActionButtons.jsx
@@ -9,6 +9,8 @@ const FooterActionButtons = ({ children, file }) => {
   return mapToAllChildren(children, child => cloneElement(child, { file }))
 }
 
+FooterActionButtons.displayName = 'FooterActionButtons'
+
 FooterActionButtons.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, Children, cloneElement } from 'react'
+import React, { useMemo, Children, cloneElement, isValidElement } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 
@@ -27,16 +27,19 @@ const FooterContent = ({ file, toolbarRef, children }) => {
 
   const { contactName, isLoadingContacts } = useReferencedContactName(file)
 
-  const FooterActionButtons = Children.toArray(children).find(child => {
-    return (
-      child.type.name === 'FooterActionButtons' ||
-      child.type.displayName === 'FooterActionButtons'
-    )
-  })
+  const FooterActionButtons =
+    Children.toArray(children).find(child => {
+      return (
+        child.type.name === 'FooterActionButtons' ||
+        child.type.displayName === 'FooterActionButtons'
+      )
+    }) || null
 
-  const FooterActionButtonsWithFile = cloneElement(FooterActionButtons, {
-    file
-  })
+  const FooterActionButtonsWithFile = isValidElement(FooterActionButtons)
+    ? cloneElement(FooterActionButtons, {
+        file
+      })
+    : null
 
   // We have to wait for the Contact request to finish before rendering `BottomSheet`, because it doesn't handle async well.
   if (isValidForPanel({ file }) && !isLoadingContacts) {


### PR DESCRIPTION
As the name `FooterActionButtons` does not exist in the build version, the parent component could not find it..
And the implementation of the parent, caused a crash..
