### PR TITLE
feat(BottomDrawer): Add possibility to use it with  long content

### DIFF
--- a/react/BottomDrawer/Readme.md
+++ b/react/BottomDrawer/Readme.md
@@ -1,25 +1,34 @@
 Displays content coming up from the bottom of the screen.
 
 ```jsx
-import BottomDrawer from 'cozy-ui/transpiled/react/BottomDrawer';
-import Card from 'cozy-ui/transpiled/react/Card';
-import Button from 'cozy-ui/transpiled/react/Button';
-import Typography from "cozy-ui/transpiled/react/Typography";
+import BottomDrawer from 'cozy-ui/transpiled/react/BottomDrawer'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Typography from "cozy-ui/transpiled/react/Typography"
+import Variants from 'cozy-ui/docs/components/Variants'
 
-initialState = { isDrawerDisplayed: isTesting() };
+const initialState = { isDrawerDisplayed: isTesting() }
+const initialVariants = [{ longText: false }]
 
 const showDrawer = () => setState({ isDrawerDisplayed: true });
-const hideDrawer = () => setState({ isDrawerDisplayed: false });
+const hideDrawer = () => setState({ isDrawerDisplayed: false })
 
-<div>
-  <Button onClick={showDrawer}>Open drawer</Button>
-  {state.isDrawerDisplayed &&
-    <BottomDrawer onClose={hideDrawer}>
-      <Card className="u-bg-white">
-        <Typography className="u-mb-1" variant="h5">This is a card in a drawer</Typography>
-        <Typography className="u-mb-1" variant="body1">This is some card content. Content can be small or huge.</Typography>
-        <Button className="u-ml-0" label="Demo button" />
-      </Card>
-  </BottomDrawer>}
-</div>
+;
+
+<Variants initialVariants={initialVariants}>
+  {variant => (
+    <>
+      <Button variant="ghost" size="small" onClick={showDrawer} label="Open drawer" />
+
+      {state.isDrawerDisplayed &&
+        <BottomDrawer onClose={hideDrawer}>
+          <Paper className="u-p-1" style={{ borderRadius: '1rem 1rem 0 0' }}>
+            <Typography variant="h5" paragraph>This is a paper in a drawer</Typography>
+            <Typography paragraph>{variant.longText ? content.ada.long : content.ada.short}</Typography>
+            <Button label="Demo button" onClick={() => console.info('huhu')} />
+          </Paper>
+      </BottomDrawer>}
+    </>
+  )}
+</Variants>
 ```

--- a/react/BottomDrawer/styles.styl
+++ b/react/BottomDrawer/styles.styl
@@ -8,11 +8,12 @@
     @extends $transition-transform-ease-out
 
 .BottomDrawer-content
-    z-index        $drawer-index
-    position       fixed
-    bottom         0
-    left           0
-    right          0
-    width          100%
-    margin         0
-
+    z-index $drawer-index
+    position fixed
+    bottom 0
+    left 0
+    right 0
+    width 100%
+    margin 0
+    max-height 100vh
+    overflow-y auto

--- a/react/Overlay/index.jsx
+++ b/react/Overlay/index.jsx
@@ -7,7 +7,7 @@ import { RemoveScroll } from 'react-remove-scroll'
 
 const ESC_KEYCODE = 27
 
-const nonDOMProps = ['onEscape', 'children', 'className']
+const nonDOMProps = ['onEscape', 'children', 'className', 'innerRef']
 
 const bodyTallerThanWindow = () => {
   return document.body.getBoundingClientRect().height > window.innerHeight
@@ -45,7 +45,7 @@ class Overlay extends Component {
   }
 
   render() {
-    const { children, className } = this.props
+    const { children, className, innerRef } = this.props
     const domProps = omit(this.props, nonDOMProps)
     // We use Overlay when opening an ActionMenu.
     // We don't want to block the scroll on Desktop if the ActionMenu
@@ -53,10 +53,12 @@ class Overlay extends Component {
     // @todo Overlay should not RemoveScroll by itself. It should
     // be done by lower component (like ActionMenu / Dialog / Modal...)
     const Wrapper = bodyTallerThanWindow() ? React.Fragment : RemoveScroll
+
     return (
       <div
-        onClick={this.handleClick}
+        ref={innerRef}
         className={cx(styles['c-overlay'], className)}
+        onClick={this.handleClick}
         {...domProps}
       >
         <Wrapper>{children}</Wrapper>
@@ -71,4 +73,6 @@ Overlay.propTypes = {
   onEscape: PropTypes.func
 }
 
-export default Overlay
+export default React.forwardRef((props, ref) => (
+  <Overlay innerRef={ref} {...props} />
+))


### PR DESCRIPTION
Le BottomSheet est censé remplacer le bottomDrawer mais il y a encore pas mal de travail à fournir dessus... en attendant on passe un petit correctif pour avoir un BottomDrawer un peu plus utilisable.

demo : https://jf-cozy.github.io/cozy-ui/react/#!/BottomDrawer