### PR TITLE
fix(Input): Ref must be passed by forwardRef

### DIFF
--- a/react/Input/index.jsx
+++ b/react/Input/index.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 
-const Input = props => {
+const Input = forwardRef((props, ref) => {
   const {
     autoComplete,
     disabled,
@@ -15,7 +15,6 @@ const Input = props => {
     error,
     size,
     fullwidth,
-    inputRef,
     ...restProps
   } = props
   return (
@@ -24,7 +23,7 @@ const Input = props => {
       autoComplete={autoComplete}
       type={type}
       id={id}
-      ref={inputRef}
+      ref={ref}
       className={cx(
         styles['c-input-text'],
         {
@@ -40,7 +39,9 @@ const Input = props => {
       {...restProps}
     />
   )
-}
+})
+
+Input.displayName = 'Input'
 
 Input.propTypes = {
   autoComplete: PropTypes.string,


### PR DESCRIPTION
BREAKING CHANGES: The Input component forwards the reference via the HOC `forwardRef` and no longer via the props.
So, the prop `inputRef` becomes `ref`.

You can use a codemods `transform-input.js` to automatically handle this breaking change.
[See the codemods documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-codemods).
Using linter js auto-correction can be a good idea after that.
Here a common example (don't forget to change `src` value):
```
jscodeshift -t $(yarn global dir)/node_modules/@cozy/codemods/src/transforms/transform-input.js src --parser babel --extensions js,jsx && yarn lint:js --fix
```