### PR TITLE
BottomSheet : Add backdrop and onClose props

### DIFF
--- a/react/BottomSheet/BackdropOrFragment.jsx
+++ b/react/BottomSheet/BackdropOrFragment.jsx
@@ -1,0 +1,14 @@
+import React, { Fragment } from 'react'
+
+import Backdrop from '../Backdrop'
+
+const BackdropOrFragment = ({ showBackdrop, children }) => {
+  const Comp = showBackdrop ? Backdrop : Fragment
+  const props = showBackdrop
+    ? { style: { zIndex: 'var(--zIndex-overlay)' }, open: showBackdrop }
+    : undefined
+
+  return <Comp {...props}>{children}</Comp>
+}
+
+export default BackdropOrFragment

--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -121,15 +121,7 @@ const BottomSheet = ({ toolbarProps, settings, children }) => {
     setPeekHeights([minHeight, computedMediumHeight, maxHeight])
     setInitPos(computedMediumHeight)
     setBottomSpacerHeight(bottomSpacerHeight)
-    // TODO: validate the deps are correct
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    innerContentRef,
-    headerContentRef.current,
-    toolbarProps,
-    mediumHeightRatio,
-    mediumHeight
-  ])
+  }, [innerContentRef, toolbarProps, mediumHeightRatio, mediumHeight])
 
   const handleOnIndexChange = snapIndex => {
     const maxHeightSnapIndex = peekHeights.length - 1
@@ -163,7 +155,7 @@ const BottomSheet = ({ toolbarProps, settings, children }) => {
         defaultHeight={initPos}
         backdrop={false}
         fullHeight={false}
-        onIndexChange={snapIndex => handleOnIndexChange(snapIndex)}
+        onIndexChange={handleOnIndexChange}
         styles={{ root: styles.root }}
         threshold={0}
         // springConfig doc : https://docs.pmnd.rs/react-spring/common/configs

--- a/react/BottomSheet/README.md
+++ b/react/BottomSheet/README.md
@@ -1,33 +1,176 @@
-Display content coming up from the bottom of the screen. The pane can be swiped to the top of the screen. [API documentation is here](https://github.com/cozy/mui-bottom-sheet#props-options)
+
+Display content coming up from the bottom of the screen. The pane can be swiped to the top of the screen. Based on cozy
+/ mui-bottom-sheet: [API documentation is here](https://github.com/cozy/mui-bottom-sheet#props-options).
+
+### Props
+
+* **toolbarProps** : `<object>` – Toolbar properties
+  * **ref** : `<object>` – React reference of the toolbar node
+  * **height** : `<number>` – Toolbar height value
+* **settings** : `<object>` – Settings that can be modified
+  * **mediumHeight** : `<number>` – Height in pixel of the middle snap point
+  * **mediumHeightRatio** : `<number>` – Height of the middle snap point, expressed as a percentage of the viewport height
+* **backdrop** : `<boolean>` – To add a backdrop
+* **onClose** : `<function>` – To totally close the BottomSheet by swaping it down
+
+⚠️ If **`backdrop`** is set to **`true`**, you must pass an **`onClose`** method.
+
+In this documentation, **`closable`** variant must be checked if **`backdrop`** is checked too.
 
 ```jsx
 import BottomSheet, { BottomSheetItem, BottomSheetHeader } from 'cozy-ui/transpiled/react/BottomSheet'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 
 // <-- only useful for the documentation
-initialState = { isBottomSheetDisplayed: isTesting() }
-const showBottomSheet = () => setState({ isBottomSheetDisplayed: true })
+import Variants from 'cozy-ui/docs/components/Variants'
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
+import FileTypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
+import Radio from 'cozy-ui/transpiled/react/Radios'
 
-const settings = isTesting() ? { mediumHeight: 450 } : undefined
+const initialVariants = [{
+  backdrop: true,
+  closable: true,
+  longContent: false,
+  withFakeToolbar: false,
+  withHeader: true,
+  withListContent: false
+}]
+const initialState = {
+  isBottomSheetDisplayed: isTesting(),
+  mediumHeight: isTesting() ? 450 : undefined,
+  mediumHeightRatio: undefined
+}
+const showBottomSheet = () => setState({ isBottomSheetDisplayed: true })
+const hideBottomSheet = () => setState({ isBottomSheetDisplayed: false })
+
+const handleChangeMediumHeight = el => {
+  setState({ mediumHeight: Number(el.target.value) })
+}
+const handleChangeMediumHeightRatio = el => {
+  setState({ mediumHeightRatio: Number(el.target.value) })
+}
+
+const settings = state.mediumHeight === undefined && state.mediumHeightRatio === undefined
+  ? undefined
+  : { mediumHeight: state.mediumHeight, mediumHeightRatio: state.mediumHeightRatio }
+
 // -->
 
 ;
 
-<>
-  <Button label="Open BottomSheet" onClick={showBottomSheet} />
-  {state.isBottomSheetDisplayed && (
-    <BottomSheet settings={settings}>
-      <BottomSheetHeader className="u-ph-1 u-pb-1">
-        <Button className="u-mr-half" variant="secondary" label="Button 1" fullWidth />
-        <Button variant="secondary" label="Button 2" fullWidth />
-      </BottomSheetHeader>
-      <BottomSheetItem>
-        {content.ada.short}
-      </BottomSheetItem>
-      <BottomSheetItem disableElevation>
-        {content.ada.long}
-      </BottomSheetItem>
-    </BottomSheet>
+<Variants initialVariants={initialVariants}>
+  {variant => (
+    <>
+      <div>
+        <TextField
+          type="number"
+          margin="dense"
+          label="mediumHeight"
+          variant="outlined"
+          helperText="Height of the medium snap point"
+          onChange={handleChangeMediumHeight}
+        />
+        <TextField
+          className="u-ml-0-s u-ml-half"
+          type="number"
+          margin="dense"
+          label="mediumHeightRatio"
+          variant="outlined"
+          helperText="Height ratio of the medium snap point"
+          onChange={handleChangeMediumHeightRatio}
+        />
+        <Button
+          className="u-ml-0-s u-ml-half u-mt-1"
+          size="small"
+          variant="ghost"
+          label="Open BottomSheet"
+          onClick={showBottomSheet}
+        />
+      </div>
+
+      {state.isBottomSheetDisplayed && (
+        <BottomSheet
+          toolbarProps={variant.withFakeToolbar ? { height: 50 } : undefined}
+          settings={settings}
+          backdrop={variant.backdrop}
+          onClose={variant.closable ? hideBottomSheet : undefined}
+        >
+          {variant.withHeader && (
+            <BottomSheetHeader className="u-ph-1 u-pb-1">
+              <Button className="u-mr-half" variant="secondary" label="Button 1" fullWidth />
+              <Button variant="secondary" label="Button 2" fullWidth />
+            </BottomSheetHeader>
+          )}
+          {!variant.withListContent && (
+            <BottomSheetItem disableElevation>
+              {variant.longContent ? content.ada.long : content.ada.short}
+            </BottomSheetItem>
+          )}
+          {variant.withListContent && (
+            <BottomSheetItem disableGutters>
+              <List>
+                <ListItem button>
+                  <ListItemIcon>
+                    <Icon icon={FileTypeTextIcon} size={32} />
+                  </ListItemIcon>
+                  <ListItemText primary="Title" />
+                </ListItem>
+                <ListSubheader>Section 1</ListSubheader>
+                <ListItem button>
+                  <ListItemIcon>
+                    <Icon icon={FileIcon} />
+                  </ListItemIcon>
+                  <ListItemText primary="Item with icon" />
+                </ListItem>
+                <Divider variant="inset" />
+                <ListItem button>
+                  <ListItemIcon>
+                    <Checkbox />
+                  </ListItemIcon>
+                  <ListItemText primary="Item with checkbox" />
+                </ListItem>
+                <Divider variant="inset" />
+                <ListItem button>
+                  <ListItemIcon>
+                    <Radio />
+                  </ListItemIcon>
+                  <ListItemText primary="Item with radio" />
+                </ListItem>
+                <Divider variant="inset" />
+                <ListItem button>
+                  <ListItemIcon>
+                    <Icon icon={FileIcon} />
+                  </ListItemIcon>
+                  <ListItemText primary="Item with secondary" secondary="With secondary text" />
+                </ListItem>
+                <Divider variant="inset" />
+                <ListItem button>
+                  <ListItemIcon>
+                    <Icon icon={FileIcon} />
+                  </ListItemIcon>
+                  <ListItemText primary="Item with secondary action" />
+                  <ListItemSecondaryAction className="u-mr-1">
+                    <Icon icon={RightIcon} color="var(--iconTextColor)" />
+                  </ListItemSecondaryAction>
+                </ListItem>
+                <Divider variant="inset" />
+              </List>
+            </BottomSheetItem>
+          )}
+        </BottomSheet>
+      )}
+    </>
   )}
-</>
+</Variants>
 ```

--- a/react/BottomSheet/helpers.js
+++ b/react/BottomSheet/helpers.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import { getFlagshipMetadata } from 'cozy-device-helper'
+
+export const computeMaxHeight = toolbarProps => {
+  const { ref, height } = toolbarProps
+  let computedToolbarHeight = 1
+
+  if (height) {
+    computedToolbarHeight = height
+  } else if (ref && ref.current) {
+    computedToolbarHeight = ref.current.offsetHeight
+  }
+
+  return window.innerHeight - computedToolbarHeight
+}
+
+export const computeMediumHeight = ({
+  backdrop,
+  maxHeight,
+  mediumHeight,
+  mediumHeightRatio,
+  innerContentHeight
+}) => {
+  const mediumHeightOrWithRatio =
+    mediumHeight || Math.round(maxHeight * mediumHeightRatio)
+
+  if (backdrop) {
+    if (mediumHeightOrWithRatio < innerContentHeight) {
+      return mediumHeightOrWithRatio < maxHeight
+        ? mediumHeightOrWithRatio
+        : maxHeight
+    }
+    return innerContentHeight > maxHeight ? maxHeight : innerContentHeight
+  }
+
+  return mediumHeightOrWithRatio > maxHeight
+    ? maxHeight
+    : mediumHeightOrWithRatio
+}
+
+export const computeMinHeight = ({
+  isClosable,
+  headerRef,
+  actionButtonsHeight,
+  actionButtonsBottomMargin
+}) => {
+  if (isClosable) return 0
+  return (
+    headerRef.current.offsetHeight +
+    actionButtonsHeight +
+    actionButtonsBottomMargin +
+    (getFlagshipMetadata().navbarHeight || 0)
+  )
+}
+
+export const makeOverridenChildren = (children, headerContentRef) => {
+  return React.Children.map(children, child => {
+    if (
+      child?.type?.name === 'BottomSheetHeader' ||
+      child?.type?.displayName === 'BottomSheetHeader'
+    ) {
+      return React.cloneElement(child, { headerContentRef })
+    }
+    return child
+  })
+}
+
+export const setTopPosition = ({
+  snapIndex,
+  maxHeightSnapIndex,
+  isTopPosition,
+  setIsTopPosition
+}) => {
+  if (snapIndex > maxHeightSnapIndex) {
+    setIsTopPosition(true)
+  }
+  if (snapIndex === maxHeightSnapIndex && !isTopPosition) {
+    setIsTopPosition(true)
+  }
+  if (snapIndex < maxHeightSnapIndex && isTopPosition) {
+    setIsTopPosition(false)
+  }
+}
+
+export const setBottomPosition = ({
+  snapIndex,
+  isBottomPosition,
+  setIsBottomPosition
+}) => {
+  if (snapIndex === 0 && !isBottomPosition) {
+    setIsBottomPosition(true)
+  }
+  if (snapIndex !== 0 && isBottomPosition) {
+    setIsBottomPosition(false)
+  }
+}

--- a/react/BottomSheet/helpers.spec.js
+++ b/react/BottomSheet/helpers.spec.js
@@ -1,0 +1,235 @@
+import {
+  computeMaxHeight,
+  computeMediumHeight,
+  computeMinHeight,
+  setTopPosition,
+  setBottomPosition
+} from './helpers'
+
+jest.mock('cozy-device-helper', () => ({
+  getFlagshipMetadata: jest.fn(() => ({ navbarHeight: 10 }))
+}))
+const windowSpy = jest.spyOn(window, 'window', 'get')
+windowSpy.mockImplementation(() => ({ innerHeight: 800 }))
+
+describe('computeMaxHeight', () => {
+  it('should return correct value if no arg', () => {
+    const res = computeMaxHeight({})
+
+    expect(res).toBe(799)
+  })
+
+  it('should return correct value with height arg', () => {
+    const res = computeMaxHeight({ height: 50 })
+
+    expect(res).toBe(750)
+  })
+
+  it('should return correct value with ref arg', () => {
+    const res = computeMaxHeight({ ref: { current: { offsetHeight: 50 } } })
+
+    expect(res).toBe(750)
+  })
+})
+
+describe('computeMediumHeight', () => {
+  describe('with no backdrop', () => {
+    it('should return mediumHeight value if mediumHeight < maxHeight', () => {
+      const res = computeMediumHeight({
+        backdrop: false,
+        maxHeight: 800,
+        mediumHeight: 400
+      })
+
+      expect(res).toBe(400)
+    })
+
+    it('should return maxHeight value if mediumHeight > maxHeight', () => {
+      const res = computeMediumHeight({
+        backdrop: false,
+        maxHeight: 800,
+        mediumHeight: 900
+      })
+
+      expect(res).toBe(800)
+    })
+  })
+
+  describe('with backdrop', () => {
+    it('should return innerContentHeight value if lower than mediumHeight', () => {
+      const res = computeMediumHeight({
+        backdrop: true,
+        maxHeight: 800,
+        mediumHeight: 400,
+        innerContentHeight: 300
+      })
+
+      expect(res).toBe(300)
+    })
+
+    it('should return mediumHeight value if lower than innerContentHeight', () => {
+      const res = computeMediumHeight({
+        backdrop: true,
+        maxHeight: 800,
+        mediumHeight: 300,
+        innerContentHeight: 400
+      })
+
+      expect(res).toBe(300)
+    })
+
+    it('should return maxHeight value if mediumHeight and innerContentHeight are higher', () => {
+      const res = computeMediumHeight({
+        backdrop: true,
+        maxHeight: 800,
+        mediumHeight: 900,
+        innerContentHeight: 900
+      })
+
+      expect(res).toBe(800)
+    })
+  })
+})
+
+describe('computeMinHeight', () => {
+  it('should return 0 if isClosable true', () => {
+    const res = computeMinHeight({ isClosable: true })
+
+    expect(res).toBe(0)
+  })
+
+  it('should return correct value if isClosable false', () => {
+    const res = computeMinHeight({
+      isClosable: false,
+      headerRef: { current: { offsetHeight: 10 } },
+      actionButtonsHeight: 20,
+      actionButtonsBottomMargin: 30
+    })
+
+    expect(res).toBe(70)
+  })
+})
+
+describe('setTopPosition', () => {
+  describe('it should set top position', () => {
+    it('to true if snapIndex is higher than maxHeightSnapIndex', () => {
+      const setIsTopPosition = jest.fn()
+
+      setTopPosition({
+        snapIndex: 3,
+        maxHeightSnapIndex: 2,
+        setIsTopPosition
+      })
+
+      expect(setIsTopPosition).toHaveBeenCalledWith(true)
+    })
+
+    it('to true if snapIndex = maxHeightSnapIndex and isTopPosition is false', () => {
+      const setIsTopPosition = jest.fn()
+
+      setTopPosition({
+        snapIndex: 2,
+        maxHeightSnapIndex: 2,
+        isTopPosition: false,
+        setIsTopPosition
+      })
+
+      expect(setIsTopPosition).toHaveBeenCalledWith(true)
+    })
+
+    it('to false if snapIndex < maxHeightSnapIndex and isTopPosition is true', () => {
+      const setIsTopPosition = jest.fn()
+
+      setTopPosition({
+        snapIndex: 1,
+        maxHeightSnapIndex: 2,
+        isTopPosition: true,
+        setIsTopPosition
+      })
+
+      expect(setIsTopPosition).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('it should not set top position', () => {
+    it('if snapIndex = maxHeightSnapIndex and isTopPosition is true', () => {
+      const setIsTopPosition = jest.fn()
+
+      setTopPosition({
+        snapIndex: 2,
+        maxHeightSnapIndex: 2,
+        isTopPosition: true,
+        setIsTopPosition
+      })
+
+      expect(setIsTopPosition).not.toHaveBeenCalled()
+    })
+
+    it('if snapIndex < maxHeightSnapIndex and isTopPosition is false', () => {
+      const setIsTopPosition = jest.fn()
+
+      setTopPosition({
+        snapIndex: 1,
+        maxHeightSnapIndex: 2,
+        isTopPosition: false,
+        setIsTopPosition
+      })
+
+      expect(setIsTopPosition).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('setBottomPosition', () => {
+  describe('it should set bottom position', () => {
+    it('if snapIndex = 0 and isBottomPosition is false', () => {
+      const setIsBottomPosition = jest.fn()
+
+      setBottomPosition({
+        snapIndex: 0,
+        isBottomPosition: false,
+        setIsBottomPosition
+      })
+
+      expect(setIsBottomPosition).toHaveBeenCalledWith(true)
+    })
+
+    it('should snapIndex != 0 and isBottomPosition is true', () => {
+      const setIsBottomPosition = jest.fn()
+
+      setBottomPosition({
+        snapIndex: 1,
+        isBottomPosition: true,
+        setIsBottomPosition
+      })
+
+      expect(setIsBottomPosition).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('it should not set bottom position', () => {
+    it('if snapIndex = 0 and isBottomPosition is true', () => {
+      const setIsBottomPosition = jest.fn()
+
+      setBottomPosition({
+        snapIndex: 0,
+        isBottomPosition: true,
+        setIsBottomPosition
+      })
+
+      expect(setIsBottomPosition).not.toHaveBeenCalled()
+    })
+
+    it('if snapIndex != 0 and isBottomPosition is false', () => {
+      const setIsBottomPosition = jest.fn()
+
+      setBottomPosition({
+        snapIndex: 1,
+        isBottomPosition: false,
+        setIsBottomPosition
+      })
+
+      expect(setIsBottomPosition).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Il y a eu également pas mal de petits ajustements, ça été compliqué de séparer les commits. La review risque de ne pas être simple à comprendre.

Comportement testé sur mobile dans une app, validé par Joel.

Pour info il y a quelques soucis de comportement sur le doc cozy-ui (la page qui slide par exemple), ce n'est pas présent dans l'app.

On a déjà passé le temps imparti sur le sujet, je ne peux faire que des corrections mineurs et rapides...

demo : https://jf-cozy.github.io/cozy-ui/react/#!/BottomSheet

ps : histoire d'avancer sur les autres features dans Banks dont dépendent cette PR, je suis d'avis de passer outre le comportement bizarre dans Argos (à cause des animations et donc de l'ouverture du BottomSheet)

fix https://github.com/cozy/cozy-ui/issues/2182
fix https://github.com/cozy/cozy-ui/issues/2183