### PR TITLE
fix(BottomSheet): Remove bouncerSafer when  clicking in backdrop

### DIFF
--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -128,6 +128,8 @@ const BottomSheet = ({
   const handleMinimizeAndClose = () => {
     if (backdrop) {
       setCurrentIndex(0)
+      setIsTopPosition(false)
+      setIsBottomPosition(true)
       setTimeout(handleClose, ANIMATION_DURATION)
     }
   }

--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -16,10 +16,10 @@ import {
   computeMinHeight,
   makeOverridenChildren,
   setTopPosition,
-  setBottomPosition
+  setBottomPosition,
+  minimizeAndClose
 } from './helpers'
-
-const ANIMATION_DURATION = 250
+import { ANIMATION_DURATION } from './constants'
 
 const createStyles = ({ squared, hasToolbarProps }) => ({
   root: {
@@ -125,15 +125,6 @@ const BottomSheet = ({
     onClose && onClose()
   }, [onClose])
 
-  const handleMinimizeAndClose = () => {
-    if (backdrop) {
-      setCurrentIndex(0)
-      setIsTopPosition(false)
-      setIsBottomPosition(true)
-      setTimeout(handleClose, ANIMATION_DURATION)
-    }
-  }
-
   const handleOnIndexChange = snapIndex => {
     const maxHeightSnapIndex = peekHeights.length - 1
 
@@ -234,7 +225,17 @@ const BottomSheet = ({
           hidden={isHidden}
           snapPointSeekerMode="next"
         >
-          <ClickAwayListener onClickAway={handleMinimizeAndClose}>
+          <ClickAwayListener
+            onClickAway={() =>
+              minimizeAndClose({
+                backdrop,
+                setCurrentIndex,
+                setIsTopPosition,
+                setIsBottomPosition,
+                handleClose
+              })
+            }
+          >
             <span>
               <div ref={innerContentRef}>
                 <Paper

--- a/react/BottomSheet/constants.js
+++ b/react/BottomSheet/constants.js
@@ -1,0 +1,1 @@
+export const ANIMATION_DURATION = 250

--- a/react/BottomSheet/helpers.js
+++ b/react/BottomSheet/helpers.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { getFlagshipMetadata } from 'cozy-device-helper'
 
+import { ANIMATION_DURATION } from './constants'
+
 export const computeMaxHeight = toolbarProps => {
   const { ref, height } = toolbarProps
   let computedToolbarHeight = 1
@@ -92,5 +94,20 @@ export const setBottomPosition = ({
   }
   if (snapIndex !== 0 && isBottomPosition) {
     setIsBottomPosition(false)
+  }
+}
+
+export const minimizeAndClose = ({
+  backdrop,
+  setCurrentIndex,
+  setIsTopPosition,
+  setIsBottomPosition,
+  handleClose
+}) => {
+  if (backdrop) {
+    setCurrentIndex(0)
+    setIsTopPosition(false)
+    setIsBottomPosition(true)
+    setTimeout(handleClose, ANIMATION_DURATION)
   }
 }

--- a/react/BottomSheet/helpers.spec.js
+++ b/react/BottomSheet/helpers.spec.js
@@ -3,7 +3,8 @@ import {
   computeMediumHeight,
   computeMinHeight,
   setTopPosition,
-  setBottomPosition
+  setBottomPosition,
+  minimizeAndClose
 } from './helpers'
 
 jest.mock('cozy-device-helper', () => ({
@@ -231,5 +232,53 @@ describe('setBottomPosition', () => {
 
       expect(setIsBottomPosition).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('minimizeAndClose', () => {
+  jest.useFakeTimers()
+
+  it('should not trigger function if no backdrop', () => {
+    const setCurrentIndex = jest.fn()
+    const setIsTopPosition = jest.fn()
+    const setIsBottomPosition = jest.fn()
+    const handleClose = jest.fn()
+
+    minimizeAndClose({
+      backdrop: false,
+      setCurrentIndex,
+      setIsTopPosition,
+      setIsBottomPosition,
+      handleClose
+    })
+
+    jest.runAllTimers()
+
+    expect(setCurrentIndex).not.toHaveBeenCalled()
+    expect(setIsTopPosition).not.toHaveBeenCalled()
+    expect(setIsBottomPosition).not.toHaveBeenCalled()
+    expect(handleClose).not.toHaveBeenCalled()
+  })
+
+  it('should trigger every function if backdrop is true', () => {
+    const setCurrentIndex = jest.fn()
+    const setIsTopPosition = jest.fn()
+    const setIsBottomPosition = jest.fn()
+    const handleClose = jest.fn()
+
+    minimizeAndClose({
+      backdrop: true,
+      setCurrentIndex,
+      setIsTopPosition,
+      setIsBottomPosition,
+      handleClose
+    })
+
+    jest.runAllTimers()
+
+    expect(setCurrentIndex).toHaveBeenCalledWith(0)
+    expect(setIsTopPosition).toHaveBeenCalledWith(false)
+    expect(setIsBottomPosition).toHaveBeenCalledWith(true)
+    expect(handleClose).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
On ajoute un bloc de la couleur du Bottomsheet en bas de la page pour éviter de voir le contenu sous le BottomSheet si on bouce celui-ci trop haut. Ce bloc n'était pas supprimé quand on fermait le Bottomsheet en cliquant dans le backdrop, contrairement à quand on le fermait avec un swipe down.