### PR TITLE
fix(CozyDialogs): Close and Back button z-index

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -12,8 +12,7 @@
   ],
   "groups": [
     {
-        "path": "transpiled/react/**",
-        "maxPercentIncrease": 0.5,
+        "path": "transpiled/react/**"
     },
 ],
   "reportOutput": ["github"]

--- a/react/CozyDialogs/styles.styl
+++ b/react/CozyDialogs/styles.styl
@@ -4,7 +4,7 @@
     position absolute
     top 1.15rem
     right 1.15rem
-    z-index var(--zIndex-modal) //needed for an iOS bug https://github.com/cozy/cozy-ui/pull/1790
+    z-index 1
     transform translateY(var(--flagship-top-height))
     +small-screen()
         top 0.25rem
@@ -14,7 +14,7 @@
     position absolute
     top 1.15rem
     left 1.15rem
-    z-index var(--zIndex-modal) //needed for an iOS bug https://github.com/cozy/cozy-ui/pull/1790
+    z-index 1
     +small-screen()
         top 0.25rem
         left 0.25rem


### PR DESCRIPTION
le problème initial : https://github.com/cozy/cozy-ui/pull/1790

sauf qu'on avait une valeur trop élevée, et donc les boutons était par-dessus le backdrop (qui a un zindex moindre). Inutile d'avoir une valeur élevée ici, il suffit juste d'avoir une valeur, même faible, pour passer par-dessus le titre et le content, qui eux n'ont pas de zindex.

testé sur iOS 15.5 et 12.4

demo : https://jf-cozy.github.io/cozy-ui/react/#!/CozyDialogs