### PR TITLE
fix: Apply top/bottom spacing on dialog fullscreen

### DIFF
--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -591,7 +591,7 @@ const makeOverrides = theme => ({
   },
   MuiDialogTitle: {
     root: {
-      '.flagship-app &': {
+      '.flagship-app .MuiDialog-paperFullScreen &': {
         paddingTop: 'calc(var(--flagship-top-height) + 0.75rem) !important'
       },
       ...theme.typography.h3,
@@ -621,7 +621,7 @@ const makeOverrides = theme => ({
   },
   MuiDialogContent: {
     root: {
-      '.flagship-app &': {
+      '.flagship-app .MuiDialog-paperFullScreen &': {
         marginBottom: 'var(--flagship-bottom-height) !important'
       },
       padding: '24px 32px 0',


### PR DESCRIPTION
Previously it was also applied to small dialogs which is not right.
We only need it on fullscreen modals when in flagship app.