### PR TITLE
fix: Prevent `AppLinker` to call openApp when target link has same slug

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@semantic-release/npm": "9.0.1",
     "@svgr/cli": "^5.4.0",
     "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/user-event": "^14.4.2",
     "@testing-library/react": "11.2.7",
     "@testing-library/react-hooks": "^3.2.1",
     "argos-cli": "^0.3.3",

--- a/react/AppLinker/__snapshots__/index.deprecated.spec.jsx.snap
+++ b/react/AppLinker/__snapshots__/index.deprecated.spec.jsx.snap
@@ -2,23 +2,24 @@
 
 exports[`app icon should not crash if no href 1`] = `
 <div>
-  <a
-    onClick={[Function]}
-  >
-    Open 
-    Cozy Drive
-  </a>
+  <div>
+    <a>
+      Open 
+      Cozy Drive
+    </a>
+  </div>
 </div>
 `;
 
 exports[`app icon should render correctly 1`] = `
 <div>
-  <a
-    href="https://fake.link"
-    onClick={null}
-  >
-    Open 
-    Cozy Drive
-  </a>
+  <div>
+    <a
+      href="https://fake.link"
+    >
+      Open 
+      Cozy Drive
+    </a>
+  </div>
 </div>
 `;

--- a/react/AppLinker/__snapshots__/index.spec.jsx.snap
+++ b/react/AppLinker/__snapshots__/index.spec.jsx.snap
@@ -2,23 +2,24 @@
 
 exports[`app icon should not crash if no href 1`] = `
 <div>
-  <a
-    onClick={[Function]}
-  >
-    Open 
-    Cozy Drive
-  </a>
+  <div>
+    <a>
+      Open 
+      Cozy Drive
+    </a>
+  </div>
 </div>
 `;
 
 exports[`app icon should render correctly 1`] = `
 <div>
-  <a
-    href="https://fake.link"
-    onClick={null}
-  >
-    Open 
-    Cozy Drive
-  </a>
+  <div>
+    <a
+      href="https://fake.link"
+    >
+      Open 
+      Cozy Drive
+    </a>
+  </div>
 </div>
 `;

--- a/react/AppLinker/index.jsx
+++ b/react/AppLinker/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { withClient } from 'cozy-client'
 
 import {
   checkApp,
@@ -79,7 +80,7 @@ export class AppLinker extends React.Component {
   }
 
   static getOnClickHref(props, nativeAppIsAvailable, context, imgRef) {
-    const { app, nativePath } = props
+    const { app, client, nativePath } = props
     const slug = AppLinker.getSlug(props)
     let href = props.href
     let onClick = null
@@ -87,23 +88,29 @@ export class AppLinker extends React.Component {
     const appInfo = NATIVE_APP_INFOS[slug]
 
     if (isFlagshipApp()) {
-      const imgPayload =
-        imgRef &&
-        JSON.stringify({
-          ...imgRef.getBoundingClientRect().toJSON()
-        })
+      const { app: currentApp } = client
+        ? client.getInstanceOptions()
+        : undefined
 
-      return {
-        onClick: event => {
-          event.preventDefault()
+      if (currentApp === undefined || app.slug !== currentApp.slug) {
+        const imgPayload =
+          imgRef &&
+          JSON.stringify({
+            ...imgRef.getBoundingClientRect().toJSON()
+          })
 
-          context
-            ? context.call('openApp', href, app, imgPayload)
-            : logger.error(
-                `Failed to "openApp(${app})". WebviewService has the following falsy value "${context}" in AppLinker's context.`
-              )
-        },
-        href: '#'
+        return {
+          onClick: event => {
+            event.preventDefault()
+
+            context
+              ? context.call('openApp', href, app, imgPayload)
+              : logger.error(
+                  `Failed to "openApp(${app})". WebviewService has the following falsy value "${context}" in AppLinker's context.`
+                )
+          },
+          href: '#'
+        }
       }
     }
 
@@ -234,7 +241,7 @@ AppLinker.propTypes = {
   }).isRequired
 }
 
-export default AppLinker
+export default withClient(AppLinker)
 export {
   NATIVE_APP_INFOS,
   getUniversalLinkDomain,

--- a/react/AppLinker/index.spec.jsx
+++ b/react/AppLinker/index.spec.jsx
@@ -1,23 +1,24 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
 import {
   isMobileApp,
   isMobile,
   openDeeplinkOrRedirect,
   startApp,
-  isAndroid
+  isAndroid,
+  checkApp
 } from 'cozy-device-helper'
 
 import AppLinker from './index'
 import { generateUniversalLink } from './native'
 jest.useFakeTimers()
 
-const tMock = x => x
-
-class AppItem extends React.Component {
-  render() {
-    const { app, onAppSwitch } = this.props
-    return (
+const setup = ({ app, onAppSwitch }) => {
+  return {
+    user: userEvent.setup({ delay: null }),
+    ...render(
       <AppLinker onAppSwitch={onAppSwitch} href={'https://fake.link'} app={app}>
         {({ onClick, href, name }) => (
           <div>
@@ -30,6 +31,7 @@ class AppItem extends React.Component {
     )
   }
 }
+
 jest.mock('./native', () => ({
   ...jest.requireActual('./native'),
   generateUniversalLink: jest.fn()
@@ -41,7 +43,8 @@ jest.mock('cozy-device-helper', () => ({
   isMobile: jest.fn(),
   openDeeplinkOrRedirect: jest.fn(),
   startApp: jest.fn().mockResolvedValue(),
-  isAndroid: jest.fn()
+  isAndroid: jest.fn(),
+  checkApp: jest.fn()
 }))
 
 const app = {
@@ -50,7 +53,7 @@ const app = {
 }
 
 describe('app icon', () => {
-  let spyConsoleError, openNativeFromNativeSpy, appSwitchMock
+  let spyConsoleError, appSwitchMock
 
   beforeEach(() => {
     isMobileApp.mockReturnValue(false)
@@ -60,7 +63,6 @@ describe('app icon', () => {
         throw new Error(message)
       }
     })
-    openNativeFromNativeSpy = jest.spyOn(AppLinker, 'openNativeFromNative')
     isMobileApp.mockReturnValue(false)
     isMobile.mockReturnValue(false)
     isAndroid.mockReturnValue(false)
@@ -73,20 +75,25 @@ describe('app icon', () => {
   })
 
   it('should render correctly', () => {
-    const root = shallow(<AppItem t={tMock} app={app} />).dive()
-    expect(root.getElement()).toMatchSnapshot()
+    const { container } = setup({ app })
+    expect(container).toMatchSnapshot()
   })
 
-  it('should work for native -> native', () => {
-    const root = shallow(
-      <AppItem t={tMock} app={app} onAppSwitch={appSwitchMock} />
-    ).dive()
-    root.find('a').simulate('click')
+  it('should work for web -> web', async () => {
+    isMobileApp.mockReturnValue(false)
+    const { container, user } = setup({ app, onAppSwitch: appSwitchMock })
+    const link = container.querySelector('a')
+    await user.click(link)
     expect(appSwitchMock).not.toHaveBeenCalled()
+    expect(startApp).not.toHaveBeenCalled()
+  })
+
+  it('should work for native -> native', async () => {
     isMobileApp.mockReturnValue(true)
-    root.setState({ nativeAppIsAvailable: true })
-    root.find('a').simulate('click')
-    expect(openNativeFromNativeSpy).toHaveBeenCalled()
+    checkApp.mockResolvedValue(true)
+    const { container, user } = setup({ app, onAppSwitch: appSwitchMock })
+    const link = container.querySelector('a')
+    await user.click(link)
     expect(startApp).toHaveBeenCalledWith({
       appId: 'io.cozy.drive.mobile',
       name: 'Cozy Drive',
@@ -95,13 +102,12 @@ describe('app icon', () => {
     expect(appSwitchMock).toHaveBeenCalled()
   })
 
-  it('should work for web -> native for Android (custom schema) ', () => {
+  it('should work for web -> native for Android (custom schema) ', async () => {
     isMobile.mockReturnValue(true)
     isAndroid.mockResolvedValue(true)
-    const root = shallow(
-      <AppItem t={tMock} app={app} onAppSwitch={appSwitchMock} />
-    ).dive()
-    root.find('a').simulate('click', { preventDefault: () => {} })
+    const { container, user } = setup({ app, onAppSwitch: appSwitchMock })
+    const link = container.querySelector('a')
+    await user.click(link)
     expect(openDeeplinkOrRedirect).toHaveBeenCalledWith(
       'cozydrive://',
       expect.any(Function)
@@ -109,39 +115,39 @@ describe('app icon', () => {
     expect(appSwitchMock).toHaveBeenCalled()
   })
 
-  it('should work for web -> native for iOS (universal link)', () => {
+  it('should work for web -> native for iOS (universal link)', async () => {
     isMobile.mockReturnValue(true)
-    const root = shallow(
-      <AppItem t={tMock} app={app} onAppSwitch={appSwitchMock} />
-    ).dive()
-    root.find('a').simulate('click', { preventDefault: () => {} })
+    const { container, user } = setup({ app, onAppSwitch: appSwitchMock })
+    const link = container.querySelector('a')
+    await user.click(link)
 
     expect(generateUniversalLink).toHaveBeenCalled()
   })
 
-  it('should work for native -> web', () => {
+  it('should work for native -> web', async () => {
     isMobileApp.mockReturnValue(true)
-    const root = shallow(
-      <AppItem t={tMock} app={app} onAppSwitch={appSwitchMock} />
-    ).dive()
-    root.find('a').simulate('click')
+    const { container, user } = setup({ app, onAppSwitch: appSwitchMock })
+    const link = container.querySelector('a')
+    await user.click(link)
     expect(appSwitchMock).toHaveBeenCalled()
   })
 
   it('should not crash if no href', () => {
     isMobileApp.mockReturnValue(true)
     spyConsoleError.mockImplementation(() => {})
-    const root = shallow(
+    const { container } = render(
       <AppLinker onAppSwitch={appSwitchMock} app={app}>
-        {({ onClick, href, name }) => (
-          <div>
-            <a href={href} onClick={onClick}>
-              Open {name}
-            </a>
-          </div>
-        )}
+        {({ onClick, href, name }) => {
+          return (
+            <div>
+              <a href={href} onClick={onClick}>
+                Open {name}
+              </a>
+            </div>
+          )
+        }}
       </AppLinker>
     )
-    expect(root.getElement()).toMatchSnapshot()
+    expect(container).toMatchSnapshot()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,6 +2669,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^14.4.2":
+  version "14.4.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.2.tgz#d3fb5d24e2d7d019a7d2e9978a8deb90b0aa230b"
+  integrity sha512-1gVTWtueNimveOjcm2ApFCnCTeky7WqY3EX31/GRKLWyCd+HfH+Gd2l1J8go9FpDNe+0Mx8X4zbQHTg0WWNJwg==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
When in Flagship mobile app, `AppLinker` is responsible to call
`openApp` for the specified URL and the specified slug, so the mobile
app can handle navigation to the target app

But if the target slug is the same as the current displayed app, it is
unnecessary to call `openApp` as the mobile app would have to handle
navigation to the same route

Instead we want to use the default `web` behaviour in this scenario.
Which means that the web app would redirect to the target URL by using
classic `window.location` redirection

We only check for the URL's slug. The domain here should not be a
problem because if it is the same, then we stay on the app, and if it
is different, then the mobile app would be responsible to detect it and
to open a dedicated view for the external link

Note: this feature is enabled ONLY IF the `AppLinker` component is
inside a `CozyProvider`. If it is not the case, then `AppLinker` would
always call `openApp` like before

___

Related PRs:

- https://github.com/cozy/cozy-notes/pull/318
- https://github.com/cozy/cozy-client/pull/1217