### PR TITLE
fix: Add missing document date label in the viewer

### DIFF
--- a/react/Viewer/locales/en.json
+++ b/react/Viewer/locales/en.json
@@ -42,7 +42,8 @@
             "issueDate": "Delivered on",
             "expirationDate": "Expiration date",
             "referencedDate": "Referenced date",
-            "shootingDate": "Shooting date"
+            "shootingDate": "Shooting date",
+            "date": "Document date"
           }
         },
         "identity": "Identity",

--- a/react/Viewer/locales/fr.json
+++ b/react/Viewer/locales/fr.json
@@ -42,7 +42,8 @@
             "issueDate": "Délivré le",
             "expirationDate": "Expire le",
             "referencedDate": "Date de référence",
-            "shootingDate": "Date de prise de vue"
+            "shootingDate": "Date de prise de vue",
+            "date": "Date du document"
           }
         },
         "identity": "Identité",


### PR DESCRIPTION
The app `mespapiers` was already using this key for the "other documents" but it was not yet defined.