### PR TITLE
fix: LoadMore component effect

### DIFF
--- a/react/LoadMore/index.jsx
+++ b/react/LoadMore/index.jsx
@@ -17,22 +17,28 @@ const LoadMore = ({ fetchMore, label }) => {
     }
   }, [isLoading, fetchMore])
 
-  const checkIntersectionsEntries = intersectionEntries => {
-    if (intersectionEntries.filter(entry => entry.isIntersecting).length > 0)
-      startFetchMore()
-  }
+  const checkIntersectionsEntries = useCallback(
+    intersectionEntries => {
+      if (intersectionEntries.filter(entry => entry.isIntersecting).length > 0)
+        startFetchMore()
+    },
+    [startFetchMore]
+  )
 
   useEffect(() => {
     const observer = new IntersectionObserver(checkIntersectionsEntries)
-    observer.observe(elementRef.current)
+    /*
+      The ref value 'elementRef.current' will likely have changed by the time this effect cleanup function runs
+      It is better to copy the ref to a variable inside the effect
+    */
+    const observerRefValue = elementRef.current
+    observer.observe(observerRefValue)
 
     return () => {
-      // TODO: validate the deps are correct
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      observer.unobserve(elementRef.current)
+      observer.unobserve(observerRefValue)
       observer.disconnect()
     }
-  })
+  }, [checkIntersectionsEntries])
 
   return (
     <span ref={elementRef}>


### PR DESCRIPTION
Fix of an error that causes a crash in React 18+ version
![Capture d’écran 2022-08-19 à 16 22 53](https://user-images.githubusercontent.com/14182143/185641845-17ef1700-a2fd-4219-a3e0-20654e30e335.png)

When unmount the LoadMore component, `elementRef.current` is null in the cleanup function, which caused an error.

Copy the element contained in the ref to a local variable allows the cleanup function to have the element and not a null value

In addition, the `useEffect` should have an array of dependencies 

(Tested with the CoachCO2 app)