### PR TITLE
fix: Do not display Viewer's Download button on iOS Flagship app

### DIFF
--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -16,7 +16,8 @@ const useStyles = makeStyles(theme => ({
     height: '100%',
     paddingLeft: '1rem',
     paddingRight: '1rem',
-    borderTop: `1px solid ${theme.palette.divider}`
+    borderTop: `1px solid ${theme.palette.divider}`,
+    columnGap: '0.5rem'
   }
 }))
 

--- a/react/Viewer/Footer/ForwardOrDownloadButton.jsx
+++ b/react/Viewer/Footer/ForwardOrDownloadButton.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
+import { isFlagshipApp, isIOS } from 'cozy-device-helper'
 
 import ForwardButton from './ForwardButton'
 import DownloadButton from './DownloadButton'
@@ -14,7 +15,10 @@ const ForwardOrDownloadButton = ({ file }) => {
     ? ForwardButton
     : DownloadButton
 
-  return <FileActionButton file={file} />
+  // Temporarily disable Download button on iOS Flagship app until
+  // the download feature is fixed on this platform
+  // When fixed on this platform, revert this commit from PR #2215
+  return isFlagshipApp() && isIOS() ? null : <FileActionButton file={file} />
 }
 
 ForwardOrDownloadButton.propTypes = {

--- a/react/Viewer/Footer/Sharing.jsx
+++ b/react/Viewer/Footer/Sharing.jsx
@@ -25,7 +25,6 @@ const Sharing = ({ file }) => {
           />
         )}
         <ShareButton
-          className="u-mr-half"
           extension="full"
           useShortLabel
           docId={file.id}

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -102,7 +102,7 @@ const ShareButtonFake = () => {
   return (
     <Button
       label="Share"
-      className="u-w-100 u-ml-0 u-mr-half"
+      className="u-w-100 u-ml-0 u-mr-0"
       variant="secondary"
       startIcon={<Icon icon={ShareIcon} />}
       onClick={() => {


### PR DESCRIPTION
Current implementation of iOS Flagship app doesn't handle files
download correctly

So we want to temporarily disable Download button on this platform

This commit is meant to be reverted when files download is fixed on iOS
Flagship app

---

This commit also refactor margin handling on `FooterContent` items

---

Related PRs:

- https://github.com/cozy/cozy-drive/pull/2672

---

TODO:

- [ ] Apply breaking change on [cozy-mespapiers-lib/SelectFileButton](https://github.com/cozy/cozy-libs/blob/a77d785bd557c73d1bf46509697629a471f972de/packages/cozy-mespapiers-lib/src/components/Viewer/SelectFileButton.jsx#L18) after this PR is merged