### PR TITLE
feat: Let the user able to select content

### DIFF
--- a/react/Viewer/ViewerControls.jsx
+++ b/react/Viewer/ViewerControls.jsx
@@ -47,11 +47,6 @@ class ViewerControls extends Component {
     }
   }
 
-  onTap = () => {
-    if (this.state.hidden) this.showControls()
-    else this.hideAfterDelay()
-  }
-
   hideAfterDelay = () => {
     clearTimeout(this.hideTimeout)
     this.hideTimeout = setTimeout(() => {
@@ -65,13 +60,18 @@ class ViewerControls extends Component {
   }
 
   initGestures = () => {
-    const gestures = new Hammer(this.wrapped)
-    gestures.on('swipe', this.onSwipe)
-    gestures.on('tap', this.onTap)
-    const tap = gestures.get('tap')
-    const doubleTap = gestures.get('doubletap')
-    doubleTap.recognizeWith(tap)
-    tap.requireFailure(doubleTap)
+    const gestures = new Hammer(
+      this.wrapped,
+      this.props.breakpoints.isDesktop
+        ? {
+            cssProps: {
+              userSelect: 'auto'
+            }
+          }
+        : {}
+    )
+    if (!this.props.breakpoints.isDesktop) gestures.on('swipe', this.onSwipe)
+
     return gestures
   }
 
@@ -116,7 +116,6 @@ class ViewerControls extends Component {
     } = this.props
     const { showToolbar, showClose, toolbarRef } = toolbarProps
     const { hidden } = this.state
-
     return (
       <div
         className={cx(styles['viewer-controls'], {


### PR DESCRIPTION
An user reported us that he was not able
to select a text from a PDF (https://github.com/cozy/cozy-drive/issues/2673).

After a quick look, it appears that HammerJS
adds a `user-select:none` inline style in
order to be able to add its gestures things.

We can disable this option when creating the
Hammer object. This is what I've done here
for the desktop version.

I also removed the swipe gesture for desktop
because we can have "conflict" between text
selection and swipe. This is why I didn't
remove this behavior on mobile, since I don't
have the time to test it correctly on several
devices.

It also appears that we don't need the tap/
doubletap gesture anymore in order to display
the controls because the control is now
only displayed on hover. Else wehre, the opacity
is set to false.

https://crash--.github.io/cozy-ui/react/#!/Viewer