### PR TITLE
fix: Don't rely on cozy-doctypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "copyfiles": "2.4.1",
     "cozy-client": "^33.0.0",
     "cozy-device-helper": "2.0.0",
-    "cozy-doctypes": "^1.69.0",
     "cozy-flags": "^2.10.1",
     "cozy-harvest-lib": "^6.7.3",
     "cozy-intent": "1.16.1",
@@ -180,7 +179,6 @@
   "peerDependencies": {
     "cozy-client": ">=33.0.0",
     "cozy-device-helper": "^2.0.0",
-    "cozy-doctypes": "^1.69.0",
     "cozy-harvest-lib": "^6.7.3",
     "cozy-intent": ">=1.3.0",
     "cozy-sharing": "^3.10.0",

--- a/react/ContactPicker/index.jsx
+++ b/react/ContactPicker/index.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { Contact } from 'cozy-doctypes'
+import { models } from 'cozy-client'
+const { getDisplayName } = models.contact
 
 import ContactsListModal from '../ContactsListModal'
 import styles from './styles.styl'
@@ -58,7 +59,7 @@ class ContactPicker extends React.Component {
     return (
       <>
         <SelectControl {...rest} onClick={this.open}>
-          {value ? Contact.getDisplayName(value) : placeholder}
+          {value ? getDisplayName(value) : placeholder}
         </SelectControl>
         {opened && (
           <ContactsListModal

--- a/react/ContactsList/ContactRow.jsx
+++ b/react/ContactsList/ContactRow.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-import { Contact } from 'cozy-doctypes'
 import { models } from 'cozy-client'
 
 import ListItem from '../MuiCozyTheme/ListItem'
@@ -37,7 +36,7 @@ const ContactRow = ({ className, contact, onClick, divider, ...rest }) => {
 }
 
 ContactRow.propTypes = {
-  contact: Contact.propType.isRequired,
+  contact: PropTypes.object.isRequired,
   onClick: PropTypes.func,
   divider: PropTypes.bool
 }

--- a/react/ContactsList/Contacts/ContactIdentity.jsx
+++ b/react/ContactsList/Contacts/ContactIdentity.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { Contact } from 'cozy-doctypes'
 import { models } from 'cozy-client'
+import PropTypes from 'prop-types'
 
 import { Avatar } from '../../Avatar'
 import { TableCell } from '../../Table'
@@ -32,7 +32,7 @@ const ContactIdentity = ({ contact }) => {
 }
 
 ContactIdentity.propTypes = {
-  contact: Contact.propType.isRequired
+  contact: PropTypes.object.isRequired
 }
 
 export default ContactIdentity

--- a/react/ContactsListModal/ContactsListContent.jsx
+++ b/react/ContactsListModal/ContactsListContent.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { Contact } from 'cozy-doctypes'
+import { models } from 'cozy-client'
+const { getDisplayName } = models.contact
 
 import ContactsList from '../ContactsList'
 import Spinner from '../Spinner'
@@ -15,7 +16,7 @@ const mkFilter = filterStr => contacts => {
 
   // TODO better filtering methods can be extracted from drive. See https://github.com/cozy/cozy-ui/pull/1273#discussion_r351845385
   return contacts.filter(contact => {
-    const displayName = Contact.getDisplayName(contact)
+    const displayName = getDisplayName(contact)
 
     if (!displayName) {
       return false

--- a/yarn.lock
+++ b/yarn.lock
@@ -5879,17 +5879,6 @@ cozy-device-helper@^1.12.0:
   dependencies:
     lodash "^4.17.19"
 
-cozy-doctypes@^1.69.0:
-  version "1.83.7"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.7.tgz#258448aa5fa8f76d557c7635c148d9bfe54bbe33"
-  integrity sha512-sAMZ/xajc2rXWmBFB0fP4NWQmUDh6FmStRE2KFpMrq7UGM6wIBouVl1CYD7grdlompBh3/1kBNmAb5PuWRMnBQ==
-  dependencies:
-    cozy-logger "^1.9.0"
-    date-fns "^1.30.1"
-    es6-promise-pool "^2.5.0"
-    lodash "^4.17.19"
-    prop-types "^15.7.2"
-
 cozy-doctypes@^1.82.3:
   version "1.82.3"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.82.3.tgz#e8e759c7698fb2718a35c06e46b24c000a2b3cd4"


### PR DESCRIPTION
Cozy-doctypes is an old project that should not be used
anymore.

Almost all the contact's related methods have been moved
to cozy-client so let's use them.

We lose the Contact's proptype ATM, but it will come
back with cozy-client's types pretty soon.

If your changes have graphic impacts, it is useful to deploy a version
of the styleguidist to your repository.
