### PR TITLE
Wrap BottomSheet in Portal

### DIFF
--- a/react/BottomSheet/BackdropOrFragment.jsx
+++ b/react/BottomSheet/BackdropOrFragment.jsx
@@ -6,7 +6,6 @@ const BackdropOrFragment = ({ showBackdrop, onClick, children }) => {
   const Comp = showBackdrop ? Backdrop : Fragment
   const props = showBackdrop
     ? {
-        style: { zIndex: 'var(--zIndex-overlay)' },
         open: showBackdrop,
         onClick
       }

--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -1,11 +1,21 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  forwardRef,
+  memo,
+  Fragment
+} from 'react'
 import PropTypes from 'prop-types'
 import { BottomSheet as MuiBottomSheet } from 'mui-bottom-sheet'
 import { useTimeoutWhen } from 'rooks'
 import Fade from '@material-ui/core/Fade'
+import Portal from '@material-ui/core/Portal'
 
 import { getFlagshipMetadata } from 'cozy-device-helper'
 
+import CozyTheme, { useCozyTheme } from '../CozyTheme'
 import Stack from '../Stack'
 import Paper from '../Paper'
 import BackdropOrFragment from './BackdropOrFragment'
@@ -21,11 +31,15 @@ import {
 import { ANIMATION_DURATION } from './constants'
 
 const createStyles = ({ squared, hasToolbarProps }) => ({
+  container: {
+    position: 'fixed',
+    zIndex: 'var(--zIndex-modal)',
+    inset: 0
+  },
   root: {
     borderTopLeftRadius: '1rem',
     borderTopRightRadius: '1rem',
     transition: 'border-radius 0.5s',
-    zIndex: 'var(--zIndex-drawer)',
     boxShadow:
       '0 -0.5px 0px 0 rgba(0, 0, 0, 0.10), 0 -2px 2px 0 rgba(0, 0, 0, 0.02), 0 -4px 4px 0 rgba(0, 0, 0, 0.02), 0 -8px 8px 0 rgba(0, 0, 0, 0.02), 0 -16px 16px 0 rgba(0, 0, 0, 0.02)',
     backgroundColor: 'var(--paperBackgroundColor)',
@@ -52,8 +66,7 @@ const createStyles = ({ squared, hasToolbarProps }) => ({
     position: 'fixed',
     bottom: 0,
     left: 0,
-    backgroundColor: 'var(--paperBackgroundColor)',
-    zIndex: 'var(--zIndex-overlay)'
+    backgroundColor: 'var(--paperBackgroundColor)'
   },
   flagshipImmersive: {
     backgroundColor: 'var(--paperBackgroundColor)',
@@ -77,194 +90,191 @@ const defaultSettings = {
   mediumHeight: null
 }
 
-const BottomSheet = ({
-  toolbarProps,
-  settings,
-  backdrop,
-  skipAnimation,
-  onClose,
-  children
-}) => {
-  const { mediumHeightRatio, mediumHeight } = {
-    ...defaultSettings,
-    ...settings
-  }
+const BottomSheet = memo(
+  ({ toolbarProps, settings, backdrop, skipAnimation, onClose, children }) => {
+    const { mediumHeightRatio, mediumHeight } = {
+      ...defaultSettings,
+      ...settings
+    }
 
-  const innerContentRef = useRef()
-  const headerRef = useRef()
-  const headerContentRef = useRef()
-  const [isTopPosition, setIsTopPosition] = useState(false)
-  const [isBottomPosition, setIsBottomPosition] = useState(false)
-  const [isHidden, setIsHidden] = useState(false)
-  const [showBackdrop, setShowBackdrop] = useState(backdrop)
-  const [peekHeights, setPeekHeights] = useState(null)
-  const [currentIndex, setCurrentIndex] = useState()
-  const [bottomSpacerHeight, setBottomSpacerHeight] = useState(0)
-  const [initPos, setInitPos] = useState(0)
+    const innerContentRef = useRef()
+    const headerRef = useRef()
+    const headerContentRef = useRef()
+    const [isTopPosition, setIsTopPosition] = useState(false)
+    const [isBottomPosition, setIsBottomPosition] = useState(false)
+    const [isHidden, setIsHidden] = useState(false)
+    const [showBackdrop, setShowBackdrop] = useState(backdrop)
+    const [peekHeights, setPeekHeights] = useState(null)
+    const [currentIndex, setCurrentIndex] = useState()
+    const [bottomSpacerHeight, setBottomSpacerHeight] = useState(0)
+    const [initPos, setInitPos] = useState(0)
 
-  const squared = backdrop
-    ? isTopPosition && bottomSpacerHeight <= 0
-    : isTopPosition
-  const hasToolbarProps = !!Object.keys(toolbarProps).length
-  const isClosable = !!onClose || backdrop
+    const squared = backdrop
+      ? isTopPosition && bottomSpacerHeight <= 0
+      : isTopPosition
+    const hasToolbarProps = !!Object.keys(toolbarProps).length
+    const isClosable = !!onClose || backdrop
 
-  const styles = createStyles({
-    squared,
-    hasToolbarProps
-  })
-  const overriddenChildren = makeOverridenChildren(children, headerContentRef)
+    const styles = createStyles({
+      squared,
+      hasToolbarProps
+    })
+    const overriddenChildren = makeOverridenChildren(children, headerContentRef)
 
-  if (backdrop && !onClose) {
-    throw new Error(
-      'BottomSheet must have `onClose` method to work properly when setting `backdrop` to `true`'
+    if (backdrop && !onClose) {
+      throw new Error(
+        'BottomSheet must have `onClose` method to work properly when setting `backdrop` to `true`'
+      )
+    }
+
+    const handleClose = useCallback(() => {
+      setShowBackdrop(false)
+      setIsHidden(true)
+      onClose && onClose()
+    }, [onClose])
+
+    const handleOnIndexChange = snapIndex => {
+      const maxHeightSnapIndex = peekHeights.length - 1
+
+      setCurrentIndex(snapIndex)
+      setTopPosition({
+        snapIndex,
+        maxHeightSnapIndex,
+        isTopPosition,
+        setIsTopPosition
+      })
+      setBottomPosition({ snapIndex, isBottomPosition, setIsBottomPosition })
+    }
+
+    // hack to prevent pull-down-to-refresh behavior when dragging down the bottom sheet.
+    // Needed for iOS Safari
+    useEffect(() => {
+      document.body.style.overflow = 'hidden'
+      return () => {
+        document.body.style.overflow = 'auto'
+      }
+    }, [])
+
+    // close the bottom sheet by swaping it below the minimum height
+    useTimeoutWhen(
+      () => handleClose(),
+      ANIMATION_DURATION,
+      isClosable && isBottomPosition
+    )
+    const innerContentHeight = innerContentRef?.current?.offsetHeight ?? 0
+
+    useEffect(() => {
+      const headerContent = headerContentRef.current
+      const actionButtonsHeight = headerContent
+        ? parseFloat(getComputedStyle(headerContent).getPropertyValue('height'))
+        : 0
+      const actionButtonsBottomMargin = headerContent
+        ? parseFloat(
+            getComputedStyle(headerContent).getPropertyValue('padding-bottom')
+          )
+        : 0
+
+      const maxHeight = computeMaxHeight(toolbarProps)
+      const computedMediumHeight = computeMediumHeight({
+        backdrop,
+        maxHeight,
+        mediumHeight,
+        mediumHeightRatio,
+        innerContentHeight
+      })
+      const minHeight = computeMinHeight({
+        isClosable,
+        headerRef,
+        actionButtonsHeight,
+        actionButtonsBottomMargin
+      })
+      const bottomSpacerHeight = maxHeight - innerContentHeight
+
+      if (computedMediumHeight >= maxHeight) {
+        setIsTopPosition(true)
+      }
+      setPeekHeights([...new Set([minHeight, computedMediumHeight, maxHeight])])
+      setInitPos(computedMediumHeight)
+      // Used so that the BottomSheet can be opened to the top without stopping at the content height
+      setBottomSpacerHeight(bottomSpacerHeight)
+    }, [
+      innerContentHeight,
+      toolbarProps,
+      mediumHeightRatio,
+      mediumHeight,
+      showBackdrop,
+      backdrop,
+      isClosable
+    ])
+
+    return (
+      <div style={styles.container}>
+        {getFlagshipMetadata().immersive && (
+          <span style={styles.flagshipImmersive} />
+        )}
+        <BackdropOrFragment
+          showBackdrop={showBackdrop}
+          onClick={() =>
+            minimizeAndClose({
+              backdrop,
+              setCurrentIndex,
+              setIsTopPosition,
+              setIsBottomPosition,
+              handleClose
+            })
+          }
+        />
+        <MuiBottomSheet
+          peekHeights={peekHeights}
+          defaultHeight={initPos}
+          backdrop={false}
+          fullHeight={hasToolbarProps ? false : true}
+          currentIndex={currentIndex}
+          onIndexChange={handleOnIndexChange}
+          styles={{ root: styles.root }}
+          threshold={0}
+          // springConfig doc : https://docs.pmnd.rs/react-spring/common/configs
+          springConfig={{
+            tension: defaultBottomSheetSpringConfig.tension,
+            friction: defaultBottomSheetSpringConfig.friction,
+            clamp: defaultBottomSheetSpringConfig.clamp
+          }}
+          disabledClosing={!onClose}
+          hidden={isHidden}
+          snapPointSeekerMode="next"
+          skipAnimation={skipAnimation}
+        >
+          <div ref={innerContentRef}>
+            <Paper
+              data-testid="bottomSheet-header"
+              className="u-w-100 u-h-2-half u-pos-relative u-flex u-flex-items-center u-flex-justify-center"
+              ref={headerRef}
+              elevation={0}
+              square
+            >
+              <div style={styles.indicator} />
+            </Paper>
+            <Stack
+              style={styles.stack}
+              className="u-flex u-flex-column u-ov-hidden"
+              spacing="s"
+            >
+              {overriddenChildren}
+            </Stack>
+          </div>
+          <div style={{ height: backdrop ? 0 : bottomSpacerHeight }} />
+        </MuiBottomSheet>
+        {!isBottomPosition && (
+          <Fade in timeout={ANIMATION_DURATION}>
+            <div style={styles.bounceSafer} />
+          </Fade>
+        )}
+      </div>
     )
   }
+)
 
-  const handleClose = useCallback(() => {
-    setShowBackdrop(false)
-    setIsHidden(true)
-    onClose && onClose()
-  }, [onClose])
-
-  const handleOnIndexChange = snapIndex => {
-    const maxHeightSnapIndex = peekHeights.length - 1
-
-    setCurrentIndex(snapIndex)
-    setTopPosition({
-      snapIndex,
-      maxHeightSnapIndex,
-      isTopPosition,
-      setIsTopPosition
-    })
-    setBottomPosition({ snapIndex, isBottomPosition, setIsBottomPosition })
-  }
-
-  // hack to prevent pull-down-to-refresh behavior when dragging down the bottom sheet.
-  // Needed for iOS Safari
-  useEffect(() => {
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = 'auto'
-    }
-  }, [])
-
-  // close the bottom sheet by swaping it below the minimum height
-  useTimeoutWhen(
-    () => handleClose(),
-    ANIMATION_DURATION,
-    isClosable && isBottomPosition
-  )
-  const innerContentHeight = innerContentRef?.current?.offsetHeight ?? 0
-
-  useEffect(() => {
-    const headerContent = headerContentRef.current
-    const actionButtonsHeight = headerContent
-      ? parseFloat(getComputedStyle(headerContent).getPropertyValue('height'))
-      : 0
-    const actionButtonsBottomMargin = headerContent
-      ? parseFloat(
-          getComputedStyle(headerContent).getPropertyValue('padding-bottom')
-        )
-      : 0
-
-    const maxHeight = computeMaxHeight(toolbarProps)
-    const computedMediumHeight = computeMediumHeight({
-      backdrop,
-      maxHeight,
-      mediumHeight,
-      mediumHeightRatio,
-      innerContentHeight
-    })
-    const minHeight = computeMinHeight({
-      isClosable,
-      headerRef,
-      actionButtonsHeight,
-      actionButtonsBottomMargin
-    })
-    const bottomSpacerHeight = maxHeight - innerContentHeight
-
-    if (computedMediumHeight >= maxHeight) {
-      setIsTopPosition(true)
-    }
-    setPeekHeights([...new Set([minHeight, computedMediumHeight, maxHeight])])
-    setInitPos(computedMediumHeight)
-    // Used so that the BottomSheet can be opened to the top without stopping at the content height
-    setBottomSpacerHeight(bottomSpacerHeight)
-  }, [
-    innerContentHeight,
-    toolbarProps,
-    mediumHeightRatio,
-    mediumHeight,
-    showBackdrop,
-    backdrop,
-    isClosable
-  ])
-
-  return (
-    <>
-      {getFlagshipMetadata().immersive && (
-        <span style={styles.flagshipImmersive} />
-      )}
-      <BackdropOrFragment
-        showBackdrop={showBackdrop}
-        onClick={() =>
-          minimizeAndClose({
-            backdrop,
-            setCurrentIndex,
-            setIsTopPosition,
-            setIsBottomPosition,
-            handleClose
-          })
-        }
-      />
-      <MuiBottomSheet
-        peekHeights={peekHeights}
-        defaultHeight={initPos}
-        backdrop={false}
-        fullHeight={hasToolbarProps ? false : true}
-        currentIndex={currentIndex}
-        onIndexChange={handleOnIndexChange}
-        styles={{ root: styles.root }}
-        threshold={0}
-        // springConfig doc : https://docs.pmnd.rs/react-spring/common/configs
-        springConfig={{
-          tension: defaultBottomSheetSpringConfig.tension,
-          friction: defaultBottomSheetSpringConfig.friction,
-          clamp: defaultBottomSheetSpringConfig.clamp
-        }}
-        disabledClosing={!onClose}
-        hidden={isHidden}
-        snapPointSeekerMode="next"
-        skipAnimation={skipAnimation}
-      >
-        <div ref={innerContentRef}>
-          <Paper
-            data-testid="bottomSheet-header"
-            className="u-w-100 u-h-2-half u-pos-relative u-flex u-flex-items-center u-flex-justify-center"
-            ref={headerRef}
-            elevation={0}
-            square
-          >
-            <div style={styles.indicator} />
-          </Paper>
-          <Stack
-            style={styles.stack}
-            className="u-flex u-flex-column u-ov-hidden"
-            spacing="s"
-          >
-            {overriddenChildren}
-          </Stack>
-        </div>
-        <div style={{ height: backdrop ? 0 : bottomSpacerHeight }} />
-      </MuiBottomSheet>
-      {!isBottomPosition && (
-        <Fade in timeout={ANIMATION_DURATION}>
-          <div style={styles.bounceSafer} />
-        </Fade>
-      )}
-    </>
-  )
-}
+BottomSheet.displayName = 'BottomSheet'
 
 BottomSheet.defaultProps = {
   classes: {},
@@ -295,4 +305,19 @@ BottomSheet.propTypes = {
   onClose: PropTypes.func
 }
 
-export default React.memo(BottomSheet)
+const BottomSheetPortal = forwardRef(({ portalProps, ...props }, ref) => {
+  const CozyThemeWrapper = portalProps?.disablePortal ? Fragment : CozyTheme
+  const cozyTheme = useCozyTheme()
+
+  return (
+    <Portal {...portalProps}>
+      <CozyThemeWrapper variant={cozyTheme}>
+        <BottomSheet ref={ref} {...props} />
+      </CozyThemeWrapper>
+    </Portal>
+  )
+})
+
+BottomSheetPortal.displayName = 'BottomSheetPortal'
+
+export default BottomSheetPortal

--- a/react/BottomSheet/README.md
+++ b/react/BottomSheet/README.md
@@ -1,8 +1,11 @@
 Display content coming up from the bottom of the screen. The pane can be swiped to the top of the screen. Based on cozy
-/ mui-bottom-sheet: [API documentation is here](https://github.com/cozy/mui-bottom-sheet#props-options).
+/ mui-bottom-sheet: [API documentation is here](https://github.com/cozy/mui-bottom-sheet#props-options). It uses `Portal` to have the same behavior as `Dialogs` / `Modals` (can be disabled with the `disablePortal` prop).
 
 ### Props
 
+* **portalProps** : `<object>` – Portal properties
+  * **container** : `<HTMLElement> | <function> | <React.Component>` – Portal container
+  * **disablePortal** : `<boolean>` – Disable the portal behavior
 * **toolbarProps** : `<object>` – Toolbar properties
   * **ref** : `<object>` – React reference of the toolbar node
   * **height** : `<number>` – Toolbar height value

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -56,6 +56,8 @@ import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 import FormControl from 'cozy-ui/transpiled/react/FormControl'
 import FormLabel from 'cozy-ui/transpiled/react/FormLabel'
+import BottomSheet, { BottomSheetItem } from 'cozy-ui/transpiled/react/BottomSheet'
+import Stack from 'cozy-ui/transpiled/react/Stack'
 
 import CloudIcon from "cozy-ui/transpiled/react/Icons/Cloud"
 
@@ -64,6 +66,12 @@ const handleBack = () => {
   Alerter.success('Back button has been pressed', { duration: 5000 })
   setState({ modalOpened: !state.modalOpened })
 }
+const hideBottomSheet = () => setState({ bottomSheetOpened: false })
+const showBottomSheet = () => setState({ bottomSheetOpened: true })
+const hideSecondConfirmDialog = () => setState({ secondConfirmDialogOpened: false })
+const showSecondConfirmDialog = () => setState({ secondConfirmDialogOpened: true })
+const hideBSConfirmDialog = () => setState({ BSConfirmDialogOpened: false })
+const showBSConfirmDialog = () => setState({ BSConfirmDialogOpened: true })
 
 const DialogComponent = state.modal
 
@@ -152,6 +160,9 @@ const toggleDialog = dialog => {
 
 initialState = {
   modalOpened: isTesting(),
+  bottomSheetOpened: false,
+  secondConfirmDialogOpened: false,
+  BSConfirmDialogOpened: false,
   modal: Dialog,
   size: 'medium',
   content: 'default',
@@ -257,14 +268,52 @@ const initialVariants = [{
           }
           disableGutters={variant.disableGutters}
           content={
-            <Typography variant='body1' color='textPrimary'>
-              { state.content == 'default'
-              ? dialogContents[DialogComponent.name]
-              : state.content == 'long'
-                ? content.ada.long
-                : content.ada.short}<br/>
-              <Button className='u-mt-1 u-ml-0' label="Show an alert" onClick={() => Alerter.success('Hello', { duration: 100000 })}/>
-            </Typography>}
+            <>
+              <Typography component="div" variant="body1">
+                { state.content == 'default'
+                  ? dialogContents[DialogComponent.name]
+                  : state.content == 'long'
+                    ? content.ada.long
+                    : content.ada.short
+                }
+                <Stack className="u-mt-1" spacing="s">
+                  <div>
+                    <Button label="Show an alert" onClick={() => Alerter.success('Hello', { duration: 100000 })}/>
+                  </div>
+                  <div>
+                    <Button label="Show inner bottom sheet" onClick={showBottomSheet}/>
+                  </div>
+                  <div>
+                    <Button label="Show inner confirm dialog" onClick={showSecondConfirmDialog}/>
+                  </div>
+                </Stack>
+              </Typography>
+
+              {state.secondConfirmDialogOpened && (
+                <ConfirmDialog open onClose={hideSecondConfirmDialog}
+                  title="This is a simple title"
+                  content="This is a simple content"
+                />
+              )}
+
+              {state.bottomSheetOpened && (
+                <BottomSheet backdrop onClose={hideBottomSheet}>
+                  <BottomSheetItem>
+                    <div className="u-mb-1">
+                      <Button label="Show inner confirm dialog" onClick={showBSConfirmDialog}/>
+                    </div>
+                    {content.ada.long}
+                    {state.BSConfirmDialogOpened && (
+                      <ConfirmDialog open onClose={hideBSConfirmDialog}
+                        title="This is a simple title"
+                        content="This is a simple content"
+                      />
+                    )}
+                  </BottomSheetItem>
+                </BottomSheet>
+              )}
+            </>
+          }
           actions={variant.showActions && dialogActions[DialogComponent.name]}
           actionsLayout={variant.actionsLayoutColumn ? 'column' : 'row'}
         />

--- a/react/CozyTheme/index.jsx
+++ b/react/CozyTheme/index.jsx
@@ -1,7 +1,8 @@
 import React, { createContext, useContext } from 'react'
+import cx from 'classnames'
+
 import MuiCozyTheme from '../MuiCozyTheme'
 import themesStyles from '../../stylus/settings/palette.styl'
-import cx from 'classnames'
 
 export const CozyThemeContext = createContext()
 


### PR DESCRIPTION
Le BottomSheet fonctionne maintenant plus logiquement, à savoir comme une modale, à savoir avec Portal et donc par défaut s'attache au body. C'est le comportement des Modal et Dialog de Mui, j'ai repris la même approche.

BREAKING CHANGE: BottomSheet now use Portal by default to work as a modal, and so is attached to the body. If for some reasons you need to use the BottomSheet inside a specific place in the DOM, you can use `disablePortal` prop.

demo : https://jf-cozy.github.io/cozy-ui/react/#!/BottomSheet et https://jf-cozy.github.io/cozy-ui/react/#!/CozyDialogs