### PR TITLE
feat: Display Viewer's Download button on iOS Flagship app

### DIFF
--- a/react/Viewer/Footer/ForwardOrDownloadButton.jsx
+++ b/react/Viewer/Footer/ForwardOrDownloadButton.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
-import { isFlagshipApp, isIOS } from 'cozy-device-helper'
 
 import ForwardButton from './ForwardButton'
 import DownloadButton from './DownloadButton'
@@ -15,10 +14,7 @@ const ForwardOrDownloadButton = ({ file }) => {
     ? ForwardButton
     : DownloadButton
 
-  // Temporarily disable Download button on iOS Flagship app until
-  // the download feature is fixed on this platform
-  // When fixed on this platform, revert this commit from PR #2215
-  return isFlagshipApp() && isIOS() ? null : <FileActionButton file={file} />
+  return <FileActionButton file={file} />
 }
 
 ForwardOrDownloadButton.propTypes = {


### PR DESCRIPTION
This commit is a revert from  db2303da03b4ea445737dad9a5de16bac71fe3b4

In previous commit we removed the Viewer's Download button on iOS
Flagship app as this platform was not able to handle downloads
correctly

Now that we implemented a solution to handle downloads on this platform
we can add this feature back

Related PR: cozy/cozy-ui#2215