### PR TITLE
fix: Restore BottomSheet items' gap in `FooterContent` container

### DIFF
--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, Children, cloneElement, isValidElement } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
+import cx from 'classnames'
 
 import BottomSheet, { BottomSheetHeader } from '../../BottomSheet'
 
@@ -17,6 +18,9 @@ const useStyles = makeStyles(theme => ({
     paddingLeft: '1rem',
     paddingRight: '1rem',
     borderTop: `1px solid ${theme.palette.divider}`,
+    columnGap: '0.5rem'
+  },
+  bottomSheetHeader: {
     columnGap: '0.5rem'
   }
 }))
@@ -46,7 +50,9 @@ const FooterContent = ({ file, toolbarRef, children }) => {
   if (isValidForPanel({ file }) && !isLoadingContacts) {
     return (
       <BottomSheet toolbarProps={toolbarProps}>
-        <BottomSheetHeader className="u-ph-1 u-pb-1">
+        <BottomSheetHeader
+          className={cx('u-ph-1 u-pb-1', styles.bottomSheetHeader)}
+        >
           {FooterActionButtonsWithFile}
         </BottomSheetHeader>
         <BottomSheetContent file={file} contactsFullname={contactName} />


### PR DESCRIPTION
In 22776e2d46a254dd22aca6411e294706952bc696 we chose to handle gap
between items directly in `FooterContent` so child items don't have to
care about this

We forgot to propagate this into BottomSheet version of the Viewer's
footer (i.e: when displaying CarbonCopy data)

### Before
![image](https://user-images.githubusercontent.com/1884255/188688313-3d2feba9-3bff-4031-89d0-6134b6c065f6.png)

### After
![image](https://user-images.githubusercontent.com/1884255/188688003-ab4c6320-c83f-405c-992b-dd77d91c014d.png)
