### PR TITLE
fix: isLoadingContacts on useReferencedContactName hook

### DIFF
--- a/react/Viewer/Footer/useReferencedContactName.jsx
+++ b/react/Viewer/Footer/useReferencedContactName.jsx
@@ -10,17 +10,20 @@ const useReferencedContactName = file => {
   const contactIds = getReferencedBy(file, 'io.cozy.contacts').map(
     ref => ref.id
   )
+  const isContactByIdsQueryEnabled = contactIds.length > 0
+
   const contactByIdsQuery = buildContactByIdsQuery(contactIds)
   const { data: contacts, ...contactsQueryResult } = useQuery(
     contactByIdsQuery.definition,
     {
       ...contactByIdsQuery.options,
-      enabled: contactIds.length > 0
+      enabled: isContactByIdsQueryEnabled
     }
   )
 
   const isLoadingContacts =
-    isQueryLoading(contactsQueryResult) || contactsQueryResult.hasMore
+    isContactByIdsQueryEnabled &&
+    (isQueryLoading(contactsQueryResult) || contactsQueryResult.hasMore)
 
   const contactName =
     contacts && contacts.length > 0


### PR DESCRIPTION
The Query being conditioned by `contactIds.length > 0`,
`isLoadingContacts` must also be.
Otherwise `isQueryLoading(contactsQueryResult)` is always `true`.