### PR TITLE
fix(ListItem): Focus effect remains after a click on button ListItem

### DIFF
--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -490,17 +490,6 @@ const makeOverrides = theme => ({
     },
     secondaryAction: {
       paddingRight: '2rem'
-    },
-    button: {
-      '&$selected, &$selected:hover': {
-        backgroundColor: theme.palette.action.selected
-      },
-      '&:hover': {
-        backgroundColor: theme.palette.background.default
-      },
-      '&:focus': {
-        backgroundColor: theme.palette.background.default
-      }
     }
   },
   MuiListItemText: {


### PR DESCRIPTION
Initialement on avait un souci qui faisait que lorsqu'on cliquait sur un ListItem button, l'effet focus restait présent, particulièrement visible si le button ouvre une modale, qu'on ferme ensuite.

Ici on reprend le style initiale de Mui, ce qui corrige le problème.

demo : https://jf-cozy.github.io/cozy-ui/react/#!/List