### PR TITLE
feat(Viewer): Show all possible qualification  data, uninformed if empty

### DIFF
--- a/react/Viewer/Panel/ActionMenuWrapper.jsx
+++ b/react/Viewer/Panel/ActionMenuWrapper.jsx
@@ -65,7 +65,7 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
     return (
       <ActionMenuMobile
         onClose={onClose}
-        isEditable={editPath && isEditableAttribute}
+        isEditable={Boolean(editPath) && isEditableAttribute}
         actions={{ handleCopy, handleEdit }}
         appLink={url}
         appSlug={mespapiersAppSlug}
@@ -77,7 +77,7 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
     <ActionMenuDesktop
       ref={ref}
       onClose={onClose}
-      isEditable={editPath && isEditableAttribute}
+      isEditable={Boolean(editPath) && isEditableAttribute}
       actions={{ handleCopy, handleEdit }}
       appLink={url}
       appSlug={mespapiersAppSlug}

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -104,4 +104,4 @@ Qualification.propTypes = {
   file: PropTypes.object
 }
 
-export default withViewerLocales(React.memo(Qualification))
+export default withViewerLocales(Qualification)

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -50,6 +50,10 @@ const Qualification = ({ file = {} }) => {
       {metadataComputed.map((meta, idx) => {
         const { name } = meta
 
+        if (name === 'contact') {
+          return <QualificationListItemContact key={idx} file={file} />
+        }
+
         if (knownDateMetadataNames.includes(name)) {
           return (
             <QualificationListItemDate
@@ -73,10 +77,6 @@ const Qualification = ({ file = {} }) => {
         }
 
         if (knowOtherMetadataNames.includes(name)) {
-          if (name === 'contact') {
-            return <QualificationListItemContact key={idx} file={file} />
-          }
-
           return (
             <QualificationListItemOther
               key={idx}

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -80,7 +80,7 @@ const Qualification = ({ file = {} }) => {
         )
       })}
 
-      {optionFile.value && (
+      {optionFile.name && (
         <ActionMenuWrapper
           onClose={hideActionsMenu}
           file={file}

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -6,8 +6,8 @@ import { withViewerLocales } from '../hoc/withViewerLocales'
 import {
   formatMetadataQualification,
   knownDateMetadataNames,
-  knowInformationMetadataNames,
-  knowOtherMetadataNames
+  knownInformationMetadataNames,
+  knownOtherMetadataNames
 } from '../helpers'
 import QualificationListItemContact from './QualificationListItemContact'
 import ActionMenuWrapper from './ActionMenuWrapper'
@@ -20,11 +20,11 @@ const makeQualificationListItemComp = metadataName => {
     return QualificationListItemDate
   }
 
-  if (knowInformationMetadataNames.includes(metadataName)) {
+  if (knownInformationMetadataNames.includes(metadataName)) {
     return QualificationListItemInformation
   }
 
-  if (knowOtherMetadataNames.includes(metadataName)) {
+  if (knownOtherMetadataNames.includes(metadataName)) {
     return QualificationListItemOther
   }
 }

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -49,19 +49,19 @@ const Qualification = ({ file = {} }) => {
     })
   }
 
-  const metadataComputed = useMemo(() => {
+  const formatedMetadataQualification = useMemo(() => {
     return formatMetadataQualification(metadata)
   }, [metadata])
 
   useEffect(() => {
-    actionBtnRef.current = metadataComputed.map(
+    actionBtnRef.current = formatedMetadataQualification.map(
       (_, idx) => actionBtnRef.current[idx] ?? createRef()
     )
-  }, [metadataComputed])
+  }, [formatedMetadataQualification])
 
   return (
     <List className={'u-pv-1'}>
-      {metadataComputed.map((meta, idx) => {
+      {formatedMetadataQualification.map((meta, idx) => {
         const { name } = meta
 
         if (name === 'contact') {
@@ -74,7 +74,7 @@ const Qualification = ({ file = {} }) => {
           <QualificationListItemComp
             key={idx}
             ref={actionBtnRef.current[idx]}
-            metadataComputed={meta}
+            formatedMetadataQualification={meta}
             toggleActionsMenu={val => toggleActionsMenu(idx, name, val)}
           />
         )

--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -15,6 +15,20 @@ import QualificationListItemDate from './QualificationListItemDate'
 import QualificationListItemInformation from './QualificationListItemInformation'
 import QualificationListItemOther from './QualificationListItemOther'
 
+const makeQualificationListItemComp = metadataName => {
+  if (knownDateMetadataNames.includes(metadataName)) {
+    return QualificationListItemDate
+  }
+
+  if (knowInformationMetadataNames.includes(metadataName)) {
+    return QualificationListItemInformation
+  }
+
+  if (knowOtherMetadataNames.includes(metadataName)) {
+    return QualificationListItemOther
+  }
+}
+
 const Qualification = ({ file = {} }) => {
   const { metadata = {} } = file
   const actionBtnRef = useRef([])
@@ -54,38 +68,16 @@ const Qualification = ({ file = {} }) => {
           return <QualificationListItemContact key={idx} file={file} />
         }
 
-        if (knownDateMetadataNames.includes(name)) {
-          return (
-            <QualificationListItemDate
-              key={idx}
-              ref={actionBtnRef.current[idx]}
-              metadataComputed={meta}
-              toggleActionsMenu={val => toggleActionsMenu(idx, name, val)}
-            />
-          )
-        }
+        const QualificationListItemComp = makeQualificationListItemComp(name)
 
-        if (knowInformationMetadataNames.includes(name)) {
-          return (
-            <QualificationListItemInformation
-              key={idx}
-              ref={actionBtnRef.current[idx]}
-              metadataComputed={meta}
-              toggleActionsMenu={val => toggleActionsMenu(idx, name, val)}
-            />
-          )
-        }
-
-        if (knowOtherMetadataNames.includes(name)) {
-          return (
-            <QualificationListItemOther
-              key={idx}
-              ref={actionBtnRef.current[idx]}
-              metadataComputed={meta}
-              toggleActionsMenu={val => toggleActionsMenu(idx, name, val)}
-            />
-          )
-        }
+        return (
+          <QualificationListItemComp
+            key={idx}
+            ref={actionBtnRef.current[idx]}
+            metadataComputed={meta}
+            toggleActionsMenu={val => toggleActionsMenu(idx, name, val)}
+          />
+        )
       })}
 
       {optionFile.value && (

--- a/react/Viewer/Panel/QualificationListItemDate.jsx
+++ b/react/Viewer/Panel/QualificationListItemDate.jsx
@@ -14,13 +14,16 @@ const QualificationListItemDate = forwardRef(
   ({ formatedMetadataQualification, toggleActionsMenu }, ref) => {
     const { t, f, lang } = useI18n()
     const { name, value } = formatedMetadataQualification
-    const formattedDate = formatDate({ f, lang, date: value })
+    const formattedDate = value
+      ? formatDate({ f, lang, date: value })
+      : t('Viewer.panel.qualification.noInfo')
 
     return (
       <ListItem className={'u-pl-2 u-pr-3'}>
         <QualificationListItemText
           primary={t(`Viewer.panel.qualification.date.title.${name}`)}
           secondary={formattedDate}
+          disabled={!value}
         />
         <ListItemSecondaryAction>
           <IconButton
@@ -34,6 +37,7 @@ const QualificationListItemDate = forwardRef(
     )
   }
 )
+
 QualificationListItemDate.displayName = 'QualificationListItemDate'
 
 QualificationListItemDate.propTypes = {

--- a/react/Viewer/Panel/QualificationListItemDate.jsx
+++ b/react/Viewer/Panel/QualificationListItemDate.jsx
@@ -11,9 +11,9 @@ import { useI18n } from '../../I18n'
 import { formatDate } from '../helpers'
 
 const QualificationListItemDate = forwardRef(
-  ({ metadataComputed, toggleActionsMenu }, ref) => {
+  ({ formatedMetadataQualification, toggleActionsMenu }, ref) => {
     const { t, f, lang } = useI18n()
-    const { name, value } = metadataComputed
+    const { name, value } = formatedMetadataQualification
     const formattedDate = formatDate({ f, lang, date: value })
 
     return (
@@ -37,7 +37,7 @@ const QualificationListItemDate = forwardRef(
 QualificationListItemDate.displayName = 'QualificationListItemDate'
 
 QualificationListItemDate.propTypes = {
-  metadataComputed: PropTypes.shape({
+  formatedMetadataQualification: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.string
   }).isRequired,

--- a/react/Viewer/Panel/QualificationListItemInformation.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.jsx
@@ -10,9 +10,9 @@ import QualificationListItemText from './QualificationListItemText'
 import { useI18n } from '../../I18n'
 
 const QualificationListItemInformation = forwardRef(
-  ({ metadataComputed, toggleActionsMenu }, ref) => {
+  ({ formatedMetadataQualification, toggleActionsMenu }, ref) => {
     const { t } = useI18n()
-    const { name, value } = metadataComputed
+    const { name, value } = formatedMetadataQualification
 
     return (
       <ListItem className={'u-pl-2 u-pr-3'}>
@@ -32,7 +32,7 @@ const QualificationListItemInformation = forwardRef(
 QualificationListItemInformation.displayName = 'QualificationListItemNumber'
 
 QualificationListItemInformation.propTypes = {
-  metadataComputed: PropTypes.shape({
+  formatedMetadataQualification: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.string
   }).isRequired,

--- a/react/Viewer/Panel/QualificationListItemInformation.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.jsx
@@ -18,7 +18,8 @@ const QualificationListItemInformation = forwardRef(
       <ListItem className={'u-pl-2 u-pr-3'}>
         <QualificationListItemText
           primary={t(`Viewer.panel.qualification.information.title.${name}`)}
-          secondary={value}
+          secondary={value || t('Viewer.panel.qualification.noInfo')}
+          disabled={!value}
         />
         <ListItemSecondaryAction>
           <IconButton ref={ref} onClick={() => toggleActionsMenu(value)}>
@@ -29,6 +30,7 @@ const QualificationListItemInformation = forwardRef(
     )
   }
 )
+
 QualificationListItemInformation.displayName = 'QualificationListItemNumber'
 
 QualificationListItemInformation.propTypes = {

--- a/react/Viewer/Panel/QualificationListItemOther.jsx
+++ b/react/Viewer/Panel/QualificationListItemOther.jsx
@@ -19,10 +19,10 @@ const {
 } = models
 
 const QualificationListItemOther = forwardRef(
-  ({ metadataComputed, toggleActionsMenu }, ref) => {
+  ({ formatedMetadataQualification, toggleActionsMenu }, ref) => {
     const { t, lang } = useI18n()
     const scannerT = getBoundT(lang)
-    const { name, value } = metadataComputed
+    const { name, value } = formatedMetadataQualification
 
     if (!value) return null
 
@@ -52,7 +52,7 @@ const QualificationListItemOther = forwardRef(
 QualificationListItemOther.displayName = 'QualificationListItemOther'
 
 QualificationListItemOther.propTypes = {
-  metadataComputed: PropTypes.shape({
+  formatedMetadataQualification: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.string
   }).isRequired,

--- a/react/Viewer/Panel/QualificationListItemText.jsx
+++ b/react/Viewer/Panel/QualificationListItemText.jsx
@@ -8,15 +8,19 @@ const QualificationListItemText = ({ primary, secondary }) => {
   return (
     <ListItemText
       disableTypography
-      primary={<Typography variant={'caption'}>{primary}</Typography>}
-      secondary={<Typography variant={'body1'}>{secondary}</Typography>}
+      primary={<Typography variant="caption">{primary}</Typography>}
+      secondary={
+        <Typography component="div" variant="body1">
+          {secondary}
+        </Typography>
+      }
     />
   )
 }
 
 QualificationListItemText.propTypes = {
   primary: PropTypes.string.isRequired,
-  secondary: PropTypes.string.isRequired
+  secondary: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired
 }
 
 export default QualificationListItemText

--- a/react/Viewer/Panel/QualificationListItemText.jsx
+++ b/react/Viewer/Panel/QualificationListItemText.jsx
@@ -4,13 +4,17 @@ import PropTypes from 'prop-types'
 import ListItemText from '../../ListItemText'
 import Typography from '../../Typography'
 
-const QualificationListItemText = ({ primary, secondary }) => {
+const QualificationListItemText = ({ primary, secondary, disabled }) => {
   return (
     <ListItemText
       disableTypography
       primary={<Typography variant="caption">{primary}</Typography>}
       secondary={
-        <Typography component="div" variant="body1">
+        <Typography
+          component="div"
+          variant="body1"
+          style={disabled ? { color: 'var(--disabledTextColor)' } : undefined}
+        >
           {secondary}
         </Typography>
       }

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -58,8 +58,14 @@ const files = [
     mime: 'application/pdf',
     metadata: {
       carbonCopy: true,
+      AObtentionDate: null,
       BObtentionDate: "2022-02-09T09:05:38.000Z",
+      CObtentionDate: null,
+      DObtentionDate: null,
+      datetime: "2022-09-23T07:50:22.000Z",
       datetimeLabel: "BObtentionDate",
+      number: "",
+      page: "front",
       qualification: {
         label: "driver_license",
         purpose: "attestation",
@@ -170,8 +176,6 @@ const editPathByModelProps = {
                 files={files}
                 currentIndex={state.currentIndex}
                 currentURL={state.currentURL}
-                onCloseRequest={toggleViewer}
-                onChangeRequest={onFileChange}
                 showNavigation={variant.navigation}
                 editPathByModelProps={editPathByModelProps}
                 onlyOfficeProps={{
@@ -182,6 +186,8 @@ const editPathByModelProps = {
                   showToolbar: variant.toolbar,
                   showClose: state.showToolbarCloseButton
                 }}
+                onCloseRequest={toggleViewer}
+                onChangeRequest={onFileChange}
               >
                 <FooterActionButtons>
                   <ShareButtonFake />

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -87,17 +87,19 @@ export const downloadFile = async ({ client, file, url }) => {
 
 export const isFileEncrypted = file => isEncrypted(file)
 
+const makeMetadataQualification = (name, value) => {
+  if (value) {
+    return { name, value }
+  }
+}
+
 /**
  * @param {Object} metadata
  * @returns {{ name: string, value: string }[]} Array of formated metadata
  */
 export const formatMetadataQualification = metadata => {
   const dates = knownDateMetadataNames
-    .map(dateName => {
-      if (metadata[dateName]) {
-        return { name: dateName, value: metadata[dateName] }
-      }
-    })
+    .map(dateName => makeMetadataQualification(dateName, metadata[dateName]))
     .filter(Boolean)
     .filter((data, _, arr) => {
       if (arr.length > 1) return data.name !== 'datetime'
@@ -105,11 +107,9 @@ export const formatMetadataQualification = metadata => {
     })
 
   const numbers = knowInformationMetadataNames
-    .map(numberName => {
-      if (metadata[numberName]) {
-        return { name: numberName, value: metadata[numberName] }
-      }
-    })
+    .map(numberName =>
+      makeMetadataQualification(numberName, metadata[numberName])
+    )
     .filter(Boolean)
 
   const others = knowOtherMetadataNames
@@ -119,7 +119,7 @@ export const formatMetadataQualification = metadata => {
           ? metadata[otherName]?.label
           : metadata[otherName]
 
-      return { name: otherName, value }
+      return makeMetadataQualification(otherName, value)
     })
     .filter(Boolean)
 

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -87,9 +87,13 @@ export const downloadFile = async ({ client, file, url }) => {
 
 export const isFileEncrypted = file => isEncrypted(file)
 
-const makeMetadataQualification = (name, value) => {
-  if (value) {
-    return { name, value }
+const makeMetadataQualification = ({ metadata, knownMetadataName, value }) => {
+  const shouldReturnThisMetadata = Object.keys(metadata).includes(
+    knownMetadataName
+  )
+
+  if (shouldReturnThisMetadata) {
+    return { name: knownMetadataName, value: value || null }
   }
 }
 
@@ -99,7 +103,13 @@ const makeMetadataQualification = (name, value) => {
  */
 export const formatMetadataQualification = metadata => {
   const dates = knownDateMetadataNames
-    .map(dateName => makeMetadataQualification(dateName, metadata[dateName]))
+    .map(dateName =>
+      makeMetadataQualification({
+        metadata,
+        knownMetadataName: dateName,
+        value: metadata[dateName]
+      })
+    )
     .filter(Boolean)
     .filter((data, _, arr) => {
       if (arr.length > 1) return data.name !== 'datetime'
@@ -108,7 +118,11 @@ export const formatMetadataQualification = metadata => {
 
   const numbers = knowInformationMetadataNames
     .map(numberName =>
-      makeMetadataQualification(numberName, metadata[numberName])
+      makeMetadataQualification({
+        metadata,
+        knownMetadataName: numberName,
+        value: metadata[numberName]
+      })
     )
     .filter(Boolean)
 
@@ -119,7 +133,11 @@ export const formatMetadataQualification = metadata => {
           ? metadata[otherName]?.label
           : metadata[otherName]
 
-      return makeMetadataQualification(otherName, value)
+      return makeMetadataQualification({
+        metadata,
+        knownMetadataName: otherName,
+        value
+      })
     })
     .filter(Boolean)
 

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -114,10 +114,12 @@ export const formatMetadataQualification = metadata => {
 
   const others = knowOtherMetadataNames
     .map(otherName => {
-      if (otherName === 'qualification') {
-        return { name: otherName, value: metadata[otherName]?.label }
-      }
-      return { name: otherName, value: metadata[otherName] }
+      const value =
+        otherName === 'qualification'
+          ? metadata[otherName]?.label
+          : metadata[otherName]
+
+      return { name: otherName, value }
     })
     .filter(Boolean)
 

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -15,19 +15,19 @@ export const knownDateMetadataNames = [
   'date',
   'datetime'
 ]
-export const knowInformationMetadataNames = [
+export const knownInformationMetadataNames = [
   'number',
   'cardNumber',
   'vinNumber',
   'ibanNumber',
   'country'
 ]
-export const knowOtherMetadataNames = ['contact', 'page', 'qualification']
+export const knownOtherMetadataNames = ['contact', 'page', 'qualification']
 
 export const getCurrentModel = metadataName => {
   if (
     knownDateMetadataNames.includes(metadataName) ||
-    knowInformationMetadataNames.includes(metadataName)
+    knownInformationMetadataNames.includes(metadataName)
   ) {
     return 'information'
   }
@@ -116,7 +116,7 @@ export const formatMetadataQualification = metadata => {
       return data
     })
 
-  const numbers = knowInformationMetadataNames
+  const informations = knownInformationMetadataNames
     .map(numberName =>
       makeMetadataQualification({
         metadata,
@@ -126,7 +126,7 @@ export const formatMetadataQualification = metadata => {
     )
     .filter(Boolean)
 
-  const others = knowOtherMetadataNames
+  const others = knownOtherMetadataNames
     .map(otherName => {
       const value =
         otherName === 'qualification'
@@ -141,7 +141,7 @@ export const formatMetadataQualification = metadata => {
     })
     .filter(Boolean)
 
-  return [...dates, ...numbers, ...others]
+  return [...dates, ...informations, ...others]
 }
 
 export const formatDate = ({ f, lang, date }) => {

--- a/react/Viewer/helpers.spec.js
+++ b/react/Viewer/helpers.spec.js
@@ -7,7 +7,7 @@ import {
   getCurrentModel,
   buildEditAttributePath,
   knownDateMetadataNames,
-  knowInformationMetadataNames
+  knownInformationMetadataNames
 } from './helpers'
 
 const fakeMetadata = {
@@ -125,7 +125,7 @@ describe('helpers', () => {
   })
   describe('getCurrentModel', () => {
     const expected = 'information'
-    it.each([...knownDateMetadataNames, ...knowInformationMetadataNames])(
+    it.each([...knownDateMetadataNames, ...knownInformationMetadataNames])(
       `getCurrentModel(%s) should return ${expected}`,
       input => {
         expect(getCurrentModel(input)).toBe(expected)

--- a/react/Viewer/locales/en.json
+++ b/react/Viewer/locales/en.json
@@ -64,6 +64,7 @@
         "front": "Front side",
         "back": "Back side",
         "qualification": "Qualification",
+        "noInfo": "No information",
         "actions": {
           "copy": "Copy",
           "copyClipboard": "Copy to clipboard",

--- a/react/Viewer/locales/fr.json
+++ b/react/Viewer/locales/fr.json
@@ -64,6 +64,7 @@
         "front": "Face avant",
         "back": "Face arrière",
         "qualification": "Qualification",
+        "noInfo": "Non renseigné(e)",
         "actions": {
           "copy": "Copier",
           "copyClipboard": "Copier dans le presse-papier",


### PR DESCRIPTION
On souhaite maintenant afficher toutes les qualification possible sur un document dans le viewer augmenté. Précédemment lorsqu'ils étaient vides, on ne les affichait pas. Ils sont maintenant affichés avec une valeur par défaut.

demo : https://jf-cozy.github.io/cozy-ui/react/#!/Viewer