### PR TITLE
chore: Add skip argos possibility for CI [skip argos]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache:
   yarn: true
   directories:
     - node_modules
+env:
+  global:
+    - PR_TITLE=$(curl https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST} 2> /dev/null | grep "title" | head -1)
 script:
   - yarn lint
   - yarn build
@@ -12,13 +15,16 @@ script:
   - yarn build:doc:react
   - yarn build:doc:kss
   - yarn test
-  - mkdir ./screenshots
-  - yarn screenshots --mode react --viewport desktop --screenshot-dir ./screenshots/reactDesktop
-  - yarn screenshots --mode react --viewport 300x600 --screenshot-dir ./screenshots/reactMobile
-  - yarn screenshots --mode kss --screenshot-dir ./screenshots/kss
-  - yarn argos:upload --parallel screenshots/reactDesktop/ --token $ARGOS_TOKEN  --parallel-total 3 --parallel-nonce $TRAVIS_BUILD_ID
-  - yarn argos:upload --parallel screenshots/reactMobile/ --token $ARGOS_TOKEN  --parallel-total 3 --parallel-nonce $TRAVIS_BUILD_ID
-  - yarn argos:upload --parallel screenshots/kss/ --token $ARGOS_TOKEN  --parallel-total 3 --parallel-nonce $TRAVIS_BUILD_ID
+  - |
+    if [[ "${PR_TITLE}" != *"[skip argos]"* ]]; then
+      mkdir ./screenshots
+      yarn screenshots --mode react --viewport desktop --screenshot-dir ./screenshots/reactDesktop
+      yarn screenshots --mode react --viewport 300x600 --screenshot-dir ./screenshots/reactMobile
+      yarn screenshots --mode kss --screenshot-dir ./screenshots/kss
+      yarn argos:upload --parallel screenshots/reactDesktop/ --token $ARGOS_TOKEN  --parallel-total 3 --parallel-nonce $TRAVIS_BUILD_ID
+      yarn argos:upload --parallel screenshots/reactMobile/ --token $ARGOS_TOKEN  --parallel-total 3 --parallel-nonce $TRAVIS_BUILD_ID
+      yarn argos:upload --parallel screenshots/kss/ --token $ARGOS_TOKEN  --parallel-total 3 --parallel-nonce $TRAVIS_BUILD_ID
+    fi
   - yarn bundlemon
 deploy:
   - provider: script


### PR DESCRIPTION
ignore argos si `[skip argos]` est présent dans le titre de la PR.

A utiliser avec des pincettes. C'est par exemple pour faire passer des PR de modif de doc non argosée, ou de refacto de code non argosé comme des tests ou autre