### PR TITLE
fix: Rename componentWill* to UNSAFE_componentWill*

### DIFF
--- a/react/Viewer/ViewersByFile/ImageViewer.jsx
+++ b/react/Viewer/ViewersByFile/ImageViewer.jsx
@@ -36,7 +36,7 @@ class ImageViewer extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       nextProps.file &&
       this.props.file &&

--- a/react/Viewer/hoc/withFileUrl.jsx
+++ b/react/Viewer/hoc/withFileUrl.jsx
@@ -20,11 +20,11 @@ const withFileUrl = BaseComponent =>
     static contextTypes = {
       client: PropTypes.object.isRequired
     }
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.loadDownloadUrl()
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       if (
         nextProps.file.id !== this.props.file.id ||
         nextProps.url !== this.props.url


### PR DESCRIPTION
In React >=18, only the UNSAFE_ name will work.
The "UNSAFE_componentWill*" methods have been added since React 16.3.