### PR TITLE
The issueDate by a Connector must not be modifiable

### DIFF
--- a/react/Viewer/Panel/ActionMenuWrapper.jsx
+++ b/react/Viewer/Panel/ActionMenuWrapper.jsx
@@ -8,7 +8,7 @@ import { useI18n } from '../../I18n'
 import useViewerSnackbar from '../providers/ViewerSnackbarProvider'
 import {
   buildEditAttributePath,
-  checkEditableAttribute,
+  isEditableAttribute,
   getCurrentModel
 } from '../helpers'
 import useActionMenuContext from '../providers/ActionMenuProvider'
@@ -25,7 +25,6 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
   const { showViewerSnackbar } = useViewerSnackbar()
   const client = useClient()
 
-  const isEditableAttribute = checkEditableAttribute(name)
   const currentModel = getCurrentModel(name)
   const editPath = buildEditAttributePath(
     editPathByModelProps,
@@ -64,7 +63,7 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
     return (
       <ActionMenuMobile
         onClose={onClose}
-        isEditable={Boolean(editPath) && isEditableAttribute}
+        isEditable={Boolean(editPath) && isEditableAttribute(name)}
         actions={{ handleCopy, handleEdit }}
         appLink={url}
         appSlug={mespapiersAppSlug}
@@ -76,7 +75,7 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
     <ActionMenuDesktop
       ref={ref}
       onClose={onClose}
-      isEditable={Boolean(editPath) && isEditableAttribute}
+      isEditable={Boolean(editPath) && isEditableAttribute(name)}
       actions={{ handleCopy, handleEdit }}
       appLink={url}
       appSlug={mespapiersAppSlug}

--- a/react/Viewer/Panel/ActionMenuWrapper.jsx
+++ b/react/Viewer/Panel/ActionMenuWrapper.jsx
@@ -17,7 +17,7 @@ import ActionMenuDesktop from './ActionMenuDesktop'
 
 const mespapiersAppSlug = 'mespapiers'
 
-const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
+const ActionMenuWrapper = forwardRef(({ onClose, file, optionFile }, ref) => {
   const { name, value } = optionFile
   const editPathByModelProps = useActionMenuContext()
   const { isMobile } = useBreakpoints()
@@ -63,7 +63,7 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
     return (
       <ActionMenuMobile
         onClose={onClose}
-        isEditable={Boolean(editPath) && isEditableAttribute(name)}
+        isEditable={Boolean(editPath) && isEditableAttribute(name, file)}
         actions={{ handleCopy, handleEdit }}
         appLink={url}
         appSlug={mespapiersAppSlug}
@@ -75,7 +75,7 @@ const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
     <ActionMenuDesktop
       ref={ref}
       onClose={onClose}
-      isEditable={Boolean(editPath) && isEditableAttribute(name)}
+      isEditable={Boolean(editPath) && isEditableAttribute(name, file)}
       actions={{ handleCopy, handleEdit }}
       appLink={url}
       appSlug={mespapiersAppSlug}
@@ -86,6 +86,7 @@ ActionMenuWrapper.displayName = 'ActionMenuWrapper'
 
 ActionMenuWrapper.propTypes = {
   onClose: PropTypes.func,
+  file: PropTypes.object,
   optionFile: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.string

--- a/react/Viewer/Panel/ActionMenuWrapper.jsx
+++ b/react/Viewer/Panel/ActionMenuWrapper.jsx
@@ -6,17 +6,16 @@ import { useAppLinkWithStoreFallback, useClient } from 'cozy-client'
 import useBreakpoints from '../../hooks/useBreakpoints'
 import { useI18n } from '../../I18n'
 import useViewerSnackbar from '../providers/ViewerSnackbarProvider'
-import { buildEditAttributePath, getCurrentModel } from '../helpers'
+import {
+  buildEditAttributePath,
+  checkEditableAttribute,
+  getCurrentModel
+} from '../helpers'
 import useActionMenuContext from '../providers/ActionMenuProvider'
 import ActionMenuMobile from './ActionMenuMobile'
 import ActionMenuDesktop from './ActionMenuDesktop'
 
 const mespapiersAppSlug = 'mespapiers'
-
-const checkEditableAttribute = name => {
-  const isNotEditableAttributes = ['datetime', 'qualification']
-  return !isNotEditableAttributes.includes(name)
-}
 
 const ActionMenuWrapper = forwardRef(({ onClose, optionFile }, ref) => {
   const { name, value } = optionFile

--- a/react/Viewer/Panel/getPanelBlocks.jsx
+++ b/react/Viewer/Panel/getPanelBlocks.jsx
@@ -1,12 +1,10 @@
 import KonnectorBlock from 'cozy-harvest-lib/dist/components/KonnectorBlock'
+import { models } from 'cozy-client'
 
-import {
-  hasCertifications,
-  hasQualifications,
-  isFromKonnector
-} from '../helpers'
 import Certifications from './Certifications'
 import Qualification from './Qualification'
+
+const { isFromKonnector, hasQualifications, hasCertifications } = models.file
 
 export const panelBlocksSpecs = {
   qualifications: {
@@ -27,7 +25,7 @@ const getPanelBlocks = ({ panelBlocksSpecs, file }) => {
   const panelBlocks = []
 
   Object.values(panelBlocksSpecs).forEach(panelBlock => {
-    panelBlock.condition({ file }) && panelBlocks.push(panelBlock.component)
+    panelBlock.condition(file) && panelBlocks.push(panelBlock.component)
   })
 
   return panelBlocks

--- a/react/Viewer/components/ViewerByFile.jsx
+++ b/react/Viewer/components/ViewerByFile.jsx
@@ -2,10 +2,11 @@ import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 
 import { isMobile as isMobileDevice } from 'cozy-device-helper'
+import { models } from 'cozy-client'
+
 import { FileDoctype } from '../../proptypes'
 import withBreakpoints from '../../helpers/withBreakpoints'
 
-import { isPlainText } from '../helpers'
 import ImageViewer from '../ViewersByFile/ImageViewer'
 import AudioViewer from '../ViewersByFile/AudioViewer'
 import VideoViewer from '../ViewersByFile/VideoViewer'
@@ -17,6 +18,8 @@ import ShortcutViewer from '../ViewersByFile/ShortcutViewer'
 import OnlyOfficeViewer from '../ViewersByFile/OnlyOfficeViewer'
 
 import { useEncrypted } from '../providers/EncryptedProvider'
+
+const { isPlainText } = models.file
 
 export const getViewerComponentName = ({
   file,

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -165,3 +165,8 @@ export const buildEditAttributePath = (
   const currentPath = editPathByModelProps[currentModel]
   return currentPath?.replace(/__NAME__/, name) ?? ''
 }
+
+export const checkEditableAttribute = name => {
+  const isNotEditableAttributes = ['datetime', 'qualification']
+  return !isNotEditableAttributes.includes(name)
+}

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -166,7 +166,7 @@ export const buildEditAttributePath = (
   return currentPath?.replace(/__NAME__/, name) ?? ''
 }
 
-export const checkEditableAttribute = name => {
+export const isEditableAttribute = name => {
   const isNotEditableAttributes = ['datetime', 'qualification']
   return !isNotEditableAttributes.includes(name)
 }

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -1,6 +1,10 @@
-import has from 'lodash/has'
 import { models } from 'cozy-client'
-const { isEncrypted } = models.file
+const {
+  isEncrypted,
+  isFromKonnector,
+  hasQualifications,
+  hasCertifications
+} = models.file
 
 export const knownDateMetadataNames = [
   'AObtentionDate',
@@ -41,25 +45,6 @@ export const getCurrentModel = metadataName => {
  * @property {string} type - doctype of the document
  */
 
-// TODO : should be in file model of cozy-client
-export const isPlainText = (mimeType = '', fileName = '') => {
-  return mimeType ? /^text\//.test(mimeType) : /\.(txt|md)$/.test(fileName)
-}
-
-export const hasQualifications = ({ file }) => {
-  return has(file, 'metadata.qualification')
-}
-
-export const hasCertifications = ({ file }) => {
-  return (
-    has(file, 'metadata.carbonCopy') || has(file, 'metadata.electronicSafe')
-  )
-}
-
-export const isFromKonnector = ({ file }) => {
-  return has(file, 'cozyMetadata.sourceAccount')
-}
-
 /**
  * Checks if the file matches one of the following conditions:
  * - Is certified
@@ -72,9 +57,7 @@ export const isFromKonnector = ({ file }) => {
  */
 export const isValidForPanel = ({ file }) => {
   return (
-    hasCertifications({ file }) ||
-    hasQualifications({ file }) ||
-    isFromKonnector({ file })
+    hasCertifications(file) || hasQualifications(file) || isFromKonnector(file)
   )
 }
 
@@ -171,7 +154,6 @@ export const isEditableAttribute = (name, file) => {
 
   return (
     !isNotEditableAttributes.includes(name) &&
-    ((name === 'issueDate' && !isFromKonnector({ file })) ||
-      name !== 'issueDate')
+    ((name === 'issueDate' && !isFromKonnector(file)) || name !== 'issueDate')
   )
 }

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -166,7 +166,12 @@ export const buildEditAttributePath = (
   return currentPath?.replace(/__NAME__/, name) ?? ''
 }
 
-export const isEditableAttribute = name => {
+export const isEditableAttribute = (name, file) => {
   const isNotEditableAttributes = ['datetime', 'qualification']
-  return !isNotEditableAttributes.includes(name)
+
+  return (
+    !isNotEditableAttributes.includes(name) &&
+    ((name === 'issueDate' && !isFromKonnector({ file })) ||
+      name !== 'issueDate')
+  )
 }

--- a/react/Viewer/helpers.spec.js
+++ b/react/Viewer/helpers.spec.js
@@ -7,7 +7,8 @@ import {
   getCurrentModel,
   buildEditAttributePath,
   knownDateMetadataNames,
-  knownInformationMetadataNames
+  knownInformationMetadataNames,
+  isEditableAttribute
 } from './helpers'
 
 const fakeMetadata = {
@@ -154,6 +155,55 @@ describe('helpers', () => {
         '#/paper/edit/information/01?metadata=cardNumber&backgroundPath=$/path'
       )
       expect(buildPagePath).toBe('#/paper/edit/page/01?backgroundPath=/path')
+    })
+  })
+  describe('isEditableAttribute', () => {
+    const makeFile = ({ fromConnector } = {}) => ({
+      _id: '00',
+      name: 'file',
+      cozyMetadata: fromConnector ? { sourceAccount: '123' } : {}
+    })
+    describe('file provided by a Connector', () => {
+      it('"issueDate" should not be a editable attribute', () => {
+        const issueDate = isEditableAttribute(
+          'issueDate',
+          makeFile({ fromConnector: true })
+        )
+        expect(issueDate).toBe(false)
+      })
+      it('"cardNumber" should be an editable attribute', () => {
+        const cardNumber = isEditableAttribute(
+          'cardNumber',
+          makeFile({ fromConnector: true })
+        )
+        expect(cardNumber).toBe(true)
+      })
+      it('"datetime" should not be an editable attribute', () => {
+        const datetime = isEditableAttribute('datetime', makeFile())
+        expect(datetime).toBe(false)
+      })
+      it('"qualification" should not be an editable attribute', () => {
+        const qualification = isEditableAttribute('qualification', makeFile())
+        expect(qualification).toBe(false)
+      })
+    })
+    describe('file NOT provided by a Connector', () => {
+      it('"issueDate" should not be a editable attribute', () => {
+        const issueDate = isEditableAttribute('issueDate', makeFile())
+        expect(issueDate).toBe(true)
+      })
+      it('"cardNumber" should be a editable attribute', () => {
+        const cardNumber = isEditableAttribute('cardNumber', makeFile())
+        expect(cardNumber).toBe(true)
+      })
+      it('"datetime" should not be an editable attribute', () => {
+        const datetime = isEditableAttribute('datetime', makeFile())
+        expect(datetime).toBe(false)
+      })
+      it('"qualification" should not be an editable attribute', () => {
+        const qualification = isEditableAttribute('qualification', makeFile())
+        expect(qualification).toBe(false)
+      })
     })
   })
 })

--- a/react/Viewer/helpers.spec.js
+++ b/react/Viewer/helpers.spec.js
@@ -2,7 +2,6 @@ import { createMockClient } from 'cozy-client'
 
 import {
   downloadFile,
-  isPlainText,
   formatMetadataQualification,
   getCurrentModel,
   buildEditAttributePath,
@@ -51,50 +50,6 @@ const computedMetadata = [
 ]
 
 describe('helpers', () => {
-  describe('isPlainText', () => {
-    describe('using mime types', () => {
-      it('should match mime types starting with "text/"', () => {
-        expect(isPlainText('text/plain')).toBe(true)
-        expect(isPlainText('text/markdown')).toBe(true)
-        expect(isPlainText('application/text')).toBe(false)
-        expect(isPlainText('something/text/else')).toBe(false)
-        expect(isPlainText('text/vnd.cozy.note+markdown')).toBe(true)
-      })
-
-      it('should not match complex text formats', () => {
-        expect(isPlainText('application/msword')).toBe(false)
-        expect(isPlainText('application/vnd.oasis.opendocument.text')).toBe(
-          false
-        )
-        expect(isPlainText('application/x-iwork-pages-sffpages')).toBe(false)
-      })
-
-      it('should not use the filename if a mime type is present', () => {
-        expect(isPlainText('application/msword', 'iswearitstext.txt')).toBe(
-          false
-        )
-      })
-    })
-
-    describe('using file names', () => {
-      it('should match txt files', () => {
-        expect(isPlainText(undefined, 'iswearitstext.txt')).toBe(true)
-      })
-
-      it('should match md files', () => {
-        expect(isPlainText(undefined, 'markdown.md')).toBe(true)
-      })
-
-      it('should not match anything else', () => {
-        expect(isPlainText(undefined, 'file.doc')).toBe(false)
-        expect(isPlainText(undefined, 'file.docx')).toBe(false)
-        expect(isPlainText(undefined, 'file.pages')).toBe(false)
-        expect(isPlainText(undefined, 'file.odt')).toBe(false)
-        expect(isPlainText(undefined, 'file.csv')).toBe(false)
-        expect(isPlainText(undefined, 'file.vcf')).toBe(false)
-      })
-    })
-  })
   describe('download', () => {
     const client = new createMockClient({})
     const mockDownload = jest.fn()


### PR DESCRIPTION
En plus d'interdire la modification de la metadata `issueDate` d'un fichier si le ce dernier provient d'un Connecteur, j'en ai profité pour enlever quelques doublons dans les helpers du Viewer