### PR TITLE
Fix contact & country attributes

### DIFF
--- a/react/Viewer/Panel/Qualification.jsx
+++ b/react/Viewer/Panel/Qualification.jsx
@@ -25,6 +25,9 @@ const makeQualificationListItemComp = metadataName => {
   }
 
   if (knownOtherMetadataNames.includes(metadataName)) {
+    if (metadataName === 'contact') {
+      return QualificationListItemContact
+    }
     return QualificationListItemOther
   }
 }
@@ -63,16 +66,12 @@ const Qualification = ({ file = {} }) => {
     <List className={'u-pv-1'}>
       {formatedMetadataQualification.map((meta, idx) => {
         const { name } = meta
-
-        if (name === 'contact') {
-          return <QualificationListItemContact key={idx} file={file} />
-        }
-
         const QualificationListItemComp = makeQualificationListItemComp(name)
 
         return (
           <QualificationListItemComp
             key={idx}
+            file={file}
             ref={actionBtnRef.current[idx]}
             formatedMetadataQualification={meta}
             toggleActionsMenu={val => toggleActionsMenu(idx, name, val)}

--- a/react/Viewer/Panel/QualificationListItemInformation.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.jsx
@@ -8,6 +8,7 @@ import Icon from '../../Icon'
 import Dots from '../../Icons/Dots'
 import QualificationListItemText from './QualificationListItemText'
 import { useI18n } from '../../I18n'
+import MidEllipsis from '../../MidEllipsis'
 
 const QualificationListItemInformation = forwardRef(
   ({ formatedMetadataQualification, toggleActionsMenu }, ref) => {
@@ -18,7 +19,10 @@ const QualificationListItemInformation = forwardRef(
       <ListItem className={'u-pl-2 u-pr-3'}>
         <QualificationListItemText
           primary={t(`Viewer.panel.qualification.information.title.${name}`)}
-          secondary={value || t('Viewer.panel.qualification.noInfo')}
+          secondary={
+            <MidEllipsis text={value} /> ||
+            t('Viewer.panel.qualification.noInfo')
+          }
           disabled={!value}
         />
         <ListItemSecondaryAction>

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -75,7 +75,7 @@ const makeMetadataQualification = ({ metadata, knownMetadataName, value }) => {
     knownMetadataName
   )
 
-  if (shouldReturnThisMetadata) {
+  if (shouldReturnThisMetadata || knownMetadataName === 'contact') {
     return { name: knownMetadataName, value: value || null }
   }
 }


### PR DESCRIPTION
Suite à un refactor précédent, le nom du contact(Titulaire) n'apparaissait plus.
Et ajout du composant `MidEllipsis` afin d'éviter d'avoir des valeurs trop longues qui pourrait gâcher l'UX