### PR TITLE
fix(Viewer): Do not use MidEllipsys component if text prop is falsy

### DIFF
--- a/react/Viewer/Panel/QualificationListItemInformation.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.jsx
@@ -15,18 +15,25 @@ const QualificationListItemInformation = forwardRef(
     const { t } = useI18n()
     const { name, value } = formatedMetadataQualification
 
+    const currentValue = value ? (
+      <MidEllipsis text={value} />
+    ) : (
+      t('Viewer.panel.qualification.noInfo')
+    )
+
     return (
       <ListItem className={'u-pl-2 u-pr-3'}>
         <QualificationListItemText
           primary={t(`Viewer.panel.qualification.information.title.${name}`)}
-          secondary={
-            <MidEllipsis text={value} /> ||
-            t('Viewer.panel.qualification.noInfo')
-          }
+          secondary={currentValue}
           disabled={!value}
         />
         <ListItemSecondaryAction>
-          <IconButton ref={ref} onClick={() => toggleActionsMenu(value)}>
+          <IconButton
+            ref={ref}
+            onClick={() => toggleActionsMenu(value)}
+            data-testid="toggleActionsMenuBtn"
+          >
             <Icon icon={Dots} />
           </IconButton>
         </ListItemSecondaryAction>

--- a/react/Viewer/Panel/QualificationListItemInformation.spec.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.spec.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import DemoProvider from '../docs/DemoProvider'
+
+import QualificationListItemInformation from './QualificationListItemInformation'
+
+const setup = ({
+  formatedMetadataQualification = {},
+  toggleActionsMenu = jest.fn()
+} = {}) => {
+  return render(
+    <DemoProvider>
+      <QualificationListItemInformation
+        formatedMetadataQualification={formatedMetadataQualification}
+        toggleActionsMenu={toggleActionsMenu}
+      />
+    </DemoProvider>
+  )
+}
+
+describe('QualificationListItemInformation', () => {
+  describe('formatedMetadataQualification', () => {
+    it('should display default text if value is falsy', () => {
+      const formatedMetadataQualification = { name: 'country', value: '' }
+      const { getByText } = setup({ formatedMetadataQualification })
+
+      expect(getByText('Viewer.panel.qualification.noInfo'))
+    })
+    it('should display current value if it is truthy', () => {
+      const formatedMetadataQualification = { name: 'country', value: 'Italie' }
+      const { queryByText } = setup({
+        formatedMetadataQualification
+      })
+
+      expect(queryByText('Viewer.panel.qualification.noInfo')).toBeNull()
+    })
+  })
+  describe('toggleActionsMenu', () => {
+    it('should call toggleActionsMenu with current value on click it', () => {
+      const formatedMetadataQualification = { name: 'country', value: 'Italie' }
+      const toggleActionsMenu = jest.fn()
+      const { getByTestId } = setup({
+        toggleActionsMenu,
+        formatedMetadataQualification
+      })
+      const toggleActionsMenuBtn = getByTestId('toggleActionsMenuBtn')
+      fireEvent.click(toggleActionsMenuBtn)
+
+      expect(toggleActionsMenu).toBeCalledWith('Italie')
+    })
+  })
+})


### PR DESCRIPTION
L'ajout récent du composant MidEllipsys pour limiter (entre autres) le champs `country` à causé un bug dans le cas où le champs n'est pas renseigné..
Ajout de quelques tests pour éviter une régression à ce sujet