### PR TITLE
BottomSheet: Add safe area

### DIFF
--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -262,7 +262,7 @@ const BottomSheet = memo(
           <div ref={innerContentRef}>
             <Paper
               data-testid="bottomSheet-header"
-              className="u-w-100 u-h-2-half u-pos-relative u-flex u-flex-items-center u-flex-justify-center"
+              className="u-w-100 u-h-3 u-pos-relative u-flex u-flex-items-center u-flex-justify-center"
               ref={headerRef}
               elevation={0}
               square

--- a/react/BottomSheet/helpers.js
+++ b/react/BottomSheet/helpers.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { getFlagshipMetadata } from 'cozy-device-helper'
 
 import { ANIMATION_DURATION } from './constants'
+import { getSafeAreaValue } from '../helpers/getSafeArea'
 
 export const computeMaxHeight = toolbarProps => {
   const { ref, height } = toolbarProps
@@ -47,11 +48,13 @@ export const computeMinHeight = ({
   actionButtonsBottomMargin
 }) => {
   if (isClosable) return 0
+
   return (
     headerRef.current.offsetHeight +
     actionButtonsHeight +
     actionButtonsBottomMargin +
-    (getFlagshipMetadata().navbarHeight || 0)
+    (getFlagshipMetadata().navbarHeight || 0) +
+    getSafeAreaValue('bottom')
   )
 }
 

--- a/react/BottomSheet/helpers.spec.js
+++ b/react/BottomSheet/helpers.spec.js
@@ -7,6 +7,9 @@ import {
   minimizeAndClose
 } from './helpers'
 
+jest.mock('../helpers/getSafeArea', () => ({
+  getSafeAreaValue: jest.fn().mockReturnValue(15)
+}))
 jest.mock('cozy-device-helper', () => ({
   getFlagshipMetadata: jest.fn(() => ({ navbarHeight: 10 }))
 }))
@@ -107,7 +110,7 @@ describe('computeMinHeight', () => {
       actionButtonsBottomMargin: 30
     })
 
-    expect(res).toBe(70)
+    expect(res).toBe(85)
   })
 })
 

--- a/react/helpers/getSafeArea.ts
+++ b/react/helpers/getSafeArea.ts
@@ -1,0 +1,15 @@
+/**
+ * Return the env(safe-area-inset-[position]) value
+ * expl: "0px"
+ */
+export const getSafeArea = (position: string): string =>
+  getComputedStyle(document.documentElement).getPropertyValue(
+    `--safe-area-inset-${position}`
+  )
+
+/**
+ * Return the env(safe-area-inset-[position]) value without unit
+ * expl: 0 for "0px"
+ */
+export const getSafeAreaValue = (position: string): number =>
+  parseInt(getSafeArea(position))

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -5,6 +5,12 @@
 @require '../settings/breakpoints'
 @require '../tools/mixins'
 
+:root
+    --safe-area-inset-top env(safe-area-inset-top)
+    --safe-area-inset-right env(safe-area-inset-right)
+    --safe-area-inset-bottom env(safe-area-inset-bottom)
+    --safe-area-inset-left env(safe-area-inset-left)
+
 html
     font-size 100%
 


### PR DESCRIPTION
On ne prenait pas en compte le safe area sur iOS. On en profite pour agrandir la taille de la poignée