### PR TITLE
Override `StepConnector`, `StepContent` and `StepLabel`

### DIFF
--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -449,7 +449,23 @@ const makeOverrides = theme => ({
   },
   MuiStepConnector: {
     line: {
-      borderColor: theme.palette.grey[300]
+      borderColor: theme.palette.divider
+    }
+  },
+  MuiStepContent: {
+    root: {
+      borderColor: theme.palette.divider
+    }
+  },
+  MuiStepLabel: {
+    label: {
+      ...theme.typography.body1,
+      '&$active': {
+        ...theme.typography.h6
+      },
+      '&$completed': {
+        ...theme.typography.h6
+      }
     }
   },
   MuiListItemIcon: {


### PR DESCRIPTION
This makes sure the border of `StepContent` is the same color as `StepConnector`'s one. Also this increases the font-size of `StepLabels` and puts bold on every active or complete `StepLabels`.