### PR TITLE
Add gap utility classes

### DIFF
--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -1010,6 +1010,49 @@ Display an chip that represents complex identity
 */
 
 /*
+    Gaps
+
+    Classes to add gaps between children nodes, vertically, horizontally or in both directions based on default font-size (16px)<br>
+    [Can be used with breakpoints modifier suffixes (`-t`,`-s`,`-m`)](section-settings.html#kssref-settings-breakpoints)
+
+    .u-g-normal - Normal gaps in both directions
+    .u-g-0 - No gaps in both directions
+    .u-g-half - Gaps in both directions with half a line (8px)
+    .u-g-1 - Gaps in both directions with 1 line (16px)
+    .u-g-1-half - Gaps in both directions with 1 line an a half (24px)
+    .u-g-2 - Gaps in both directions with 2 lines (32px)
+    .u-g-2-half - Gaps in both directions with 2 lines an a half (40px)
+    .u-g-3 - Gaps in both directions with 3 lines (48px)
+    .u-gv-normal - Normal vertically gaps
+    .u-gv-0 - No vertically gaps
+    .u-gv-half - Vertically gaps with half a line (8px)
+    .u-gv-1 - Vertically gaps with 1 line (16px)
+    .u-gv-1-half - Vertically gaps with 1 line an a half (24px)
+    .u-gv-2 - Vertically gaps with 2 lines (32px)
+    .u-gv-2-half - Vertically gaps with 2 lines an a half (40px)
+    .u-gv-3 - Vertically gaps with 3 lines (48px)
+    .u-gh-normal - Normal horizontally gaps
+    .u-gh-0 - No horizontally gaps
+    .u-gh-half - Horizontally gaps with half a line (8px)
+    .u-gh-1 - Horizontally gaps with 1 line (16px)
+    .u-gh-1-half - Horizontally gaps with 1 line an a half (24px)
+    .u-gh-2 - Horizontally gaps with 2 lines (32px)
+    .u-gh-2-half - Horizontally gaps with 2 lines an a half (40px)
+    .u-gh-3 - Horizontally gaps with 3 lines (48px)
+
+    Markup:
+    <div style="background-color: dimgrey; border: 1px solid black; line-height: 2.5rem;" class="u-flex u-flex-wrap u-w-4 u-ta-center {{modifier_class}}">
+        <div style="background-color: gainsboro;" class="u-w-2-half u-h-2-half">🎶</div>
+        <div style="background-color: gainsboro;" class="u-w-2-half u-h-2-half">🎵</div>
+        <div style="background-color: gainsboro;" class="u-w-2-half u-h-2-half">🎼</div>
+        <div style="background-color: gainsboro;" class="u-w-2-half u-h-2-half">💃</div>
+    </div>
+
+    Styleguide utilities.gaps
+*/
+
+
+/*
     Spacing
 
     Classes to add spacing between the children elements.

--- a/stylus/cozy-ui/build.styl
+++ b/stylus/cozy-ui/build.styl
@@ -882,56 +882,56 @@ Display an chip that represents complex identity
     .u-m-1 - Margins on all sides with 1 line (16px)
     .u-m-1-half - Margins on all sides with 1 line an a half (24px)
     .u-m-2 - Margins on all sides with 2 lines (32px)
-    .u-m-2-half - Margins on all sides with 1 line an a half (40px)
-    .u-m-3 - Margins on all sides with 2 lines (48px)
+    .u-m-2-half - Margins on all sides with 2 lines an a half (40px)
+    .u-m-3 - Margins on all sides with 3 lines (48px)
     .u-mv-auto - Auto vertically margins
     .u-mv-0 - No vertically margins
     .u-mv-half - Vertically margins with half a line (8px)
     .u-mv-1 - Vertically margins with 1 line (16px)
     .u-mv-1-half - Vertically margins with 1 line an a half (24px)
     .u-mv-2 - Vertically margins with 2 lines (32px)
-    .u-mv-2-half - Vertically margins with 1 line an a half (40px)
-    .u-mv-3 - Vertically margins with 2 lines (48px)
+    .u-mv-2-half - Vertically margins with 2 lines an a half (40px)
+    .u-mv-3 - Vertically margins with 3 lines (48px)
     .u-mh-auto - Auto horizontally margins
     .u-mh-0 - No horizontally margins
     .u-mh-half - Horizontally margins with half a line (8px)
     .u-mh-1 - Horizontally margins with 1 line (16px)
     .u-mh-1-half - Horizontally margins with 1 line an a half (24px)
     .u-mh-2 - Horizontally margins with 2 lines (32px)
-    .u-mh-2-half - Horizontally margins with 1 line an a half (40px)
-    .u-mh-3 - Horizontally margins with 2 lines (48px)
+    .u-mh-2-half - Horizontally margins with 2 lines an a half (40px)
+    .u-mh-3 - Horizontally margins with 3 lines (48px)
     .u-mt-auto - Margin Top auto
     .u-mt-0 - No margin Top
     .u-mt-half - Margin Top with half a line (8px)
     .u-mt-1 - Margin Top with 1 line (16px)
     .u-mt-1-half - Margin Top with 1 line an a half (24px)
     .u-mt-2 - Margin Top with 2 lines (32px)
-    .u-mt-2-half - Margin Top with 1 line an a half (40px)
-    .u-mt-3 - Margin Top with 2 lines (48px)
+    .u-mt-2-half - Margin Top with 2 lines an a half (40px)
+    .u-mt-3 - Margin Top with 3 lines (48px)
     .u-mb-auto - Margin Bottom auto
     .u-mb-0 - No margin Bottom
     .u-mb-half - Margin Bottom with half a line (8px)
     .u-mb-1 - Margin Bottom with 1 line (16px)
     .u-mb-1-half - Margin Bottom with 1 line an a half (24px)
     .u-mb-2 - Margin Bottom with 2 lines (32px)
-    .u-mb-2-half - Margin Bottom with 1 line an a half (40px)
-    .u-mb-3 - Margin Bottom with 2 lines (48px)
+    .u-mb-2-half - Margin Bottom with 2 lines an a half (40px)
+    .u-mb-3 - Margin Bottom with 3 lines (48px)
     .u-ml-auto - Margin Left auto
     .u-ml-0 - No margin Left
     .u-ml-half - Margin Left with half a line (8px)
     .u-ml-1 - Margin Left with 1 line (16px)
     .u-ml-1-half - Margin Left with 1 line an a half (24px)
     .u-ml-2 - Margin Left with 2 lines (32px)
-    .u-ml-2-half - Margin Left with 1 line an a half (40px)
-    .u-ml-3 - Margin Left with 2 lines (48px)
+    .u-ml-2-half - Margin Left with 2 lines an a half (40px)
+    .u-ml-3 - Margin Left with 3 lines (48px)
     .u-mr-auto - Margin Right auto
     .u-mr-0 - No margin Right
     .u-mr-half - Margin Right with half a line (8px)
     .u-mr-1 - Margin Right with 1 line (16px)
     .u-mr-1-half - Margin Right with 1 line an a half (24px)
     .u-mr-2 - Margin Right with 2 lines (32px)
-    .u-mr-2-half - Margin Right with 1 line an a half (40px)
-    .u-mr-3 - Margin Right with 2 lines (48px)
+    .u-mr-2-half - Margin Right with 2 lines an a half (40px)
+    .u-mr-3 - Margin Right with 3 lines (48px)
 
     Markup:
     <div style="background-color:dimgrey; border: 1px solid black;"><div style="padding:.5rem; background-color:gainsboro;" class="{{modifier_class}}">🎶 Gimme some margin 🎵 </div></div>
@@ -952,56 +952,56 @@ Display an chip that represents complex identity
     .u-p-1 - Paddings on all sides with 1 line (16px)
     .u-p-1-half - Paddings on all sides with 1 line an a half (24px)
     .u-p-2 - Paddings on all sides with 2 lines (32px)
-    .u-p-2-half - Paddings on all sides with 1 line an a half (40px)
-    .u-p-3 - Paddings on all sides with 2 lines (48px)
+    .u-p-2-half - Paddings on all sides with 2 lines an a half (40px)
+    .u-p-3 - Paddings on all sides with 3 lines (48px)
     .u-pv-auto - Auto vertically paddings
     .u-pv-0 - No vertically paddings
     .u-pv-half - Vertically paddings with half a line (8px)
     .u-pv-1 - Vertically paddings with 1 line (16px)
     .u-pv-1-half - Vertically paddings with 1 line an a half (24px)
     .u-pv-2 - Vertically paddings with 2 lines (32px)
-    .u-pv-2-half - Vertically paddings with 1 line an a half (40px)
-    .u-pv-3 - Vertically paddings with 2 lines (48px)
+    .u-pv-2-half - Vertically paddings with 2 lines an a half (40px)
+    .u-pv-3 - Vertically paddings with 3 lines (48px)
     .u-ph-auto - Auto horizontally paddings
     .u-ph-0 - No horizontally paddings
     .u-ph-half - Horizontally paddings with half a line (8px)
     .u-ph-1 - Horizontally paddings with 1 line (16px)
     .u-ph-1-half - Horizontally paddings with 1 line an a half (24px)
     .u-ph-2 - Horizontally paddings with 2 lines (32px)
-    .u-ph-2-half - Horizontally paddings with 1 line an a half (40px)
-    .u-ph-3 - Horizontally paddings with 2 lines (48px)
+    .u-ph-2-half - Horizontally paddings with 2 lines an a half (40px)
+    .u-ph-3 - Horizontally paddings with 3 lines (48px)
     .u-pt-auto - Padding Top auto
     .u-pt-0 - No padding Top
     .u-pt-half - Padding Top with half a line (8px)
     .u-pt-1 - Padding Top with 1 line (16px)
     .u-pt-1-half - Padding Top with 1 line an a half (24px)
     .u-pt-2 - Padding Top with 2 lines (32px)
-    .u-pt-2-half - Padding Top with 1 line an a half (40px)
-    .u-pt-3 - Padding Top with 2 lines (48px)
+    .u-pt-2-half - Padding Top with 2 lines an a half (40px)
+    .u-pt-3 - Padding Top with 3 lines (48px)
     .u-pb-auto - Padding Bottom auto
     .u-pb-0 - No padding Bottom
     .u-pb-half - Padding Bottom with half a line (8px)
     .u-pb-1 - Padding Bottom with 1 line (16px)
     .u-pb-1-half - Padding Bottom with 1 line an a half (24px)
     .u-pb-2 - Padding Bottom with 2 lines (32px)
-    .u-pb-2-half - Padding Bottom with 1 line an a half (40px)
-    .u-pb-3 - Padding Bottom with 2 lines (48px)
+    .u-pb-2-half - Padding Bottom with 2 lines an a half (40px)
+    .u-pb-3 - Padding Bottom with 3 lines (48px)
     .u-pl-auto - Padding Left auto
     .u-pl-0 - No padding Left
     .u-pl-half - Padding Left with half a line (8px)
     .u-pl-1 - Padding Left with 1 line (16px)
     .u-pl-1-half - Padding Left with 1 line an a half (24px)
     .u-pl-2 - Padding Left with 2 lines (32px)
-    .u-pl-2-half - Padding Left with 1 line an a half (40px)
-    .u-pl-3 - Padding Left with 2 lines (48px)
+    .u-pl-2-half - Padding Left with 2 lines an a half (40px)
+    .u-pl-3 - Padding Left with 3 lines (48px)
     .u-pr-auto - Padding Right auto
     .u-pr-0 - No padding Right
     .u-pr-half - Padding Right with half a line (8px)
     .u-pr-1 - Padding Right with 1 line (16px)
     .u-pr-1-half - Padding Right with 1 line an a half (24px)
     .u-pr-2 - Padding Right with 2 lines (32px)
-    .u-pr-2-half - Padding Right with 1 line an a half (40px)
-    .u-pr-3 - Padding Right with 2 lines (48px)
+    .u-pr-2-half - Padding Right with 2 lines an a half (40px)
+    .u-pr-3 - Padding Right with 3 lines (48px)
 
     Markup:
     <div style="background-color:gainsboro; display: inline-block;" class="{{modifier_class}}"><span style="background-color:bisque;">🎼 Gimme some padding 💃</span></div>

--- a/stylus/utilities/spaces.styl
+++ b/stylus/utilities/spaces.styl
@@ -21,6 +21,27 @@ directions = {
     h: horizontal
 }
 
+gapTypes = {
+    g: gap
+}
+
+gapSizes = {
+    'normal': normal,
+    '0': 0,
+    'half': rem(8),
+    '1': rem(16),
+    '1-half': rem(24),
+    '2': rem(32),
+    '2-half': rem(40),
+    '3': rem(48)
+}
+
+gapDirections = {
+    '': all,
+    v: row,
+    h: column
+}
+
 // Placeholders generation
 for kType, vType in types
     for kSize, vSize in sizes
@@ -39,6 +60,15 @@ for kType, vType in types
             else
                 ${kType}{kDir}-{kSize}
                     {vType}-{vDir}: vSize !important
+for kType, vType in gapTypes
+    for kSize, vSize in gapSizes
+        for kDir, vDir in gapDirections
+            if vDir == all
+                ${kType}-{kSize}
+                    {vType}: vSize !important
+            else
+                ${kType}{kDir}-{kSize}
+                    {vDir}-{vType}: vSize !important
 
 // Classes generation
 cssModulesSpacingUtils()
@@ -77,6 +107,24 @@ cssModulesSpacingUtils()
                             else
                                 :global(.u-{kType}{kDir}-{kSize}-{vBp})
                                     {vType}-{vDir}: vSize !important
+        for kType, vType in gapTypes
+            for kSize, vSize in gapSizes
+                for kDir, vDir in gapDirections
+                    if vBp == ''
+                        if vDir == all
+                            :global(.u-{kType}-{kSize})
+                                {vType}: vSize !important
+                        else
+                            :global(.u-{kType}{kDir}-{kSize})
+                                {vDir}-{vType}: vSize !important
+                    else
+                        @media (max-width: rem(lookup('BP-'+kBp)))
+                            if vDir == all
+                                :global(.u-{kType}-{kSize}-{vBp})
+                                    {vType}: vSize !important
+                            else
+                                :global(.u-{kType}{kDir}-{kSize}-{vBp})
+                                    {vDir}-{vType}: vSize !important
 
 nativeSpacingUtils()
     for kBp, vBp in breakpoints
@@ -114,6 +162,25 @@ nativeSpacingUtils()
                             else
                                 .u-{kType}{kDir}-{kSize}-{vBp}
                                     {vType}-{vDir}: vSize !important
+        for kType, vType in gapTypes
+            for kSize, vSize in gapSizes
+                for kDir, vDir in gapDirections
+                    if vBp == ''
+                        if vDir == all
+                            .u-{kType}-{kSize}
+                                {vType}: vSize !important
+                        else
+                            .u-{kType}{kDir}-{kSize}
+                                {vDir}-{vType}: vSize !important
+                    else
+                        @media (max-width: rem(lookup('BP-'+kBp)))
+                            if vDir == all
+                                .u-{kType}-{kSize}-{vBp}
+                                    {vType}: vSize !important
+                            else
+                                .u-{kType}{kDir}-{kSize}-{vBp}
+                                    {vDir}-{vType}: vSize !important
+
 if cssmodules == true
     cssModulesSpacingUtils()
 else


### PR DESCRIPTION
We often need to put some regular spacing between elements. I learned there are the `u-stack-*` classes that basically allow that, but :

- in only one direction
- by overriding margins

At the end, it seems we don't really use these classes but rather margin utility classes on each element.

As we often are in flex contexts, i propose adding new gap utility classes that do not have these limiations and allow to add gutters between child *nodes* (not elements) of a flex element by declaring them only at a single location.
Gaps can also be used in grid contexts and multi-column layouts, and eventually will likely be compatible with subgrids, masonry layouts, table layouts, multi-row layouts...

Demo link: https://polaritoon.github.io/cozy-ui/styleguide/section-utilities.html#kssref-utilities-gaps