### PR TITLE
feat(CozyDialogs): Add possibility to override DialogTitle props

### DIFF
--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -30,6 +30,8 @@ import Button from  'cozy-ui/transpiled/react/Buttons'
 
 ### Props
 
+* **componentsProps** : `<object>` – overriden properties of specific components
+  * **dialogTitle** : `<object>` – DialogTitle component properties
 * **size** : `<string>` – Can be "s", "m" (default) or "l"
 * **open** : `<boolean>` (required) – To open/close the modal
 * **disableTitleAutoPadding** : `<boolean>` (optional) – Disable title padding calculation that would prevent overlapping with close and back buttons
@@ -339,5 +341,59 @@ const initialVariants = [{
       </>
     )}
   </Variants>
+</BreakpointsProvider>
+```
+
+
+### Dialogs with title button
+
+```jsx
+import cx from 'classnames'
+import useBreakpoints, { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import { Dialog } from  'cozy-ui/transpiled/react/CozyDialogs'
+import Button from  'cozy-ui/transpiled/react/Buttons'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
+
+initialState = { showModal: false }
+
+const Modal = () => {
+  const { isMobile } = useBreakpoints()
+
+  return (
+    <Dialog
+      open
+      title={
+        <>
+          This is the title
+          <IconButton>
+            <Icon icon={DotsIcon} />
+          </IconButton>
+        </>
+      }
+      content="Here's the content"
+      actions={
+        <Button label="Close" onClick={() => setState({ showModal: false })} />
+      }
+      componentsProps={{
+        dialogTitle: {
+          className: "u-flex u-flex-items-center u-flex-justify-between u-pv-0-s u-pv-1 u-pr-0-s"
+        }
+      }}
+      onClose={() => setState({ showModal: false })}
+    />
+  )
+}
+
+;
+
+<BreakpointsProvider>
+  <Button label="Open modal" onClick={() => setState({ showModal: true })}/>
+
+  {state.showModal && (
+    <Modal />
+  )}
 </BreakpointsProvider>
 ```

--- a/react/CozyDialogs/useCozyDialog.js
+++ b/react/CozyDialogs/useCozyDialog.js
@@ -32,6 +32,7 @@ const useCozyDialog = props => {
     disableGutters,
     titleRef,
     background,
+    componentsProps,
     ...otherProps
   } = props
   const { isMobile } = useBreakpoints()
@@ -66,15 +67,19 @@ const useCozyDialog = props => {
   const showBackButton = onBack || (fullScreen && onClose) // back and close buttons are merged in fullScreen
 
   const dialogTitleProps = {
+    ...componentsProps?.dialogTitle,
     id: `modal-title-${id}`,
     ref: titleRef,
     disableTypography: true,
-    className: cx({
-      'u-ellipsis': !isFluidTitle,
-      dialogTitleFluid: isFluidTitle,
-      dialogTitleWithClose: showCloseButton && !disableTitleAutoPadding,
-      dialogTitleWithBack: showBackButton && !disableTitleAutoPadding
-    })
+    className: cx(
+      {
+        'u-ellipsis': !isFluidTitle,
+        dialogTitleFluid: isFluidTitle,
+        dialogTitleWithClose: showCloseButton && !disableTitleAutoPadding,
+        dialogTitleWithBack: showBackButton && !disableTitleAutoPadding
+      },
+      componentsProps?.dialogTitle?.className
+    )
   }
 
   const listItemClassName = 'listItem--dialog'


### PR DESCRIPTION
On souhaite pouvoir ajouter des boutons dans le titre d'une modale. Or à cause des padding implicites ce n'est pas possible car le bouton faisant 48px, on se retrouve avec un titre qui a une hauteur de 48px + padding.

L'idée est alors de pouvoir supprimer les padding. Pour ce faire, deux solutions : soit des props spécifiques, soit un prop plus globale. C'est cette solution qu'on retient (explication dans cet article https://mui.com/blog/making-customizable-components/#passing-props ) afin de stopper l'ajout d'un enième prop (il y en a déjà trop) et permettre plus de modularité à l'app qui utilise la Dialog.

J'ai rajouté un exemple dans la doc

demo : https://jf-cozy.github.io/cozy-ui/react/#!/CozyDialogs
