### PR TITLE
fix: Load default langage when using createUseI18n

### DIFF
--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -102,9 +102,17 @@ export const createUseI18n = locales => () => {
   const { lang } = useI18n() || { lang: DEFAULT_LANG }
   return useMemo(() => {
     const polyglot = new Polyglot({
-      lang: lang,
-      phrases: locales[lang]
+      locale: DEFAULT_LANG,
+      phrases: locales[DEFAULT_LANG]
     })
+    if (lang && lang !== DEFAULT_LANG) {
+      try {
+        polyglot.locale(lang)
+        polyglot.extend(locales[lang])
+      } catch (e) {
+        console.warn(`The dict phrases for "${lang}" can't be loaded`)
+      }
+    }
     const f = initFormat(lang)
     const t = polyglot.t.bind(polyglot)
     return { t, f, lang }

--- a/react/I18n/index.spec.jsx
+++ b/react/I18n/index.spec.jsx
@@ -87,3 +87,40 @@ describe('use i18n with custom locales', () => {
     expect(root.getByText('Bonjour le monde')).toBeTruthy()
   })
 })
+
+describe('use i18n with custom locales and fallback to default', () => {
+  const locales = {
+    en: {
+      'hello-world': 'Hello world',
+      'how-are-you': 'How are you ?'
+    },
+    fr: {
+      'hello-world': 'Bonjour le monde'
+    }
+  }
+  const useI18n = createUseI18n(locales)
+  const Child = () => {
+    const { t } = useI18n()
+    return (
+      <div>
+        <div>{t('hello-world')}</div>
+        <div>{t('how-are-you')}</div>
+      </div>
+    )
+  }
+  const Parent = () => {
+    return (
+      <>
+        <I18n lang="fr" dictRequire={() => ({})}>
+          <Child />
+        </I18n>
+      </>
+    )
+  }
+
+  it('should display missing key in default langage', () => {
+    const root = render(<Parent />)
+    expect(root.getByText('Bonjour le monde')).toBeInTheDocument()
+    expect(root.getByText('How are you ?')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
When using createUseI18n, default langage was not loaded. Missing keys were displayed instead of default langage translations.