### PR TITLE
fix: Fix bottomSheet height if the content is pretty small 

### DIFF
--- a/react/BottomSheet/helpers.js
+++ b/react/BottomSheet/helpers.js
@@ -26,7 +26,6 @@ export const computeMediumHeight = ({
 }) => {
   const mediumHeightOrWithRatio =
     mediumHeight || Math.round(maxHeight * mediumHeightRatio)
-
   if (backdrop) {
     if (mediumHeightOrWithRatio < innerContentHeight) {
       return mediumHeightOrWithRatio < maxHeight
@@ -35,7 +34,7 @@ export const computeMediumHeight = ({
     }
     return innerContentHeight > maxHeight ? maxHeight : innerContentHeight
   }
-
+  if (innerContentHeight < mediumHeightOrWithRatio) return innerContentHeight
   return mediumHeightOrWithRatio > maxHeight
     ? maxHeight
     : mediumHeightOrWithRatio

--- a/react/BottomSheet/helpers.spec.js
+++ b/react/BottomSheet/helpers.spec.js
@@ -57,6 +57,17 @@ describe('computeMediumHeight', () => {
 
       expect(res).toBe(800)
     })
+
+    it('should return the innerContentHeight if innerContentHeight < mediumHeight', () => {
+      const res = computeMediumHeight({
+        backdrop: false,
+        maxHeight: 800,
+        mediumHeight: 400,
+        innerContentHeight: 200
+      })
+
+      expect(res).toBe(200)
+    })
   })
 
   describe('with backdrop', () => {


### PR DESCRIPTION
If the innerContent is smaller than the mediumHeight, we don't want the BottomSheet to take all the available space. We want to take only the needed place.


The global idea is: 
- App can set the mediumHeight for the BottomSheet 
- But if the content is smaller than this mediumHeight, the BottomSheet size should not be this mediumHeight but should be the content size instead. 


Here is a before / after (this test is already in the Readme...): 
![before](https://user-images.githubusercontent.com/1107936/204326707-b4a634a2-6565-4213-b03e-f76821abb8a9.png)
![after](https://user-images.githubusercontent.com/1107936/204326751-117bf141-f6e2-4f9d-934a-d51022ad8afb.png)


demo here: https://crash--.github.io/cozy-ui/react/#!/BottomSheet (deselect backdrop and play with no long content) 