### PR TITLE
feat(search.js): add maintenance activated matcher

### DIFF
--- a/react/AppSections/search.js
+++ b/react/AppSections/search.js
@@ -27,12 +27,17 @@ const doctypeMatcher = doctype => app => {
 }
 const pendingUpdateMatcher = () => app => !!app.availableVersion
 
+const underMaintenanceMatcher = isUnderMaintenance => app => {
+  return (app.maintenance !== undefined) === isUnderMaintenance
+}
+
 const searchAttrToMatcher = {
   type: typeMatcher,
   category: categoryMatcher,
   tag: tagMatcher,
   doctype: doctypeMatcher,
-  pendingUpdate: pendingUpdateMatcher
+  pendingUpdate: pendingUpdateMatcher,
+  underMaintenance: underMaintenanceMatcher
 }
 
 /**

--- a/react/AppSections/search.spec.js
+++ b/react/AppSections/search.spec.js
@@ -5,6 +5,20 @@
 import { makeMatcherFromSearch } from './search'
 import mockApps from '../mocks/apps'
 
+const mockMaintenanceApps = [
+  { slug: 'collect' },
+  { slug: 'drive' },
+  {
+    slug: 'konnectorInMaintenance',
+    maintenance: {
+      flag_infra_maintenance: true,
+      flag_short_maintenance: true,
+      flag_disallow_manual_exec: true,
+      messages: []
+    }
+  }
+]
+
 describe('makeMatcherFromSearch', () => {
   it('should filter correctly on type', () => {
     const matcher = makeMatcherFromSearch({ type: 'webapp' })
@@ -29,6 +43,29 @@ describe('makeMatcherFromSearch', () => {
   it('should filter correctly on pending update apps', () => {
     const matcher = makeMatcherFromSearch({ pendingUpdate: true })
     expect(mockApps.filter(matcher)).toMatchSnapshot()
+  })
+
+  it('should filter correctly when under maintenance is false', () => {
+    const matcher = makeMatcherFromSearch({ underMaintenance: false })
+    expect(mockMaintenanceApps.filter(matcher)).toStrictEqual([
+      { slug: 'collect' },
+      { slug: 'drive' }
+    ])
+  })
+
+  it('should filter correctly when under maintenance is true', () => {
+    const matcher = makeMatcherFromSearch({ underMaintenance: true })
+    expect(mockMaintenanceApps.filter(matcher)).toStrictEqual([
+      {
+        maintenance: {
+          flag_disallow_manual_exec: true,
+          flag_infra_maintenance: true,
+          flag_short_maintenance: true,
+          messages: []
+        },
+        slug: 'konnectorInMaintenance'
+      }
+    ])
   })
 
   it('should handle correctly multi filters', () => {


### PR DESCRIPTION
```
### ✨ Features

* add maintenance activated matcher

```

It allows you to filter the applications in the AppSection to display only those that are not under maintenance. 

**Related PRs:**
* https://github.com/cozy/cozy-store/pull/829