### PR TITLE
fix(search.js): rename underMaintenance to showMaintenance

### DIFF
--- a/react/AppSections/search.js
+++ b/react/AppSections/search.js
@@ -27,8 +27,9 @@ const doctypeMatcher = doctype => app => {
 }
 const pendingUpdateMatcher = () => app => !!app.availableVersion
 
-const underMaintenanceMatcher = isUnderMaintenance => app => {
-  return (app.maintenance !== undefined) === isUnderMaintenance
+const showMaintenanceMatcher = isShowMaintenance => app => {
+  if (isShowMaintenance) return true
+  return app.maintenance === undefined
 }
 
 const searchAttrToMatcher = {
@@ -37,7 +38,7 @@ const searchAttrToMatcher = {
   tag: tagMatcher,
   doctype: doctypeMatcher,
   pendingUpdate: pendingUpdateMatcher,
-  underMaintenance: underMaintenanceMatcher
+  showMaintenance: showMaintenanceMatcher
 }
 
 /**

--- a/react/AppSections/search.spec.js
+++ b/react/AppSections/search.spec.js
@@ -45,17 +45,19 @@ describe('makeMatcherFromSearch', () => {
     expect(mockApps.filter(matcher)).toMatchSnapshot()
   })
 
-  it('should filter correctly when under maintenance is false', () => {
-    const matcher = makeMatcherFromSearch({ underMaintenance: false })
+  it('should filter correctly when show maintenance is false', () => {
+    const matcher = makeMatcherFromSearch({ showMaintenance: false })
     expect(mockMaintenanceApps.filter(matcher)).toStrictEqual([
       { slug: 'collect' },
       { slug: 'drive' }
     ])
   })
 
-  it('should filter correctly when under maintenance is true', () => {
-    const matcher = makeMatcherFromSearch({ underMaintenance: true })
+  it('should filter correctly when show maintenance is true', () => {
+    const matcher = makeMatcherFromSearch({ showMaintenance: true })
     expect(mockMaintenanceApps.filter(matcher)).toStrictEqual([
+      { slug: 'collect' },
+      { slug: 'drive' },
       {
         maintenance: {
           flag_disallow_manual_exec: true,


### PR DESCRIPTION
Rename underMaintenance to showMaintenance filter to improve understanding into `cozy-store`. This filter now show all apps when it's true and hide apps under maintenance when it's false.

