### PR TITLE
fix(AppSections): MakeMatcherFromSearch now accept unsupported filter

### DIFF
--- a/react/AppSections/__snapshots__/search.spec.js.snap
+++ b/react/AppSections/__snapshots__/search.spec.js.snap
@@ -744,3 +744,229 @@ Array [
   },
 ]
 `;
+
+exports[`makeMatcherFromSearch should work even for an unsupported filter 1`] = `
+Array [
+  Object {
+    "categories": Array [
+      "cozy",
+    ],
+    "developer": Object {
+      "name": "Cozy",
+    },
+    "editor": "Cozy",
+    "icon": "<svg></svg>",
+    "installed": true,
+    "isInRegistry": true,
+    "label": 1,
+    "name": "Collect",
+    "name_prefix": "Cozy",
+    "permissions": Object {
+      "mock": Object {
+        "type": "io.mock.doctype",
+      },
+      "mock2": Object {
+        "type": "io.mock.doctype2",
+      },
+    },
+    "related": "http://collect.cozy.mock/",
+    "slug": "collect",
+    "tags": Array [
+      "konnector",
+      "collect",
+      "bills",
+      "providers",
+      "files",
+    ],
+    "type": "webapp",
+    "uninstallable": false,
+    "version": "3.0.0",
+    "versions": Object {
+      "beta": Array [
+        "3.0.0",
+      ],
+      "dev": Array [
+        "3.0.0",
+      ],
+      "stable": Array [
+        "3.0.0",
+      ],
+    },
+  },
+  Object {
+    "categories": Array [
+      "others",
+    ],
+    "developer": Object {
+      "name": "Cozy",
+    },
+    "editor": "Cozy",
+    "icon": "<svg></svg>",
+    "isInRegistry": true,
+    "locales": Object {
+      "name": "For Dev Only",
+    },
+    "name": "DevOnly",
+    "slug": "devonly",
+    "type": "webapp",
+    "uninstallable": true,
+    "versions": Object {
+      "beta": Array [],
+      "dev": Array [
+        "1.0.0-betaojdkehy989ekhflldh",
+      ],
+      "stable": Array [],
+    },
+  },
+  Object {
+    "categories": Array [
+      "cozy",
+    ],
+    "developer": Object {
+      "name": "Cozy",
+    },
+    "editor": "Cozy",
+    "icon": "<svg></svg>",
+    "installed": true,
+    "name": "Drive",
+    "name_prefix": "Cozy",
+    "permissions": Object {
+      "mock2": Object {
+        "type": "io.mock.doctype2",
+      },
+    },
+    "related": "http://drive.cozy.mock/",
+    "slug": "drive",
+    "tags": Array [
+      "search",
+      "files",
+      "folders",
+    ],
+    "type": "webapp",
+    "uninstallable": false,
+    "version": "3.0.0-beta89bnhj3993",
+  },
+  Object {
+    "categories": Array [
+      "isp",
+      "telecom",
+    ],
+    "developer": Object {
+      "name": "Cozy",
+    },
+    "icon": "<svg></svg>",
+    "isInRegistry": true,
+    "name": "Bouilligue",
+    "slug": "konnector-bouilligue",
+    "type": "konnector",
+    "uninstallable": true,
+    "versions": Object {
+      "beta": Array [
+        "0.1.0",
+      ],
+      "dev": Array [
+        "0.1.0",
+      ],
+      "stable": Array [
+        "0.1.0",
+      ],
+    },
+  },
+  Object {
+    "categories": Array [
+      "transport",
+    ],
+    "developer": Object {
+      "name": "Cozy",
+    },
+    "icon": "<svg></svg>",
+    "installed": true,
+    "isInRegistry": true,
+    "name": "Trinlane",
+    "permissions": Object {
+      "mock": Object {
+        "type": "io.mock.doctype",
+      },
+    },
+    "slug": "konnector-trinlane",
+    "tags": Array [
+      "transport",
+      "files",
+      "bills",
+    ],
+    "type": "konnector",
+    "uninstallable": true,
+    "version": "0.1.0",
+    "versions": Object {
+      "beta": Array [
+        "0.1.0",
+      ],
+      "dev": Array [
+        "0.1.0",
+      ],
+      "stable": Array [
+        "0.1.0",
+      ],
+    },
+  },
+  Object {
+    "categories": Array [
+      "cozy",
+    ],
+    "developer": Object {
+      "name": "Cozy",
+    },
+    "editor": "Cozy",
+    "icon": "<svg></svg>",
+    "isInRegistry": true,
+    "locales": Object {
+      "en": Object {
+        "long_description": "A long description finally short",
+      },
+    },
+    "name": "Photos",
+    "name_prefix": "Cozy",
+    "slug": "photos",
+    "type": "webapp",
+    "uninstallable": true,
+    "versions": Object {
+      "beta": Array [
+        "3.0.0",
+      ],
+      "dev": Array [
+        "3.0.0",
+      ],
+      "stable": Array [
+        "3.0.0",
+      ],
+    },
+  },
+  Object {
+    "availableVersion": "3.0.0",
+    "categories": Array [
+      "partners",
+    ],
+    "icon": "<svg></svg>",
+    "installed": true,
+    "isInRegistry": true,
+    "name": "Tasky",
+    "slug": "tasky",
+    "type": "webapp",
+    "uninstallable": true,
+    "versions": Object {
+      "beta": Array [
+        "3.0.0",
+        "1.0.0",
+      ],
+      "dev": Array [
+        "3.0.0",
+        "1.0.0",
+      ],
+      "stable": Array [
+        "3.0.0",
+        "1.0.0",
+      ],
+    },
+  },
+]
+`;

--- a/react/AppSections/search.js
+++ b/react/AppSections/search.js
@@ -52,7 +52,7 @@ export const makeMatcherFromSearch = (search = {}) => {
   // Create all predicates from the search object
   const predicates = Object.values(
     mapValues(search, (value, name) => {
-      return searchAttrToMatcher[name](value)
+      return searchAttrToMatcher[name]?.(value)
     })
   )
   // Return a function returning true if all predicates pass

--- a/react/AppSections/search.spec.js
+++ b/react/AppSections/search.spec.js
@@ -150,4 +150,9 @@ describe('makeMatcherFromSearch', () => {
     const matcher = makeMatcherFromSearch({ category: 'cozy' })
     expect([appWithoutCategories].filter(matcher)).toMatchSnapshot()
   })
+
+  it('should work even for an unsupported filter', () => {
+    const matcher = makeMatcherFromSearch({ unsupportedKey: 'omg' })
+    expect(mockApps.filter(matcher)).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
in this cas it will be ignored, but function will not crash anymore

cas d'usage : dans le store on filtre les app/connecteur en fonction des searchParams. Or si on passe un autre searchParams qui n'a rien à voir avec la recherche, l'app plante car la méthode crash