### PR TITLE
fix(IllustrationDialog): The title was not centered properly

### DIFF
--- a/react/CozyDialogs/IllustrationDialog.jsx
+++ b/react/CozyDialogs/IllustrationDialog.jsx
@@ -17,7 +17,11 @@ const IllustrationDialog = props => {
     fullScreen,
     dialogActionsProps,
     dialogContentProps
-  } = useCozyDialog({ ...props, isFluidTitle: true })
+  } = useCozyDialog({
+    ...props,
+    isFluidTitle: true,
+    disableTitleAutoPadding: true
+  })
 
   const onBackOrClose = onBack || onClose
 
@@ -44,9 +48,17 @@ const IllustrationDialog = props => {
       <DialogContent {...dialogContentProps}>
         <div className="dialogContentInner withFluidActions">
           {title && (
-            <DialogTitle {...dialogTitleProps}>
-              <div className="u-flex u-flex-justify-center">{title}</div>
-            </DialogTitle>
+            <div className="dialogTitleFluidContainer">
+              <DialogTitle
+                {...dialogTitleProps}
+                className={cx(
+                  `u-flex u-flex-justify-center`,
+                  dialogTitleProps.className
+                )}
+              >
+                {title}
+              </DialogTitle>
+            </div>
           )}
           <div
             className={cx('dialogContentWrapper', {


### PR DESCRIPTION
it is now, no matter if there is a back or close button

Il manquait le wrapper de suppression des marges qu'on avait pourtant sur les autres modales avec un titre fluide (non fixe), et on rajoutait une marge s'il y avait un bouton back (ce qui était inutile)

demo : https://jf-cozy.github.io/cozy-ui/react/#!/CozyDialogs

**avant**
![image](https://user-images.githubusercontent.com/67680939/213158799-6448b366-c591-4120-84bc-b9df9f8a3d0b.png)


**après**
![image](https://user-images.githubusercontent.com/67680939/213158703-27ccf373-2200-4853-965b-f3abc6d00520.png)
