### PR TITLE
Force  formatLocallyDistanceToNowStrict  to use whole number of day

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  testURL: 'http://localhost/',
+  moduleFileExtensions: ['js', 'jsx', 'json', 'styl', 'ts', 'tsx'],
+  setupFilesAfterEnv: ['./test/jestsetup.js', 'jest-canvas-mock'],
+  moduleDirectories: ['node_modules', 'src', 'react-styleguidist/lib'],
+  moduleNameMapper: {
+    '\\.(png|gif|jpe?g|svg)$': '<rootDir>/test/__mocks__/fileMock.js',
+    '\\.styl$': 'identity-obj-proxy',
+    'react-styleguidist.+\\.jsx?$': 'babel-jest',
+    '^rsg-components(.*)$':
+      '<rootDir>/node_modules/react-styleguidist/lib/client/rsg-components$1',
+    'react-pdf/dist/entry.webpack.js': 'react-pdf',
+    '^cozy-client$': 'cozy-client/dist/index'
+  },
+  transformIgnorePatterns: ['node_modules/(?!(react-styleguidist)/)'],
+  testPathIgnorePatterns: ['/node_modules/', '/transpiled/', '/dist/'],
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx)?$': 'babel-jest'
+  },
+  globals: {
+    __ALLOW_HTTP__: false,
+    cozy: {}
+  },
+  snapshotSerializers: ['enzyme-to-json/serializer']
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'UTC'
+
 module.exports = {
   testURL: 'http://localhost/',
   moduleFileExtensions: ['js', 'jsx', 'json', 'styl', 'ts', 'tsx'],

--- a/package.json
+++ b/package.json
@@ -203,52 +203,6 @@
       "cozy"
     ]
   },
-  "jest": {
-    "setupFilesAfterEnv": [
-      "./test/jestsetup.js",
-      "jest-canvas-mock"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "json",
-      "styl",
-      "ts",
-      "tsx"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/transpiled/",
-      "/dist/"
-    ],
-    "moduleDirectories": [
-      "node_modules",
-      "src",
-      "react-styleguidist/lib"
-    ],
-    "transform": {
-      "^.+\\.(ts|tsx|js|jsx)?$": "babel-jest"
-    },
-    "transformIgnorePatterns": [
-      "node_modules/(?!(react-styleguidist)/)"
-    ],
-    "moduleNameMapper": {
-      "\\.(png|gif|jpe?g|svg)$": "<rootDir>/test/__mocks__/fileMock.js",
-      "\\.styl$": "identity-obj-proxy",
-      "react-styleguidist.+\\.jsx?$": "babel-jest",
-      "^rsg-components(.*)$": "<rootDir>/node_modules/react-styleguidist/lib/client/rsg-components$1",
-      "react-pdf/dist/entry.webpack.js": "react-pdf",
-      "^cozy-client$": "cozy-client/dist/index"
-    },
-    "globals": {
-      "__ALLOW_HTTP__": false,
-      "cozy": {}
-    },
-    "testURL": "http://localhost/",
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
-  },
   "browserslist": [
     "extends browserslist-config-cozy"
   ]

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "lodash": "4.17.21",
     "michelangelo": "https://github.com/cozy/michelangelo.git",
     "mini-css-extract-plugin": "0.6.0",
+    "mockdate": "^3.0.5",
     "nodemon": "1.19.4",
     "npm-run-all": "4.1.5",
     "postcss-cli": "6.1.3",

--- a/react/I18n/format.jsx
+++ b/react/I18n/format.jsx
@@ -1,7 +1,13 @@
 import format from 'date-fns/format'
+import distanceInWordsToNow from 'date-fns/distance_in_words_to_now'
+import distanceInWordsStrict from 'date-fns/distance_in_words_strict'
+import differenceInCalendarDays from 'date-fns/difference_in_calendar_days'
+import getHours from 'date-fns/get_hours'
+import setHours from 'date-fns/set_hours'
+import setMinutes from 'date-fns/set_minutes'
+import getMinutes from 'date-fns/get_minutes'
+
 import { DEFAULT_LANG } from '.'
-import formatDistanceToNow from 'date-fns/distance_in_words_to_now'
-import formatDistanceStrict from 'date-fns/distance_in_words_strict'
 
 const locales = {}
 let lang = DEFAULT_LANG
@@ -36,7 +42,32 @@ export const initFormat = (userLang, defaultLang = DEFAULT_LANG) => (
 }
 
 export const formatLocallyDistanceToNow = date =>
-  formatDistanceToNow(date, { locale: locales[lang] })
+  distanceInWordsToNow(date, { locale: locales[lang] })
 
-export const formatLocallyDistanceToNowStrict = date =>
-  formatDistanceStrict(Date.now(), date, { locale: locales[lang] })
+export const setHoursAndMinutesFromDate = (date, refDate) => {
+  let newDate = date
+  newDate = setHours(newDate, getHours(refDate))
+  newDate = setMinutes(newDate, getMinutes(refDate))
+  return newDate
+}
+
+/**
+ * Return the distance between the given dates in words, using strict units.
+ * If the distance is in days, we force the time to be a whole number of days
+ * @param {Date} date - Future date compared to the current date
+ * @returns {string} Number of hours/day/month that separates the date from the present moment
+ */
+export const formatLocallyDistanceToNowStrict = date => {
+  const now = new Date()
+  const days = differenceInCalendarDays(date, now)
+  const isSameDay = days === 0
+  const isInMonth = days > 0 && days < 32
+
+  const refDate = isSameDay ? date : setHoursAndMinutesFromDate(date, now)
+  const unit = isInMonth ? 'd' : undefined
+
+  return distanceInWordsStrict(now, refDate, {
+    locale: locales[lang],
+    unit
+  })
+}

--- a/react/I18n/format.spec.jsx
+++ b/react/I18n/format.spec.jsx
@@ -1,7 +1,10 @@
+import MockDate from 'mockdate'
+
 import {
   initFormat,
   formatLocallyDistanceToNow,
-  formatLocallyDistanceToNowStrict
+  formatLocallyDistanceToNowStrict,
+  setHoursAndMinutesFromDate
 } from './format'
 
 describe('initFormat', () => {
@@ -75,11 +78,189 @@ describe('formatLocallyDistanceToNowStrict', () => {
     expect(result).toEqual('1 hour')
   })
 
+  it('should formatDistanceToNowStrict with one day', () => {
+    const date = Date.now() + 24 * 60 * 60 * 1000 // 1d
+
+    const result = formatLocallyDistanceToNowStrict(date)
+
+    expect(result).toEqual('1 day')
+  })
+
+  it('should formatDistanceToNowStrict with two days', () => {
+    const date = Date.now() + 2 * 24 * 60 * 60 * 1000 // 2d
+
+    const result = formatLocallyDistanceToNowStrict(date)
+
+    expect(result).toEqual('2 days')
+  })
+
   it('should formatDistanceToNowStrict with very high value', () => {
     const date = Date.now() + 42 * 24 * 60 * 60 * 1000 // 42d
 
     const result = formatLocallyDistanceToNowStrict(date)
 
     expect(result).toEqual('1 month')
+  })
+
+  describe('for hours', () => {
+    afterEach(() => {
+      MockDate.reset()
+    })
+
+    it('should return 1 hour', () => {
+      MockDate.set('2023-01-01T00:00:00')
+      const date = new Date('2023-01-01T01:00:00')
+
+      const result = formatLocallyDistanceToNowStrict(date)
+
+      expect(result).toEqual('1 hour')
+    })
+
+    it('should return 23 hours', () => {
+      MockDate.set('2023-01-01T00:00:00')
+      const date = new Date('2023-01-01T23:59:00')
+
+      const result = formatLocallyDistanceToNowStrict(date)
+
+      expect(result).toEqual('23 hours')
+    })
+
+    it('should return 11 hours', () => {
+      MockDate.set('2023-01-01T12:00:00')
+      const date = new Date('2023-01-01T23:59:00')
+
+      const result = formatLocallyDistanceToNowStrict(date)
+
+      expect(result).toEqual('11 hours')
+    })
+  })
+
+  describe('for days', () => {
+    describe('at midnight', () => {
+      beforeEach(() => {
+        MockDate.set('2023-01-01T00:00:00')
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('should return 1 day when 00:00:00', () => {
+        const date = new Date('2023-01-02T00:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('1 day')
+      })
+
+      it('should return 1 day when 01:00:00', () => {
+        const date = new Date('2023-01-02T01:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('1 day')
+      })
+
+      it('should return 1 day when 23:59:00', () => {
+        const date = new Date('2023-01-02T23:59:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('1 day')
+      })
+
+      it('should return 2 days when 00:00:00', () => {
+        const date = new Date('2023-01-03T00:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('2 days')
+      })
+
+      it('should return 2 days when 01:00:00', () => {
+        const date = new Date('2023-01-03T01:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('2 days')
+      })
+
+      it('should return 2 days when 23:59:00', () => {
+        const date = new Date('2023-01-03T23:59:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('2 days')
+      })
+    })
+
+    describe('at midday', () => {
+      beforeEach(() => {
+        MockDate.set('2023-01-01T12:00:00')
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('should return 1 day when 00:00:00', () => {
+        const date = new Date('2023-01-02T00:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('1 day')
+      })
+
+      it('should return 1 day when 11:00:00', () => {
+        const date = new Date('2023-01-02T11:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('1 day')
+      })
+
+      it('should return 1 day when 23:59:00', () => {
+        const date = new Date('2023-01-02T23:59:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('1 day')
+      })
+
+      it('should return 2 days when 00:00:00', () => {
+        const date = new Date('2023-01-03T00:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('2 days')
+      })
+
+      it('should return 2 days when 01:00:00', () => {
+        const date = new Date('2023-01-03T01:00:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('2 days')
+      })
+
+      it('should return 2 days when 23:59:00', () => {
+        const date = new Date('2023-01-03T23:59:00')
+
+        const result = formatLocallyDistanceToNowStrict(date)
+
+        expect(result).toEqual('2 days')
+      })
+    })
+  })
+})
+
+describe('setHoursAndMinutesFromDate', () => {
+  it('should return correct date', () => {
+    const res = setHoursAndMinutesFromDate(
+      new Date('2023-01-03T00:00:30'),
+      new Date('2023-01-01T12:24:00')
+    )
+
+    expect(res).toStrictEqual(new Date('2023-01-03T12:24:30'))
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12903,6 +12903,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
On veut afficher le nombre de jour entre une date et la date actuelle, peu importe l'heure de ces dates.

Avant on tombait dans un cas où on pouvait afficher 1 jours alors que 2 jours calendaires séparaient deux dates, car date-fns considère qu'on parle en jour seulement s'il y a entre 23 et 41 heures d'écart entre 2 dates https://date-fns.org/v1.28.5/docs/distanceInWordsToNow

Pour une différence entre 2 jours calendaires mais moins de 41h d'écart, ça affichait donc 1 jours au lieu de 2.

On aurait pu changer la façon de faire un arrondi avec partialMethod ceil de https://date-fns.org/v1.28.5/docs/distanceInWordsStrict mais on se retrouvait avec le même problème dans l'autre sens.

Nous on souhaite simplement parler en jour en fonction du nombre de jour calendaire qui sépare les dates, peu importe l'heure qu'il est.