### PR TITLE
Port "Make sure the message fills all the available width in `Alert` and allow overriding its classes" to `next`

### DIFF
--- a/react/Alert/index.jsx
+++ b/react/Alert/index.jsx
@@ -35,7 +35,7 @@ const makeIcon = (icon, severity) => {
 const useStyles = makeStyles({
   message: {
     maxWidth: ({ block, iconSize }) =>
-      block && `calc(100% - ${iconSize + 16}px)`
+      block && `calc(100% - ${iconSize}px - 12px)`
   }
 })
 

--- a/react/Alert/index.jsx
+++ b/react/Alert/index.jsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import merge from 'lodash/merge'
 import MuiAlert from '@mui/material/Alert'
 
 import { makeStyles } from '../styles'
@@ -43,6 +44,7 @@ const Alert = forwardRef(
   (
     {
       className,
+      classes,
       icon,
       severity,
       block,
@@ -72,7 +74,7 @@ const Alert = forwardRef(
           { block },
           { action: Boolean(action) }
         )}
-        classes={styles}
+        classes={merge(styles, classes)}
         variant={variant}
         severity={madeSeverity}
         iconMapping={defaultIconMapping}

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -780,6 +780,7 @@ export const makeOverrides = theme =>
         }
       },
       message: {
+        flex: 'auto',
         display: 'flex',
         alignItems: 'center',
         flexWrap: 'wrap'


### PR DESCRIPTION
This forward ports #2333 (identical changes).

Demo link : https://polaritoon.github.io/cozy-ui/react/#!/Alert