### PR TITLE
Port "Show CAF file number and reference tax income in the viewer" to `next`

### DIFF
--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -21,11 +21,13 @@ export const knownDateMetadataNames = [
 ]
 export const knownInformationMetadataNames = [
   'number',
+  'cafFileNumber',
   'cardNumber',
   'vinNumber',
   'ibanNumber',
   'country',
   'passportNumber',
+  'refTaxIncome',
   'noticePeriod'
 ]
 export const knownOtherMetadataNames = ['contact', 'page', 'qualification']

--- a/react/Viewer/locales/en.json
+++ b/react/Viewer/locales/en.json
@@ -53,11 +53,13 @@
         "information": {
           "title": {
             "number": "License number",
+            "cafFileNumber": "CAF file number",
             "cardNumber": "National ID card number",
             "vinNumber": "Vehicle registration number (VIN)",
             "ibanNumber": "IBAN number",
             "country": "Country of delivery",
             "passportNumber": "Passport number",
+            "refTaxIncome": "Reference tax income",
             "noticePeriod": "Expiration alert"
           },
           "day": "day |||| days"

--- a/react/Viewer/locales/fr.json
+++ b/react/Viewer/locales/fr.json
@@ -53,11 +53,13 @@
         "information": {
           "title": {
             "number": "Numéro du permis",
+            "cafFileNumber": "Numéro de dossier CAF",
             "cardNumber": "Numéro de la carte d'identité",
             "vinNumber": "Numéro de la carte grise (VIN)",
             "ibanNumber": "Numéro d'IBAN",
             "country": "Pays de délivrance",
             "passportNumber": "Numéro du passeport",
+            "refTaxIncome": "Revenu fiscal de référence",
             "noticePeriod": "Alerte d’expiration"
           },
           "day": "jour |||| jours"


### PR DESCRIPTION
See #2349.