### PR TITLE
Port "Use extensionless specifiers when importing JS files" to `next`

### DIFF
--- a/react/ActionMenu/index.spec.jsx
+++ b/react/ActionMenu/index.spec.jsx
@@ -10,7 +10,7 @@ import Icon from '../Icon'
 import FileIcon from '../Icons/File'
 import WarningIcon from '../Icons/Warning'
 
-import ActionMenu, { ActionMenuItem, ActionMenuRadio } from './'
+import ActionMenu, { ActionMenuItem, ActionMenuRadio } from '.'
 
 describe('ActionMenu', () => {
   fixPopperTesting()

--- a/react/Alerter/alerter.spec.js
+++ b/react/Alerter/alerter.spec.js
@@ -4,7 +4,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import Alerter from './'
+import Alerter from '.'
 import Alert from './Alert'
 import Button from '../Button'
 

--- a/react/AppIcon/test/AppIcon.spec.js
+++ b/react/AppIcon/test/AppIcon.spec.js
@@ -4,7 +4,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { AppIcon } from '../'
+import { AppIcon } from '..'
 
 describe('AppIcon component', () => {
   const app = {}

--- a/react/AppLinker/index.deprecated.spec.jsx
+++ b/react/AppLinker/index.deprecated.spec.jsx
@@ -19,7 +19,7 @@ import {
   checkApp
 } from 'cozy-device-helper'
 
-import AppLinker from './index'
+import AppLinker from '.'
 import { generateUniversalLink } from './native'
 jest.useFakeTimers()
 

--- a/react/AppLinker/index.spec.jsx
+++ b/react/AppLinker/index.spec.jsx
@@ -11,7 +11,7 @@ import {
   checkApp
 } from 'cozy-device-helper'
 
-import AppLinker from './index'
+import AppLinker from '.'
 import { generateUniversalLink } from './native'
 jest.useFakeTimers()
 

--- a/react/AppLinker/native.js
+++ b/react/AppLinker/native.js
@@ -3,7 +3,7 @@ import {
   ensureFirstSlash
 } from 'cozy-client'
 
-import { UNIVERSAL_LINK_URL } from './native.config.js'
+import { UNIVERSAL_LINK_URL } from './native.config'
 
 export const getUniversalLinkDomain = () => {
   return UNIVERSAL_LINK_URL

--- a/react/AppTile/AppTile.spec.jsx
+++ b/react/AppTile/AppTile.spec.jsx
@@ -9,7 +9,7 @@ import CozyClient, { CozyProvider } from 'cozy-client'
 import en from '../AppSections/locales/en.json'
 import I18n from '../I18n'
 
-import AppTile from './index'
+import AppTile from '.'
 
 const appMock = {
   slug: 'test',

--- a/react/CipherIcon/index.spec.jsx
+++ b/react/CipherIcon/index.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import CipherIcon from './index'
+import CipherIcon from '.'
 
 jest.mock('cozy-client', () => ({
   withClient: Component => {

--- a/react/ContactsListModal/index.jsx
+++ b/react/ContactsListModal/index.jsx
@@ -13,7 +13,7 @@ import {
   useCozyDialog
 } from '../CozyDialogs'
 import useRealtime from '../hooks/useRealtime'
-import useEventListener from '../hooks/useEventListener.js'
+import useEventListener from '../hooks/useEventListener'
 import useBreakpoints from '../hooks/useBreakpoints'
 import Button from '../Buttons'
 import PlusIcon from '../Icons/Plus'

--- a/react/DateMonthPicker/index.spec.jsx
+++ b/react/DateMonthPicker/index.spec.jsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme'
 import React from 'react'
-import DateMonthPicker from './index'
+import DateMonthPicker from '.'
 import { act } from 'react-dom/test-utils'
 
 import I18n from '../I18n'

--- a/react/Field/index.spec.js
+++ b/react/Field/index.spec.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Field from './'
+import Field from '.'
 import { shallow } from 'enzyme'
 
 describe('Field component', () => {

--- a/react/FileInput/index.spec.jsx
+++ b/react/FileInput/index.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import uniqueId from 'lodash/uniqueId'
 
-import FileInput from './index'
+import FileInput from '.'
 
 jest.mock('lodash/uniqueId')
 

--- a/react/FilePicker/FilePickerHeader.jsx
+++ b/react/FilePicker/FilePickerHeader.jsx
@@ -12,7 +12,7 @@ import Previous from '../Icons/Previous'
 
 import FilePickerBreadcrumb from './FilePickerBreadcrumb'
 import { buildCurrentFolderQuery } from './queries'
-import { ROOT_DIR_ID } from './index'
+import { ROOT_DIR_ID } from '.'
 
 /**
  * @param {IOCozyFolder} displayedFolder - An io.cozy.files folder

--- a/react/I18n/withLocales.jsx
+++ b/react/I18n/withLocales.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { I18n, translate } from './'
+import { I18n, translate } from '.'
 import omit from 'lodash/omit'
 
 /**

--- a/react/Input/index.spec.jsx
+++ b/react/Input/index.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import Input from './index'
+import Input from '.'
 
 describe('Input component', () => {
   it('should support number type', () => {

--- a/react/Modal/index.spec.jsx
+++ b/react/Modal/index.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { useState } from 'react'
 import { mount } from 'enzyme'
-import Modal, { BODY_CLASS } from './index'
+import Modal, { BODY_CLASS } from '.'
 import { BreakpointsProvider } from '../hooks/useBreakpoints'
 
 describe('Modal', () => {

--- a/react/PieChart/index.spec.jsx
+++ b/react/PieChart/index.spec.jsx
@@ -1,4 +1,4 @@
-import { makeOptions, makeData } from './index'
+import { makeOptions, makeData } from '.'
 
 describe('makeOptions', () => {
   it('should return default options', () => {

--- a/react/Popup/index.spec.jsx
+++ b/react/Popup/index.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 
 import { isMobileApp } from 'cozy-device-helper'
 
-import { Popup } from './'
+import { Popup } from '.'
 
 jest.mock('cozy-device-helper', () => ({
   ...jest.requireActual('cozy-device-helper'),

--- a/react/PushClientButton/index.spec.jsx
+++ b/react/PushClientButton/index.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { render } from '@testing-library/react'
 
-import PushClientButton from './'
+import PushClientButton from '.'
 
 jest.mock('../Icons/DeviceLaptop', () => () => (
   <div data-testid="device-laptop" />

--- a/react/Radio/index.spec.jsx
+++ b/react/Radio/index.spec.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import { render, fireEvent } from '@testing-library/react'
 
-import Radio from './'
+import Radio from '.'
 import RadioGroup from '../RadioGroup'
 import FormControlLabel from '../FormControlLabel'
 

--- a/react/SquareAppIcon/SquareAppIcon.spec.js
+++ b/react/SquareAppIcon/SquareAppIcon.spec.js
@@ -8,7 +8,7 @@ import CozyClient, { CozyProvider } from 'cozy-client'
 import Icon from '../Icon'
 import CozyIcon from '../Icons/Cozy'
 import MuiCozyTheme from '../MuiCozyTheme'
-import SquareAppIcon from './index'
+import SquareAppIcon from '.'
 
 const appMock = {
   slug: 'test',

--- a/react/UploadQueue/index.spec.jsx
+++ b/react/UploadQueue/index.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { UploadQueue, formatRemainingTime } from './index'
+import { UploadQueue, formatRemainingTime } from '.'
 import { render } from '@testing-library/react'
 import { useI18n } from '../I18n'
 

--- a/react/ViewStack/example.jsx
+++ b/react/ViewStack/example.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useViewStack } from './index'
+import { useViewStack } from '.'
 import Button from '../Button'
 
 const PaddedParagraph = ({ children }) => (

--- a/react/ViewStack/index.spec.jsx
+++ b/react/ViewStack/index.spec.jsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { Slide } from './example'
-import ViewStack from './index'
+import ViewStack from '.'
 import Button from '../Button'
 import SwipeableViews from 'react-swipeable-views'
 

--- a/react/Viewer/Viewer.jsx
+++ b/react/Viewer/Viewer.jsx
@@ -5,7 +5,7 @@ import { FileDoctype } from '../proptypes'
 
 import ViewerControls from './components/ViewerControls'
 import ViewerByFile from './components/ViewerByFile'
-import { toolbarPropsPropType } from './index'
+import { toolbarPropsPropType } from '.'
 
 const KEY_CODE_LEFT = 37
 const KEY_CODE_RIGHT = 39

--- a/react/Viewer/ViewerExposer.js
+++ b/react/Viewer/ViewerExposer.js
@@ -1,3 +1,3 @@
-import DefaultViewer from './index'
+import DefaultViewer from '.'
 
 export default DefaultViewer

--- a/react/Viewer/components/ViewerControls.jsx
+++ b/react/Viewer/components/ViewerControls.jsx
@@ -8,7 +8,7 @@ import { withStyles } from '../../styles'
 import withBreakpoints from '../../helpers/withBreakpoints'
 
 import { isValidForPanel } from '../helpers'
-import { toolbarPropsPropType } from '../index'
+import { toolbarPropsPropType } from '..'
 import { infoWidth } from './InformationPanel'
 import Toolbar from './Toolbar'
 import Navigation from './Navigation'

--- a/react/hooks/useConfirmExit/index.spec.js
+++ b/react/hooks/useConfirmExit/index.spec.js
@@ -1,4 +1,4 @@
-import useConfirmExit from './'
+import useConfirmExit from '.'
 import { renderHook, act } from '@testing-library/react-hooks'
 import { isElement } from 'react-dom/test-utils'
 


### PR DESCRIPTION
See #2355.