### PR TITLE
feat: Remove unused component BorderedList

### DIFF
--- a/react/MuiCozyTheme/List/index.js
+++ b/react/MuiCozyTheme/List/index.js
@@ -1,11 +1,3 @@
 import List from '@material-ui/core/List'
 
-import { withStyles } from '../../styles'
-
-export const BorderedList = withStyles({
-  root: {
-    borderTop: '1px solid var(--silver)'
-  }
-})(List)
-
 export default List


### PR DESCRIPTION
During my exploration about List and ListItem, I found this BorderedList which seems to be unused. Nothing found locally in `cozy-ui` with vscode, nothing found at an org level in GitHub.