### PR TITLE
fix: ImageViewer crashes when render are too fast

### DIFF
--- a/react/Viewer/ViewersByFile/ImageViewer.jsx
+++ b/react/Viewer/ViewersByFile/ImageViewer.jsx
@@ -85,14 +85,16 @@ class ImageViewer extends Component {
   }
 
   tearDownGestures() {
-    this.gestures.off('swipe')
-    this.gestures.on('swipe', this.props.onSwipe)
-    this.gestures.off('panstart')
-    this.gestures.off('pinchstart')
-    this.gestures.off('pinchend')
-    this.gestures.off('pan')
-    this.gestures.off('pinch')
-    this.gestures.off('panend')
+    if (this.gestures) {
+      this.gestures.off('swipe')
+      this.gestures.on('swipe', this.props.onSwipe)
+      this.gestures.off('panstart')
+      this.gestures.off('pinchstart')
+      this.gestures.off('pinchend')
+      this.gestures.off('pan')
+      this.gestures.off('pinch')
+      this.gestures.off('panend')
+    }
   }
 
   onSwipe = e => {


### PR DESCRIPTION
The problem has been encountered when updating a page is too fast for example with an useQuery. Each time thee ImageViewer is unmounted, we also teardown all the gestures. The imageViewer crashes because the Gesture object have not yet been defined. This fix checks if Gesture exists before calling any functions on it.
