### PR TITLE
ListItem by doctype

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:doc:kss": "kss --destination build/styleguide --title 'Cozy-UI Styleguide' --source stylus --builder node_modules/michelangelo/kss_styleguide/custom-template --homepage stylus/styleguide.md --css app.css",
     "build:doc:react": "styleguidist build --config docs/styleguide.config.js",
     "build:types": "tsc -p tsconfig-build.json",
+    "build:all": "yarn makeSpriteAndPalette && yarn build && yarn build:css:all && yarn build:doc",
     "build": "yarn build:types && env BABEL_ENV=transpilation babel --extensions .ts,.tsx,.js,.jsx react/ --out-dir transpiled/react --verbose",
     "clean:doc:kss": "rm -rf build/styleguide",
     "deploy:doc": "git-directory-deploy --directory build/ --branch gh-pages",

--- a/react/MuiCozyTheme/List/Readme.md
+++ b/react/MuiCozyTheme/List/Readme.md
@@ -134,34 +134,33 @@ const initialVariants = [{ dense: false, }]
               <Icon icon={CommentIcon} />
             </ListItemIcon>
             <ListItemText primary="Support" />
-            {state.showMenu && (
-              <ActionMenu
-                anchorElRef={anchorRef}
-                autoclose
-                onClose={hideMenu}
-              >
-                <ActionMenuItem left={<Icon icon={FileIcon} />}>
-                  <Typography variant="body1" gutterBottom>
-                    Item 1
-                  </Typography>
-                  <Typography variant="caption" color="textSecondary">
-                    Descriptive text to elaborate on what item 3 does.
-                  </Typography>
-                </ActionMenuItem>
-                <ActionMenuItem left={<Icon icon={FileIcon} />}>
-                  <Typography variant="body1" gutterBottom>
-                    Item 2
-                  </Typography>
-                </ActionMenuItem>
-              </ActionMenu>
-            )}
             <ListItemSecondaryAction>
               <IconButton ref={anchorRef} onClick={toggleMenu}>
                 <Icon icon={DotsIcon} />
               </IconButton>
             </ListItemSecondaryAction>
           </ListItem>
-
+          {state.showMenu && (
+            <ActionMenu
+              anchorElRef={anchorRef}
+              autoclose
+              onClose={hideMenu}
+            >
+              <ActionMenuItem left={<Icon icon={FileIcon} />}>
+                <Typography variant="body1" gutterBottom>
+                  Item 1
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                  Descriptive text to elaborate on what item 3 does.
+                </Typography>
+              </ActionMenuItem>
+              <ActionMenuItem left={<Icon icon={FileIcon} />}>
+                <Typography variant="body1" gutterBottom>
+                  Item 2
+                </Typography>
+              </ActionMenuItem>
+            </ActionMenu>
+          )}
           <Divider component="li" variant="inset" />
 
           <ListItem button>
@@ -272,4 +271,96 @@ import FiletypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
     <ListItemText primary="I'm a primary text" />
   </ListItem>
 </List>
+```
+
+### Contextualized item
+
+```jsx
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListItemContact from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem/ListItemContact'
+import ListItemFile from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem/ListItemFile'
+import ListItemByDoc from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem/ListItemByDoc'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import FiletypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
+import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
+
+const mockClient = {
+  plugins: {
+    realtime: {
+      subscribe: () => {},
+      unsubscribe: () => {},
+      unsubscribeAll: () => {}
+    }
+  }
+}
+
+const contacts = [
+  {
+    _type: 'io.cozy.contacts',
+    displayName: 'John Doe',
+    birthday: '25/10/2022',
+    email: [{ address: 'johndoe@cozy.cc', primary: true }]
+  },
+  {
+    _type: 'io.cozy.contacts',
+    displayName: 'Jason Bourne',
+    birthday: '01/01/2020',
+    email: [{ address: 'jbourne@cozy.cc', primary: true }]
+  }
+]
+
+const files = [
+  {
+    _type: 'io.cozy.files',
+    name: 'File01.pdf',
+    metadata: {
+      number: 12345,
+      qualification: {
+        label: 'driver_license'
+      }
+    }
+  }
+]
+
+;
+
+<DemoProvider mockClient={mockClient}>
+  <List>
+    <ListItem button>
+      <ListItemIcon>
+        <Icon icon={FiletypeTextIcon} width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primary="I'm a standard item" />
+    </ListItem>
+    <Divider variant="inset" />
+    <ListItemByDoc
+      doc={contacts[0]}
+      expandedAttributesProps={{ isExpandedAttributesActive: true, expandedAttributes: ['email', 'birthday'] }}
+      onClick={() => {}}
+    />
+    <Divider variant="inset" />
+    <ListItemByDoc
+      doc={contacts[1]}
+      onClick={() => {}}
+    />
+    <Divider variant="inset" />
+    <ListItemByDoc
+      doc={files[0]}
+      expandedAttributesProps={{ isExpandedAttributesActive: true, expandedAttributes: ['metadata.number'] }}
+      onClick={() => {}}
+    />
+    <Divider variant="inset" />
+    <ListItem button>
+      <ListItemIcon>
+        <Icon icon={FiletypeTextIcon} width="32" height="32" />
+      </ListItemIcon>
+      <ListItemText primary="I'm a standard item" />
+    </ListItem>
+  </List>
+</DemoProvider>
 ```

--- a/react/MuiCozyTheme/ListItem/ExpandedAttributes/ExpandedAttribute.jsx
+++ b/react/MuiCozyTheme/ListItem/ExpandedAttributes/ExpandedAttribute.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ListItem from '../../ListItem'
+import ListItemText from '../../../ListItemText'
+import ListItemIcon from '../../ListItemIcon'
+import Typography from '../../../Typography'
+import Icon from '../../../Icon'
+import CopyIcon from '../../../Icons/Copy'
+import { useI18n } from '../../../I18n'
+import { copyToClipboard } from './helpers'
+
+const ExpandedAttribute = ({ label, value, setAlertProps }) => {
+  const { t } = useI18n()
+
+  return (
+    <ListItem
+      className="u-pl-2"
+      button
+      onClick={copyToClipboard({ value, setAlertProps, t })}
+    >
+      <ListItemIcon>
+        <Icon icon={CopyIcon} />
+      </ListItemIcon>
+      <ListItemText
+        primary={<Typography variant="caption">{label}</Typography>}
+        secondary={<Typography variant="body1">{value}</Typography>}
+      />
+    </ListItem>
+  )
+}
+
+ExpandedAttribute.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  setAlertProps: PropTypes.func
+}
+
+export default ExpandedAttribute

--- a/react/MuiCozyTheme/ListItem/ExpandedAttributes/helpers.js
+++ b/react/MuiCozyTheme/ListItem/ExpandedAttributes/helpers.js
@@ -1,0 +1,139 @@
+import get from 'lodash/get'
+
+import { formatDate } from '../../../Viewer/helpers'
+
+export const normalizeExpandedAttribute = attr => attr.split('[]')[0]
+
+// attributes not considered as expanded attributes
+export const notExpandedAttributes = {
+  'io.cozy.contacts': ['fullname', 'civility', 'note'],
+  'io.cozy.files': ['name', 'flexsearchProps:translatedQualificationLabel']
+}
+
+// attributes that we want to display if no attribute of the document is related to the search
+export const defaultExpandedAttributes = {
+  'io.cozy.contacts': ['email', 'phone', 'address', 'birthday'],
+  'io.cozy.files': [
+    'metadata.number',
+    'metadata.cafFileNumber',
+    'metadata.cardNumber',
+    'metadata.vinNumber',
+    'metadata.ibanNumber',
+    'metadata.passportNumber',
+    'metadata.noticePeriod',
+    'metadata.AObtentionDate',
+    'metadata.BObtentionDate',
+    'metadata.CObtentionDate',
+    'metadata.DObtentionDate',
+    'metadata.obtentionDate',
+    'metadata.referencedDate',
+    'metadata.issueDate',
+    'metadata.shootingDate',
+    'metadata.date',
+    'metadata.datetime',
+    'metadata.expirationDate',
+    'metadata.country',
+    'metadata.refTaxIncome',
+    'metadata.contractType'
+  ]
+}
+
+export const hasAllElement = (arr1, arr2) => arr1.every(x => arr2.includes(x))
+
+export const makeDefaultExpandedAttributes = (doc, expandedAttributes) => {
+  const doctype = doc?._type
+
+  if (!expandedAttributes || !doc || !doctype) return undefined
+
+  // checks if there are any expanded attributes.
+  // If there are none, the default expanded attributes are returned
+  if (hasAllElement(expandedAttributes, notExpandedAttributes[doctype])) {
+    return defaultExpandedAttributes[doctype]
+  }
+
+  return expandedAttributes
+    .map(expandedAttribute =>
+      notExpandedAttributes[doctype].includes(expandedAttribute)
+        ? undefined
+        : normalizeExpandedAttribute(expandedAttribute)
+    )
+    .filter(x => x)
+}
+
+export const copyToClipboard = ({ value, setAlertProps, t }) => () => {
+  if (navigator?.clipboard) {
+    navigator.clipboard.writeText(value)
+
+    setAlertProps({
+      open: true,
+      severity: 'success',
+      message: t(`ListItem.snackbar.copyToClipboard.success`)
+    })
+  } else {
+    setAlertProps({
+      open: true,
+      severity: 'error',
+      message: t(`Viewer.snackbar.copyToClipboard.error`)
+    })
+  }
+}
+
+export const isDate = value => {
+  const dateTime = new Date(value).getTime()
+  const dateParsedValue = Date.parse(value)
+
+  return dateTime === dateParsedValue
+}
+
+export const formatAttrValue = ({ attribute, attrValue, f, lang }) => {
+  if (!attrValue || attrValue.length === 0) return undefined
+
+  switch (true) {
+    case isDate(attrValue):
+      return formatDate({ f, lang, date: attrValue })
+
+    case attribute === 'email':
+      return attrValue.find(x => x.primary === true)?.address
+
+    case attribute === 'address':
+      return attrValue.find(x => x.primary === true)?.formattedAddress
+
+    case attribute === 'phone':
+      return attrValue.find(x => x.primary === true)?.number
+
+    default:
+      return attrValue
+  }
+}
+
+export const makeAttrsKeyAndFormatedValue = ({
+  doc,
+  expandedAttributes,
+  f,
+  lang
+}) => {
+  const attrsKeyAndFormatedValue = expandedAttributes
+    .map(expandedAttribute => {
+      const attrValue = get(doc, expandedAttribute)
+
+      const attrFormatedValue = formatAttrValue({
+        attribute: expandedAttribute,
+        attrValue,
+        f,
+        lang
+      })
+
+      if (!attrFormatedValue) return undefined
+
+      const attrKey =
+        expandedAttribute === 'metadata.number'
+          ? `${expandedAttribute}.${doc.metadata.qualification.label}`
+          : expandedAttribute
+
+      return { attrKey, attrFormatedValue }
+    })
+    .filter(x => x)
+    .slice(0, 3)
+
+  return attrsKeyAndFormatedValue
+}

--- a/react/MuiCozyTheme/ListItem/ExpandedAttributes/helpers.spec.js
+++ b/react/MuiCozyTheme/ListItem/ExpandedAttributes/helpers.spec.js
@@ -1,0 +1,97 @@
+import { formatAttrValue } from './helpers'
+
+const f = () => 'someMockedDate'
+const lang = 'en'
+
+describe('formatAttrValue', () => {
+  it('should return primary formattedAddress from addresses', () => {
+    const res = formatAttrValue({
+      attribute: 'address',
+      attrValue: [{ formattedAddress: '2 rue des coquelicots', primary: true }],
+      f,
+      lang
+    })
+
+    expect(res).toBe('2 rue des coquelicots')
+  })
+
+  it('should return undefined if no primary address', () => {
+    const res = formatAttrValue({
+      attribute: 'address',
+      attrValue: [{ formattedAddress: '2 rue des coquelicots' }],
+      f,
+      lang
+    })
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should return primary address from emails', () => {
+    const res = formatAttrValue({
+      attribute: 'email',
+      attrValue: [
+        { address: 'primary@cozycloud.cc', primary: true },
+        { address: 'secondary@cozycloud.cc', primary: false }
+      ],
+      f,
+      lang
+    })
+
+    expect(res).toBe('primary@cozycloud.cc')
+  })
+
+  it('should return undefined if no primary email', () => {
+    const res = formatAttrValue({
+      attribute: 'email',
+      attrValue: [{ address: 'secondary@cozycloud.cc' }],
+      f,
+      lang
+    })
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should return primary number from phones', () => {
+    const res = formatAttrValue({
+      attribute: 'phone',
+      attrValue: [{ number: '06 15 64 47 63', primary: true }],
+      f,
+      lang
+    })
+
+    expect(res).toBe('06 15 64 47 63')
+  })
+
+  it('should return undefined if no primary phone', () => {
+    const res = formatAttrValue({
+      attribute: 'phone',
+      attrValue: [{ number: '06 15 64 47 63', primary: false }],
+      f,
+      lang
+    })
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should return a number for a number value', () => {
+    const res = formatAttrValue({
+      attribute: 'metadata.number',
+      attrValue: 12345,
+      f,
+      lang
+    })
+
+    expect(res).toBe(12345)
+  })
+
+  it('should return a date for an ISO string formated date', () => {
+    const res = formatAttrValue({
+      attribute: 'metadata.date',
+      attrValue: '2023-03-08T12:48:18.000Z',
+      f,
+      lang
+    })
+
+    expect(res).toBe('someMockedDate')
+  })
+})

--- a/react/MuiCozyTheme/ListItem/ExpandedAttributes/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ExpandedAttributes/index.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+import Snackbar from '../../../Snackbar'
+import Alert from '../../../Alert'
+import { withListItemLocales } from '../hoc/withListItemLocales'
+import ExpandedAttribute from './ExpandedAttribute'
+import { useI18n } from '../../../I18n'
+import { makeAttrsKeyAndFormatedValue } from './helpers'
+
+const ExpandedAttributes = ({ doc, expandedAttributes }) => {
+  const { t, f, lang } = useI18n()
+  const [alertProps, setAlertProps] = useState({
+    open: false,
+    severity: 'primary',
+    message: ''
+  })
+
+  const attrsKeyAndFormatedValue = makeAttrsKeyAndFormatedValue({
+    doc,
+    expandedAttributes,
+    f,
+    lang
+  })
+
+  const handleClose = () => setAlertProps({ open: false })
+
+  return (
+    <>
+      {attrsKeyAndFormatedValue.map(({ attrKey, attrFormatedValue }, index) => {
+        const label = t(`ListItem.attributes.${attrKey}`)
+
+        return (
+          <ExpandedAttribute
+            key={index}
+            label={label}
+            value={attrFormatedValue}
+            setAlertProps={setAlertProps}
+          />
+        )
+      })}
+      {alertProps.open && (
+        <Snackbar open onClose={handleClose}>
+          <Alert
+            variant="filled"
+            severity={alertProps.severity}
+            onClose={handleClose}
+          >
+            {alertProps.message}
+          </Alert>
+        </Snackbar>
+      )}
+    </>
+  )
+}
+
+ExpandedAttributes.propTypes = {
+  doc: PropTypes.object,
+  expandedAttributes: PropTypes.array
+}
+
+export default withListItemLocales(ExpandedAttributes)

--- a/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/ActionMenuWithClose.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/ActionMenuWithClose.jsx
@@ -1,0 +1,28 @@
+import React, {
+  forwardRef,
+  isValidElement,
+  cloneElement,
+  Children
+} from 'react'
+
+import ActionMenu from '../../../../ActionMenu'
+
+/**
+ * Add onClose method on every children, to close the menu when clicking them
+ */
+const ActionMenuWithClose = forwardRef(({ onClose, children }, ref) => {
+  return (
+    <ActionMenu anchorElRef={ref} onClose={onClose}>
+      {Children.map(children, child => {
+        if (isValidElement(child)) {
+          return cloneElement(child, { onClose })
+        }
+        return null
+      })}
+    </ActionMenu>
+  )
+})
+
+ActionMenuWithClose.displayName = 'ActionMenuWithClose'
+
+export default ActionMenuWithClose

--- a/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/ActionsItems.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/ActionsItems.jsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from '../../../../I18n'
+import { getActionName, getOnlyNeededActions } from './helpers'
+
+const ActionsItems = ({ doc, actions, isLast, setIsRenaming, onClose }) => {
+  const { t } = useI18n()
+  const cleanedActions = useMemo(() => getOnlyNeededActions(actions, doc), [
+    actions,
+    doc
+  ])
+
+  return cleanedActions.map((actionObject, idx) => {
+    const actionName = getActionName(actionObject)
+    const actionDefinition = Object.values(actionObject)[0]
+
+    const { Component, action, isEnabled } = actionDefinition
+
+    const onClick = () => {
+      action && action([doc], t, isLast)
+      actionName === 'rename' && setIsRenaming(true)
+      onClose && onClose()
+    }
+
+    return (
+      <Component
+        key={actionName + idx}
+        className="u-flex-items-center"
+        isEnabled={isEnabled}
+        docs={doc ? [doc] : []}
+        onClick={onClick}
+      />
+    )
+  })
+}
+
+ActionsItems.propTypes = {
+  doc: PropTypes.object,
+  actions: PropTypes.array,
+  isLast: PropTypes.bool,
+  setIsRenaming: PropTypes.func,
+  onClose: PropTypes.func
+}
+
+export default ActionsItems

--- a/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/helpers.js
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/helpers.js
@@ -1,0 +1,63 @@
+/**
+ * Make array of actions for ActionsItems component
+ *
+ * @param {Function[]} actionCreators - Array of function to create ActionMenuItem components with associated actions and conditions
+ * @param {object} actionOptions - Options that need to be passed on Actions
+ * @returns {object[]} Array of actions
+ */
+export const makeActions = (actionCreators = [], actionOptions = {}) => {
+  return actionCreators.map(createAction => {
+    const actionMenu = createAction(actionOptions)
+    const name = actionMenu.name || createAction.name
+
+    return { [name]: actionMenu }
+  })
+}
+
+export const getActionName = actionObject => {
+  return Object.keys(actionObject)[0]
+}
+
+// We need to clean Actions since action has a displayable
+// conditions and we can't know from the begining what the
+// behavior will be. For instance, we can't know that
+// hr will be the latest action in the sharing views for a
+// folder.
+// Or we can't know that we'll have two following hr if the
+// display condition for the actions between are true or false
+export const getOnlyNeededActions = (actions, file) => {
+  let previousAction = ''
+  const displayableActions = actions.filter(actionObject => {
+    const actionDefinition = Object.values(actionObject)[0]
+
+    return (
+      !actionDefinition.displayCondition ||
+      actionDefinition.displayCondition([file])
+    )
+  })
+
+  return (
+    displayableActions
+      // We do not want to display the same 2 actions in a row
+      .map(actionObject => {
+        const actionName = getActionName(actionObject)
+
+        if (previousAction === actionName) {
+          previousAction = actionName
+          return null
+        } else {
+          previousAction = actionName
+        }
+
+        return actionObject
+      })
+      .filter(Boolean)
+      // We don't want to have an hr as the latest actions available
+      .filter((cleanedAction, idx, cleanedActions) => {
+        return !(
+          getActionName(cleanedAction) === 'hr' &&
+          idx === cleanedActions.length - 1
+        )
+      })
+  )
+}

--- a/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/helpers.spec.js
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/ActionsMenu/helpers.spec.js
@@ -1,0 +1,36 @@
+import { makeActions } from './helpers'
+
+describe('makeActions', () => {
+  it('should have empty actions array', () => {
+    const actions = makeActions()
+
+    expect(actions).toStrictEqual([])
+  })
+
+  it('should have object with key named with name property of the object returned by the function and value is the full object returned by the function', () => {
+    const mockFuncActionWithName = jest.fn(() => ({
+      name: 'mockFuncActionWithName name'
+    }))
+
+    const actions = makeActions([mockFuncActionWithName])
+
+    expect(actions).toStrictEqual([
+      {
+        'mockFuncActionWithName name': {
+          name: 'mockFuncActionWithName name'
+        }
+      }
+    ])
+  })
+
+  it('should have object with key named with name of function passed and value is the full object returned by the function', () => {
+    const mockFuncActionWithoutName = jest.fn(() => ({
+      propA: 0,
+      propB: 1
+    }))
+
+    const actions = makeActions([mockFuncActionWithoutName])
+
+    expect(actions).toStrictEqual([{ mockConstructor: { propA: 0, propB: 1 } }])
+  })
+})

--- a/react/MuiCozyTheme/ListItem/ListItemBase/Renaming/RenameDialog.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/Renaming/RenameDialog.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Button from '../../../../Buttons'
+import { ConfirmDialog } from '../../../../CozyDialogs'
+import { useI18n } from '../../../../I18n'
+
+import { withListItemLocales } from '../../hoc/withListItemLocales'
+
+const RenameDialog = ({ onSubmit, onCancel }) => {
+  const { t } = useI18n()
+
+  return (
+    <ConfirmDialog
+      open
+      title={t('ListItem.renameModal.title')}
+      content={t('ListItem.renameModal.content')}
+      actions={
+        <>
+          <Button
+            variant="secondary"
+            label={t('ListItem.renameModal.cancel')}
+            onClick={onCancel}
+          />
+          <Button label={t('ListItem.renameModal.submit')} onClick={onSubmit} />
+        </>
+      }
+      onClose={onCancel}
+    />
+  )
+}
+
+RenameDialog.propTypes = {
+  onSubmit: PropTypes.func,
+  onCancel: PropTypes.func
+}
+
+export default withListItemLocales(RenameDialog)

--- a/react/MuiCozyTheme/ListItem/ListItemBase/Renaming/RenameInput.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/Renaming/RenameInput.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useReducer, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+import { splitFilename } from 'cozy-client/dist/models/file'
+
+import { makeStyles } from '../../../../styles'
+import Input from '../../../../Input'
+import InputGroup from '../../../../InputGroup'
+import Spinner from '../../../../Spinner'
+import RenameDialog from './RenameDialog'
+import { renameFile } from './helpers'
+
+const KEYS = {
+  ESCAPE: 'Escape',
+  ENTER: 'Enter'
+}
+
+const useStyles = makeStyles({
+  inputGroup: {
+    maxWidth: 'none',
+    height: '2rem',
+    margin: '1rem 1rem 1rem 0',
+    '& > div': {
+      display: 'flex'
+    },
+    '& input': {
+      maxWidth: 'none',
+      padding: '.3125rem'
+    }
+  },
+  spinner: {
+    margin: '.4375rem'
+  }
+})
+
+const RenameInput = ({ file, onClose }) => {
+  const client = useClient()
+  const styles = useStyles()
+  const textInput = useRef()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
+  const [isModalOpened, setIsModalOpened] = useState(false)
+  const defaultValue = file.name
+
+  const handleKeyDown = async event => {
+    if (event.key === KEYS.ENTER) {
+      await check()
+    } else if (event.key === KEYS.ESCAPE) {
+      await cancel()
+    }
+  }
+
+  const handleBlur = async () => {
+    // On top of "normal" blurs, the event happens all the time after a submit or a cancel, because this component is removed from the DOM while having the focus.
+    // we want to do things only on "normal" blurs, *not* after a cancel
+    if (!isModalOpened && !isBusy) {
+      await check()
+    }
+  }
+
+  const check = async () => {
+    const { value } = textInput.current
+    if (value === '' || value === '.' || value === '..') {
+      await submit()
+      return
+    }
+    const oldExtension = splitFilename({
+      name: defaultValue,
+      type: 'file'
+    }).extension
+    const newExtension = splitFilename({
+      name: value,
+      type: 'file'
+    }).extension
+    if (oldExtension === newExtension) {
+      await submit()
+      return
+    }
+    setIsModalOpened(true)
+  }
+
+  const submit = async () => {
+    const { value } = textInput.current
+    await close(value)
+  }
+
+  const cancel = async () => {
+    await close(defaultValue)
+  }
+
+  const close = async value => {
+    toggleBusy()
+    if (value !== defaultValue) {
+      await renameFile(client, file, value)
+    }
+    onClose()
+  }
+
+  useEffect(() => {
+    const { length } = splitFilename({
+      name: defaultValue,
+      type: 'file'
+    }).filename
+    textInput.current.setSelectionRange(0, length)
+  }, [defaultValue])
+
+  return (
+    <InputGroup className={styles.inputGroup}>
+      <Input
+        ref={textInput}
+        type="text"
+        defaultValue={defaultValue}
+        autoFocus
+        disabled={isModalOpened || isBusy}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+      {(isModalOpened || isBusy) && <Spinner className={styles.spinner} />}
+      {isModalOpened && <RenameDialog onSubmit={submit} onCancel={cancel} />}
+    </InputGroup>
+  )
+}
+
+RenameInput.propTypes = {
+  file: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired
+}
+
+export default RenameInput

--- a/react/MuiCozyTheme/ListItem/ListItemBase/Renaming/helpers.js
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/Renaming/helpers.js
@@ -1,0 +1,35 @@
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
+
+export const renameFile = async (client, file, name) => {
+  try {
+    return await client.save({
+      ...file,
+      name
+    })
+  } catch (error) {
+    if (error.message.includes('Missing name argument')) {
+      Alerter.error('RenameInput.filenameMissing')
+    } else if (error.message.includes('Invalid filename:')) {
+      Alerter.error('RenameInput.filenameIllegalName', {
+        name
+      })
+    } else if (
+      error.message.includes(
+        'Invalid filename containing illegal character(s):'
+      )
+    ) {
+      Alerter.error(
+        'RenameInput.filenameIllegalCharacters',
+        {
+          name,
+          characters: error.message.split(
+            'Invalid filename containing illegal character(s): '
+          )[1]
+        },
+        { duration: 2000 }
+      )
+    } else {
+      Alerter.error('RenameInput.fileExisting', { name })
+    }
+  }
+}

--- a/react/MuiCozyTheme/ListItem/ListItemBase/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemBase/index.jsx
@@ -1,0 +1,109 @@
+import React, { useState, useRef } from 'react'
+import PropTypes from 'prop-types'
+
+import ListItem from '..'
+import ListItemText from '../../../ListItemText'
+import ListItemIcon from '../../ListItemIcon'
+import ListItemSecondaryAction from '../../ListItemSecondaryAction'
+import IconButton from '../../../IconButton'
+import Icon from '../../../Icon'
+import DotsIcon from '../../../Icons/Dots'
+import ExpandedAttributes from '../ExpandedAttributes'
+import ActionMenuWithClose from './ActionsMenu/ActionMenuWithClose'
+import { ActionMenuHeader } from '../../../ActionMenu'
+import ActionsItems from './ActionsMenu/ActionsItems'
+import useBreakpoints from '../../../hooks/useBreakpoints'
+import RenameInput from './Renaming/RenameInput'
+import { withListItemLocales } from '../hoc/withListItemLocales'
+import Checkbox from '../../../Checkbox'
+
+const ListItemBase = ({
+  doc,
+  primary,
+  secondary,
+  icon,
+  actions,
+  actionMenuComp,
+  expandedAttributesProps: { isExpandedAttributesActive, expandedAttributes },
+  selectProps: { isSelectActive, isSelected, isChecked },
+  onClick
+}) => {
+  const [showActionMenu, setShowActionMenu] = useState(false)
+  const [isRenaming, setIsRenaming] = useState(false)
+  const anchorRef = useRef()
+  const { isMobile } = useBreakpoints()
+
+  const showActionMenuHeader = isMobile && actionMenuComp?.Header
+  const isButton = !isRenaming && !!onClick
+  const handleClick =
+    !isRenaming && !isSelected && onClick ? onClick : undefined
+
+  return (
+    <>
+      <ListItem button={isButton} disabled={isSelected} onClick={handleClick}>
+        {isSelectActive && (
+          <Checkbox
+            className="u-p-0"
+            value={doc._id}
+            checked={isChecked}
+            disabled={isSelected}
+          />
+        )}
+        <ListItemIcon>{icon}</ListItemIcon>
+        {isRenaming ? (
+          <RenameInput file={doc} onClose={() => setIsRenaming(false)} />
+        ) : (
+          <ListItemText primary={primary} secondary={secondary} />
+        )}
+        {actions && !isSelectActive && (
+          <ListItemSecondaryAction>
+            <IconButton ref={anchorRef} onClick={() => setShowActionMenu(true)}>
+              <Icon icon={DotsIcon} />
+            </IconButton>
+          </ListItemSecondaryAction>
+        )}
+      </ListItem>
+      {isExpandedAttributesActive && (
+        <ExpandedAttributes doc={doc} expandedAttributes={expandedAttributes} />
+      )}
+      {showActionMenu && (
+        <ActionMenuWithClose
+          ref={anchorRef}
+          onClose={() => setShowActionMenu(false)}
+        >
+          {showActionMenuHeader && (
+            <ActionMenuHeader>{actionMenuComp.Header}</ActionMenuHeader>
+          )}
+          <ActionsItems
+            doc={doc}
+            actions={actions}
+            setIsRenaming={setIsRenaming}
+          />
+        </ActionMenuWithClose>
+      )}
+    </>
+  )
+}
+
+ListItemBase.propTypes = {
+  doc: PropTypes.object,
+  primary: PropTypes.node,
+  secondary: PropTypes.node,
+  icon: PropTypes.node,
+  actions: PropTypes.array,
+  actionMenuComp: PropTypes.shape({
+    Header: PropTypes.node
+  }),
+  selectProps: PropTypes.shape({
+    isSelectActive: PropTypes.bool,
+    isSelected: PropTypes.bool,
+    isChecked: PropTypes.bool
+  }),
+  expandedAttributesProps: PropTypes.shape({
+    isExpandedAttributesActive: PropTypes.bool,
+    expandedAttributes: PropTypes.array
+  }),
+  onClick: PropTypes.func
+}
+
+export default withListItemLocales(ListItemBase)

--- a/react/MuiCozyTheme/ListItem/ListItemByDoc/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemByDoc/index.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ListItemFile from '../ListItemFile'
+import ListItemContact from '../ListItemContact'
+
+const ListItemByDoc = ({
+  doc,
+  primary,
+  secondary,
+  icon,
+  actions,
+  selectProps,
+  expandedAttributesProps,
+  onClick
+}) => {
+  switch (true) {
+    case doc._type === 'io.cozy.contacts':
+      return (
+        <ListItemContact
+          contact={doc}
+          primary={primary}
+          secondary={secondary}
+          icon={icon}
+          actions={actions}
+          selectProps={selectProps}
+          expandedAttributesProps={expandedAttributesProps}
+          onClick={onClick}
+        />
+      )
+
+    case doc._type === 'io.cozy.files':
+      return (
+        <ListItemFile
+          file={doc}
+          primary={primary}
+          secondary={secondary}
+          icon={icon}
+          actions={actions}
+          selectProps={selectProps}
+          expandedAttributesProps={expandedAttributesProps}
+          onClick={onClick}
+        />
+      )
+
+    default:
+      return (
+        <ListItemFile
+          file={doc}
+          primary={primary}
+          secondary={secondary}
+          icon={icon}
+          actions={actions}
+          selectProps={selectProps}
+          expandedAttributesProps={expandedAttributesProps}
+          onClick={onClick}
+        />
+      )
+  }
+}
+
+ListItemByDoc.defaultProps = {
+  selectProps: { isSelectActive: false, isSelected: false, isChecked: false },
+  expandedAttributesProps: {
+    isExpandedAttributesActive: false
+  }
+}
+
+ListItemByDoc.propTypes = {
+  doc: PropTypes.object,
+  primary: PropTypes.node,
+  secondary: PropTypes.node,
+  icon: PropTypes.node,
+  actions: PropTypes.array,
+  selectProps: PropTypes.shape({
+    isSelectActive: PropTypes.bool,
+    isSelected: PropTypes.bool,
+    isChecked: PropTypes.bool
+  }),
+  expandedAttributesProps: PropTypes.shape({
+    isExpandedAttributesActive: PropTypes.bool,
+    expandedAttributes: PropTypes.array
+  }),
+  onClick: PropTypes.func
+}
+
+export default ListItemByDoc

--- a/react/MuiCozyTheme/ListItem/ListItemByDoc/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemByDoc/index.jsx
@@ -14,8 +14,8 @@ const ListItemByDoc = ({
   expandedAttributesProps,
   onClick
 }) => {
-  switch (true) {
-    case doc._type === 'io.cozy.contacts':
+  switch (doc._type) {
+    case 'io.cozy.contacts':
       return (
         <ListItemContact
           contact={doc}
@@ -29,7 +29,7 @@ const ListItemByDoc = ({
         />
       )
 
-    case doc._type === 'io.cozy.files':
+    case 'io.cozy.files':
       return (
         <ListItemFile
           file={doc}

--- a/react/MuiCozyTheme/ListItem/ListItemContact/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemContact/index.jsx
@@ -18,7 +18,7 @@ const ListItemContact = ({
   onClick
 }) => {
   const primaryText = primary || contact.displayName
-  const secondaryText = secondary || contact.email[0].address
+  const secondaryText = secondary || contact.email?.[0]?.address
   const itemIcon = icon || <Icon icon={ContactsIcon} width="32" height="32" />
 
   const itemExpandedAttributes = makeDefaultExpandedAttributes(

--- a/react/MuiCozyTheme/ListItem/ListItemContact/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemContact/index.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Icon from '../../../Icon'
+import ContactsIcon from '../../../Icons/Contacts'
+import ListItemBase from '../ListItemBase'
+
+import { makeDefaultExpandedAttributes } from '../ExpandedAttributes/helpers'
+
+const ListItemContact = ({
+  contact,
+  primary,
+  secondary,
+  icon,
+  actions,
+  selectProps,
+  expandedAttributesProps: { isExpandedAttributesActive, expandedAttributes },
+  onClick
+}) => {
+  const primaryText = primary || contact.displayName
+  const secondaryText = secondary || contact.email[0].address
+  const itemIcon = icon || <Icon icon={ContactsIcon} width="32" height="32" />
+
+  const itemExpandedAttributes = makeDefaultExpandedAttributes(
+    contact,
+    expandedAttributes
+  )
+
+  return (
+    <ListItemBase
+      doc={contact}
+      primary={primaryText}
+      secondary={secondaryText}
+      icon={itemIcon}
+      actions={actions}
+      selectProps={selectProps}
+      expandedAttributesProps={{
+        isExpandedAttributesActive,
+        expandedAttributes: itemExpandedAttributes
+      }}
+      onClick={onClick}
+    />
+  )
+}
+
+ListItemContact.defaultProps = {
+  expandedAttributesProps: {
+    isExpandedAttributesActive: false
+  }
+}
+
+ListItemContact.propTypes = {
+  contact: PropTypes.object,
+  primary: PropTypes.node,
+  secondary: PropTypes.node,
+  icon: PropTypes.node,
+  actions: PropTypes.array,
+  selectProps: PropTypes.shape({
+    isSelectActive: PropTypes.bool,
+    isSelected: PropTypes.bool,
+    isChecked: PropTypes.bool
+  }),
+  expandedAttributesProps: PropTypes.shape({
+    isExpandedAttributesActive: PropTypes.bool,
+    expandedAttributes: PropTypes.array
+  }),
+  onClick: PropTypes.func
+}
+
+export default ListItemContact

--- a/react/MuiCozyTheme/ListItem/ListItemFile/ExpirationAnnotation.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemFile/ExpirationAnnotation.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { computeExpirationDate, isExpired } from 'cozy-client/dist/models/paper'
+
+import Typography from '../../../Typography'
+import { useI18n } from '../../../I18n'
+import { formatLocallyDistanceToNowStrict } from '../../../I18n/format'
+import { withListItemLocales } from '../hoc/withListItemLocales'
+
+const ExpirationAnnotation = ({ file }) => {
+  const { t } = useI18n()
+
+  if (isExpired(file)) {
+    return (
+      <Typography component="span" variant="inherit" color="error">
+        {t('ListItem.file.expired')}
+      </Typography>
+    )
+  }
+
+  const expirationDate = computeExpirationDate(file)
+
+  return (
+    <Typography component="span" variant="inherit" className="u-warning">
+      {t('ListItem.file.expiresIn', {
+        duration: formatLocallyDistanceToNowStrict(expirationDate)
+      })}
+    </Typography>
+  )
+}
+
+ExpirationAnnotation.propTypes = {
+  file: PropTypes.object.isRequired
+}
+
+export default withListItemLocales(ExpirationAnnotation)

--- a/react/MuiCozyTheme/ListItem/ListItemFile/ItemIcon.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemFile/ItemIcon.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+
+import Icon from '../../../Icon'
+import FileImageLoader from '../../../FileImageLoader'
+import CardMedia from '../../../CardMedia'
+import FiletypeTextIcon from '../../../Icons/FileTypeText'
+
+const ItemIcon = ({ icon, file }) => {
+  const client = useClient()
+
+  if (icon) return icon
+
+  return (
+    <FileImageLoader
+      client={client}
+      file={file}
+      linkType="tiny"
+      render={src => {
+        return <CardMedia component="img" width={32} height={32} image={src} />
+      }}
+      renderFallback={() => <Icon icon={FiletypeTextIcon} size={32} />}
+    />
+  )
+}
+
+ItemIcon.propTypes = {
+  icon: PropTypes.node,
+  file: PropTypes.object
+}
+
+export default ItemIcon

--- a/react/MuiCozyTheme/ListItem/ListItemFile/PrimaryText.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemFile/PrimaryText.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types'
+
+import { useI18n } from '../../../I18n'
+import { withListItemLocales } from '../hoc/withListItemLocales'
+
+const PrimaryText = ({ primary, file }) => {
+  const { t } = useI18n()
+
+  if (primary) return primary
+
+  const pageQualification = file?.metadata?.qualification?.page
+
+  return pageQualification === 'front' || pageQualification === 'back'
+    ? t(`ListItem.file.page.${pageQualification}`)
+    : file.name
+}
+
+PrimaryText.propTypes = {
+  primary: PropTypes.node,
+  file: PropTypes.object
+}
+
+export default withListItemLocales(PrimaryText)

--- a/react/MuiCozyTheme/ListItem/ListItemFile/SecondaryText.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemFile/SecondaryText.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { isExpired, isExpiringSoon } from 'cozy-client/dist/models/paper'
+
+import { useI18n } from '../../../I18n'
+import ExpirationAnnotation from './ExpirationAnnotation'
+
+const SecondaryText = ({ secondary, file }) => {
+  const { f } = useI18n()
+
+  if (secondary) return secondary
+
+  const date = file?.metadata?.datetime
+    ? f(file?.metadata?.datetime, 'DD/MM/YYYY')
+    : null
+
+  return (
+    <>
+      {date ? date : ''}
+      {(isExpired(file) || isExpiringSoon(file)) && (
+        <>
+          {date ? ' · ' : ''}
+          <ExpirationAnnotation file={file} />
+        </>
+      )}
+    </>
+  )
+}
+
+SecondaryText.propTypes = {
+  secondary: PropTypes.node,
+  file: PropTypes.object
+}
+
+export default SecondaryText

--- a/react/MuiCozyTheme/ListItem/ListItemFile/index.jsx
+++ b/react/MuiCozyTheme/ListItem/ListItemFile/index.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { splitFilename } from 'cozy-client/dist/models/file'
+
+import Filename from '../../../Filename'
+import FiletypePdfIcon from '../../../Icons/FileTypePdf'
+import ListItemBase from '../ListItemBase'
+import { makeDefaultExpandedAttributes } from '../ExpandedAttributes/helpers'
+import ItemIcon from './ItemIcon'
+import PrimaryText from './PrimaryText'
+import SecondaryText from './SecondaryText'
+
+const ListItemFile = ({
+  file,
+  primary,
+  secondary,
+  icon,
+  actions,
+  selectProps,
+  expandedAttributesProps: { isExpandedAttributesActive, expandedAttributes },
+  onClick
+}) => {
+  const { filename, extension } = splitFilename({
+    name: file.name,
+    type: 'file'
+  })
+
+  const itemExpandedAttributes = makeDefaultExpandedAttributes(
+    file,
+    expandedAttributes
+  )
+
+  return (
+    <ListItemBase
+      doc={file}
+      primary={<PrimaryText primary={primary} file={file} />}
+      secondary={<SecondaryText secondary={secondary} file={file} />}
+      icon={<ItemIcon icon={icon} file={file} />}
+      actions={actions}
+      actionMenuComp={{
+        Header: (
+          <Filename
+            icon={FiletypePdfIcon}
+            filename={filename}
+            extension={extension}
+          />
+        )
+      }}
+      selectProps={selectProps}
+      expandedAttributesProps={{
+        isExpandedAttributesActive,
+        expandedAttributes: itemExpandedAttributes
+      }}
+      onClick={onClick}
+    />
+  )
+}
+
+ListItemFile.defaultProps = {
+  expandedAttributesProps: {
+    isExpandedAttributesActive: false
+  }
+}
+
+ListItemFile.propTypes = {
+  file: PropTypes.object,
+  primary: PropTypes.node,
+  secondary: PropTypes.node,
+  icon: PropTypes.node,
+  actions: PropTypes.array,
+  selectProps: PropTypes.shape({
+    isSelectActive: PropTypes.bool,
+    isSelected: PropTypes.bool,
+    isChecked: PropTypes.bool
+  }),
+  expandedAttributesProps: PropTypes.shape({
+    isExpandedAttributesActive: PropTypes.bool,
+    expandedAttributes: PropTypes.array
+  }),
+  onClick: PropTypes.func
+}
+
+export default ListItemFile

--- a/react/MuiCozyTheme/ListItem/hoc/withListItemLocales.jsx
+++ b/react/MuiCozyTheme/ListItem/hoc/withListItemLocales.jsx
@@ -1,0 +1,11 @@
+import withLocales from '../../../I18n/withLocales'
+
+import en from '../locales/en.json'
+import fr from '../locales/fr.json'
+
+export const locales = {
+  en,
+  fr
+}
+
+export const withListItemLocales = withLocales(locales)

--- a/react/MuiCozyTheme/ListItem/locales/en.json
+++ b/react/MuiCozyTheme/ListItem/locales/en.json
@@ -1,0 +1,62 @@
+{
+  "ListItem": {
+    "attributes": {
+      "birthday": "Birthday",
+      "address": "Address",
+      "email": "Email address",
+      "phone": "Phone number",
+      "metadata": {
+        "datetime": "Added on",
+        "AObtentionDate": "License A, delivered on",
+        "BObtentionDate": "License B, delivered on",
+        "CObtentionDate": "License C, delivered on",
+        "DObtentionDate": "License D, delivered on",
+        "issueDate": "Delivered on",
+        "expirationDate": "Expiration date",
+        "referencedDate": "Referenced date",
+        "shootingDate": "Shooting date",
+        "obtentionDate": "Date obtained",
+        "date": "Document date",
+        "country": "Country of delivery",
+        "refTaxIncome": "Reference tax income",
+        "contractType": "Contract type",
+        "noticePeriod": "Expiration alert",
+        "number": {
+          "driver_license": "License number",
+          "caf": "CAF file number",
+          "vehicle_registration": "Vehicle registration number (VIN)",
+          "national_id_card": "National ID card number",
+          "bank_details": "IBAN number",
+          "passport": "Passport number"
+        }
+      }
+    },
+    "contact": {
+      "birthday": "Birthday",
+      "actions": {
+        "copy": "Copy",
+        "delete": "Delete"
+      }
+    },
+    "file": {
+      "expired": "Expired",
+      "expiresIn": "Expires in %{duration}",
+      "page": {
+        "back": "Back side",
+        "front": "Front side"
+      }
+    },
+    "snackbar": {
+      "copyToClipboard": {
+        "success": "Copied to clipboard",
+        "error": "Cannot copy to clipboard"
+      }
+    },
+    "renameModal": {
+      "title": "Rename",
+      "content": "You are about to change the file extension. Do you want to continue?",
+      "cancel": "Cancel",
+      "submit": "Continue"
+    }
+  }
+}

--- a/react/MuiCozyTheme/ListItem/locales/fr.json
+++ b/react/MuiCozyTheme/ListItem/locales/fr.json
@@ -1,0 +1,61 @@
+{
+  "ListItem": {
+    "attributes": {
+      "birthday": "Date de naissance",
+      "address": "Adresse",
+      "email": "Adresse e-mail",
+      "phone": "Numéro de téléphone",
+      "metadata": {
+        "datetime": "Ajouté le",
+        "AObtentionDate": "Permis A, délivré le",
+        "BObtentionDate": "Permis B, délivré le",
+        "CObtentionDate": "Permis C, délivré le",
+        "DObtentionDate": "Permis D, délivré le",
+        "issueDate": "Délivré le",
+        "expirationDate": "Date d'expiration",
+        "referencedDate": "Date de référence",
+        "shootingDate": "Date de prise de vue",
+        "obtentionDate": "Date d'obtention",
+        "date": "Date du document",
+        "country": "Pays de délivrance",
+        "refTaxIncome": "Revenu fiscal de référence",
+        "contractType": "Type de contat",
+        "noticePeriod": "Alerte d’expiration",
+        "number": {
+          "driver_license": "Numéro du permis",
+          "caf": "Numéro de dossier CAF",
+          "vehicle_registration": "Numéro de la carte grise (VIN)",
+          "national_id_card": "Numéro de la carte d'identité",
+          "bank_details": "Numéro d'IBAN",
+          "passport": "Numéro du passeport"
+        }
+      }
+    },
+    "contact": {
+      "actions": {
+        "copy": "Copier",
+        "delete": "Supprimer"
+      }
+    },
+    "file": {
+      "expired": "Expiré",
+      "expiresIn": "Expire dans %{duration}",
+      "page": {
+        "back": "Face arrière",
+        "front": "Face avant"
+      }
+    },
+    "snackbar": {
+      "copyToClipboard": {
+        "success": "Copié dans le presse-papier",
+        "error": "Impossible de copier dans le presse-papier"
+      }
+    },
+    "renameModal": {
+      "title": "Renommer",
+      "content": "Vous êtes sur le point de changer l'extension du fichier. Voulez-vous continuer ?",
+      "cancel": "Annuler",
+      "submit": "Continuer"
+    }
+  }
+}


### PR DESCRIPTION
On crée ici un composant très haut niveau ListItemDoc qui va retourner un style de ListItem spécifique selon le type de document (`io.cozy.files` et `io.cozy.contacts` pour l'instant).

Ce ListItem prend en charge les actions, le renommage, le multiselect, et l'affichage d'attributs "augmentés" avec le copy to clipboard dessus

implémentation ici https://github.com/cozy/cozy-libs/pull/2067
 
démo : https://jf-cozy.github.io/cozy-ui/react/#!/List (paragraphe **Contextualized item**)