### PR TITLE
feat: Add success/fail animations to SquareAppIcon

### DIFF
--- a/assets/icons/animated/icon-check-animated.svg
+++ b/assets/icons/animated/icon-check-animated.svg
@@ -1,0 +1,41 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+@-webkit-keyframes checkmark 
+{
+0% {
+    stroke-dashoffset: 100px
+}
+
+100% {
+    stroke-dashoffset: 200px
+}
+}
+
+@-ms-keyframes checkmark 
+{
+0% {
+    stroke-dashoffset: 100px
+}
+
+100% {
+    stroke-dashoffset: 200px
+}
+}
+
+@keyframes checkmark 
+{
+0% {
+    stroke-dashoffset: 100px
+}
+
+100% {
+    stroke-dashoffset: 0px
+}
+}
+path {
+-webkit-animation: checkmark 1.0s ease-in-out backwards;
+animation: checkmark 1.0s ease-in-out backwards
+}
+</style>
+<path d="M1 11L4 14L15 3" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="stroke-dasharray:100px, 100px; stroke-dashoffset: 200px;"/>
+</svg>

--- a/assets/icons/animated/icon-cross-animated.svg
+++ b/assets/icons/animated/icon-cross-animated.svg
@@ -1,0 +1,41 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+@-webkit-keyframes checkmark 
+{
+0% {
+    stroke-dashoffset: 100px
+}
+100% {
+    stroke-dashoffset: 200px
+}
+}
+@-ms-keyframes checkmark 
+{
+0% {
+    stroke-dashoffset: 100px
+}
+100% {
+    stroke-dashoffset: 200px
+}
+}
+@keyframes checkmark 
+{
+0% {
+    stroke-dashoffset: 100px
+}
+100% {
+    stroke-dashoffset: 0px
+}
+}
+path.l1 {
+-webkit-animation: checkmark 0.5s ease-in-out backwards;
+animation: checkmark 0.5s ease-in-out backwards
+}
+path.l2 {
+-webkit-animation: checkmark 0.5s ease-in-out 0.16s backwards;
+animation: checkmark 0.5s ease-in-out 0.16s backwards
+}
+</style>
+<path class="l1" d="M2 2L14 14" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="stroke-dasharray:100px, 100px; stroke-dashoffset: 200px;"/>
+<path class="l2" d="M14 2L2 14" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="stroke-dasharray:100px, 100px; stroke-dashoffset: 200px;"/>
+</svg>

--- a/react/Icons/IconCheckAnimated.jsx
+++ b/react/Icons/IconCheckAnimated.jsx
@@ -1,0 +1,29 @@
+// Automatically created, please run `scripts/generate-svgr-icon.sh assets/icons/animated/icon-check-animated.svg` to regenerate;
+import React from 'react'
+
+function SvgIconCheckAnimated(props) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      <style>
+        {
+          '@-webkit-keyframes checkmark{0%{stroke-dashoffset:100px}to{stroke-dashoffset:200px}}@-ms-keyframes checkmark{0%{stroke-dashoffset:100px}to{stroke-dashoffset:200px}}@keyframes checkmark{0%{stroke-dashoffset:100px}to{stroke-dashoffset:0}}'
+        }
+      </style>
+      <path
+        d="M1 11l3 3L15 3"
+        stroke="#000"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          WebkitAnimation: 'checkmark 1s ease-in-out backwards',
+          animation: 'checkmark 1s ease-in-out backwards'
+        }}
+        strokeDasharray="100px,100px"
+        strokeDashoffset={200}
+      />
+    </svg>
+  )
+}
+
+export default SvgIconCheckAnimated

--- a/react/Icons/IconCrossAnimated.jsx
+++ b/react/Icons/IconCrossAnimated.jsx
@@ -1,0 +1,44 @@
+// Automatically created, please run `scripts/generate-svgr-icon.sh assets/icons/animated/icon-cross-animated.svg` to regenerate;
+import React from 'react'
+
+function SvgIconCrossAnimated(props) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      <style>
+        {
+          '@-webkit-keyframes checkmark{0%{stroke-dashoffset:100px}to{stroke-dashoffset:200px}}@-ms-keyframes checkmark{0%{stroke-dashoffset:100px}to{stroke-dashoffset:200px}}@keyframes checkmark{0%{stroke-dashoffset:100px}to{stroke-dashoffset:0}}'
+        }
+      </style>
+      <path
+        className="icon-cross-animated_svg__l1"
+        d="M2 2l12 12"
+        stroke="#000"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          WebkitAnimation: 'checkmark .5s ease-in-out backwards',
+          animation: 'checkmark .5s ease-in-out backwards'
+        }}
+        strokeDasharray="100px,100px"
+        strokeDashoffset={200}
+      />
+      <path
+        className="icon-cross-animated_svg__l2"
+        d="M14 2L2 14"
+        stroke="#000"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          WebkitAnimation: 'checkmark .5s ease-in-out .16s backwards',
+          animation: 'checkmark .5s ease-in-out .16s backwards'
+        }}
+        strokeDasharray="100px,100px"
+        strokeDashoffset={200}
+      />
+    </svg>
+  )
+}
+
+export default SvgIconCrossAnimated

--- a/react/SquareAppIcon/Readme.md
+++ b/react/SquareAppIcon/Readme.md
@@ -13,12 +13,15 @@ import Button from 'cozy-ui/transpiled/react/Buttons'
 const theme = useCozyTheme()
 const app = { name: "Test App", slug: "testapp", type: "app" }
 const [isLoading, setLoading] = React.useState(false)
+const [isError, setIsError] = React.useState(false)
+
 
 
 ;
 
 <>
-  <Button className="u-mb-1" label="Toggle Loading" onClick={() => setLoading(!isLoading)} />
+  <Button className="u-mb-1 u-mr-1" label="Toggle Loading" onClick={() => setLoading(!isLoading)} />
+  <Button className="u-mb-1" label="Toggle Loading Error" onClick={() => setIsError(!isError)} />
 
   <Grid container spacing={1} style={{ background: `center / cover no-repeat url(${cloudWallpaper})` }}
   >
@@ -42,6 +45,9 @@ const [isLoading, setLoading] = React.useState(false)
     </Grid>
     <Grid item>
       <SquareAppIcon IconContent={<Icon icon={CozyIcon} size="48" />} name="Loading" variant={isLoading ? 'loading' : 'default'} />
+    </Grid>
+    <Grid item>
+      <SquareAppIcon IconContent={<Icon icon={CozyIcon} size="48" />} name="Loading" variant={isError ? 'error' : 'loading'} />
     </Grid>
     <Grid item>
       <SquareAppIcon name="Shortcut" variant="shortcut" IconContent={<img

--- a/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
+++ b/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
@@ -36,6 +36,9 @@ exports[`SquareAppIcon component should render an app correctly with the app nam
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
           height="100%"
@@ -100,6 +103,9 @@ exports[`SquareAppIcon component should render an app correctly with the given n
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
           height="100%"
@@ -164,6 +170,9 @@ exports[`SquareAppIcon component should render an app with the app slug if no na
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
           height="100%"
@@ -206,6 +215,9 @@ exports[`SquareAppIcon component should render correctly an app in add state 1`]
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__icon___23x3R"
           height="16"
@@ -247,12 +259,37 @@ exports[`SquareAppIcon component should render correctly an app in error state 1
   <span
     class="MuiBadge-root"
   >
+    <div
+      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
+    >
+      <svg
+        aria-busy="true"
+        class="styles__icon___23x3R styles__icon--spin___ybfC1"
+        height="16"
+        role="progressbar"
+        style="fill: var(--spinnerColor);"
+        viewBox="0 0 32 32"
+        width="16"
+      >
+        <path
+          d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
+          opacity="0.25"
+        />
+        <path
+          d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
+        />
+      </svg>
+      
+    </div>
     <span
       class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-33"
     >
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
           height="100%"
@@ -307,6 +344,9 @@ exports[`SquareAppIcon component should render correctly an app in ghost state 1
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
           height="100%"
@@ -349,6 +389,9 @@ exports[`SquareAppIcon component should render correctly an app in maintenance s
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
           height="100%"
@@ -458,6 +501,9 @@ exports[`SquareAppIcon component should render correctly an app with custom cont
       <div
         class="styles__SquareAppIcon-icon-container___39MRl"
       >
+        <div
+          class="styles__onEnd___1O6Q7"
+        />
         <svg
           class="styles__icon___23x3R"
           height="16"

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -1,19 +1,21 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
 
-import { makeStyles } from '../styles'
 import AppIcon from '../AppIcon'
 import Badge from '../Badge'
-import InfosBadge from '../InfosBadge'
-import { nameToColor } from '../Avatar'
-import Spinner from '../Spinner'
-import Typography from '../Typography'
 import Icon from '../Icon'
+import IconCheckAnimated from '../Icons/IconCheckAnimated'
+import InfosBadge from '../InfosBadge'
+import Spinner from '../Spinner'
+import SvgIconCrossAnimated from '../Icons/IconCrossAnimated'
+import Typography from '../Typography'
+import iconOut from '../Icons/LinkOut'
 import iconPlus from '../Icons/Plus'
 import iconWarning from '../Icons/WarningCircle'
-import iconOut from '../Icons/LinkOut'
+import { makeStyles } from '../styles'
+import { nameToColor } from '../Avatar'
 
 import { color } from './constants.json'
 import styles from './styles.styl'
@@ -72,6 +74,23 @@ export const SquareAppIcon = ({
   const appName =
     name || get(appIconProps, 'app.name') || get(appIconProps, 'app') || ''
   const letter = appName[0] || ''
+  const prevVariant = React.useRef(variant)
+  const [animationState, setAnimationState] = useState()
+
+  const handleAnimationEnd = e => {
+    if (e.animationName.startsWith('end')) setAnimationState()
+  }
+
+  useEffect(() => {
+    const curr = prevVariant.current
+
+    if (curr === 'loading' && variant === 'error') setAnimationState('failed')
+
+    if (curr === 'loading' && (variant === 'default' || variant === undefined))
+      setAnimationState('success')
+
+    prevVariant.current = variant
+  }, [variant])
 
   return (
     <div data-testid="square-app-icon" className={cx(classes.tileWrapper)}>
@@ -82,7 +101,7 @@ export const SquareAppIcon = ({
         overlap="rectangular"
         invisible={variant !== 'shortcut'}
       >
-        {['default', 'loading'].includes(variant) && (
+        {['default', 'loading', 'error'].includes(variant) && (
           <Spinner className={cx(styles['SquareAppIcon-spinner'], 'u-m-0')} />
         )}
         <Badge
@@ -124,6 +143,26 @@ export const SquareAppIcon = ({
             </Typography>
           ) : (
             <div className={styles['SquareAppIcon-icon-container']}>
+              <div
+                className={cx(
+                  styles['onEnd'],
+                  { [styles['isSuccess']]: animationState === 'success' },
+                  { [styles['isFailed']]: animationState === 'failed' }
+                )}
+                onAnimationEnd={handleAnimationEnd}
+              >
+                {animationState && (
+                  <Icon
+                    size="32"
+                    icon={
+                      animationState === 'success'
+                        ? IconCheckAnimated
+                        : SvgIconCrossAnimated
+                    }
+                  />
+                )}
+              </div>
+
               {variant === 'add' ? (
                 <Icon icon={iconPlus} color={color} />
               ) : IconContent ? (

--- a/react/SquareAppIcon/styles.styl
+++ b/react/SquareAppIcon/styles.styl
@@ -55,7 +55,77 @@ $color = constants['color'] // hard-coded color, because the component is curren
         transform scale(0.8334)
 
 .SquareAppIcon-spinner
+    margin 0 !important
+
     svg
         position absolute
         height 100%
         width 100%
+
+animation-duration = 1.50s
+icon-duration = 0.2s
+icon-start = 0.2s
+border-radius-start = 50%
+border-radius-end = rem(12)
+opacity-start = 0
+opacity-end = 1
+
+.onEnd
+    align-items center
+    border-radius border-radius-start
+    display flex
+    height 100%
+    opacity opacity-start
+    position absolute
+    width 100%
+    z-index 1
+
+    svg
+        fill transparent !important
+
+        path
+            animation-duration icon-duration !important
+
+        path:first-of-type
+            animation-delay icon-start !important
+
+        // The second path is a part of the cross, 
+        // since it has its own hardcoded animation delay we need to add it again (.16s)
+        path+path
+            animation-delay icon-start + .16s !important
+
+        *
+            stroke var(--white) !important
+
+.onEnd.isFailed
+    --animationColor var(--errorColor)
+
+.onEnd.isSuccess
+    --animationColor var(--successColor)
+
+.isSuccess
+.isFailed
+    animation end-animation animation-duration forwards
+
+@keyframes end-animation {
+  0% {
+    background-color transparent
+    border-radius border-radius-start
+    opacity opacity-start
+  }
+  13.33% {
+    background-color var(--animationColor)
+    border-radius border-radius-end
+    opacity opacity-end
+  }
+  66.67% {
+    background-color var(--animationColor)
+    border-radius border-radius-end
+    opacity opacity-end
+  }
+  100% {
+    border-radius border-radius-end
+    opacity opacity-start
+    background-color transparent
+  }
+}


### PR DESCRIPTION
From variant 'loading' to either variant 'default' or 'error'

https://acezard.github.io/cozy-ui/react/#!/SquareAppIcon

![image](https://user-images.githubusercontent.com/12577784/231501432-820f8741-e3d4-42ea-b60e-2b975ec9049d.png)
