### PR TITLE
fix: remove margin on sqAppIcon spinner

### DIFF
--- a/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
+++ b/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
@@ -9,7 +9,7 @@ exports[`SquareAppIcon component should render an app correctly with the app nam
     class="MuiBadge-root"
   >
     <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1"
+      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
     >
       <svg
         aria-busy="true"
@@ -73,7 +73,7 @@ exports[`SquareAppIcon component should render an app correctly with the given n
     class="MuiBadge-root"
   >
     <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1"
+      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
     >
       <svg
         aria-busy="true"
@@ -137,7 +137,7 @@ exports[`SquareAppIcon component should render an app with the app slug if no na
     class="MuiBadge-root"
   >
     <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1"
+      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
     >
       <svg
         aria-busy="true"
@@ -431,7 +431,7 @@ exports[`SquareAppIcon component should render correctly an app with custom cont
     class="MuiBadge-root"
   >
     <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1"
+      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
     >
       <svg
         aria-busy="true"

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -83,7 +83,7 @@ export const SquareAppIcon = ({
         invisible={variant !== 'shortcut'}
       >
         {['default', 'loading'].includes(variant) && (
-          <Spinner className={styles['SquareAppIcon-spinner']} />
+          <Spinner className={cx(styles['SquareAppIcon-spinner'], 'u-m-0')} />
         )}
         <Badge
           className={cx(


### PR DESCRIPTION
It pushed icons sideways

![image](https://user-images.githubusercontent.com/12577784/227223188-6abf72b5-a285-4349-bcf7-c99002afb072.png)

![image](https://user-images.githubusercontent.com/12577784/227225412-6eee0131-d40b-4732-a4bb-47b9140b30ac.png)

