### PR TITLE
feat: Use helper for get random UUID

### DIFF
--- a/react/CircleButton/index.jsx
+++ b/react/CircleButton/index.jsx
@@ -6,6 +6,7 @@ import Box from '../Box'
 import IconButton from '../IconButton'
 import Typography from '../Typography'
 import { makeTypoColor, makeButtonShadow } from './helpers'
+import { getRandomUUID } from '../helpers/getRandomUUID'
 
 const useStyles = makeStyles(theme => ({
   iconButton: {
@@ -42,7 +43,7 @@ const CircleButton = ({
   ...props
 }) => {
   const styles = useStyles({ active: variant === 'active', disabled })
-  const uuid = crypto.randomUUID()
+  const uuid = getRandomUUID()
 
   if (!ariaLabel && !label) {
     console.warn(`The "aria-label" or "label" property must be filled in.`)

--- a/react/I18n/format.spec.jsx
+++ b/react/I18n/format.spec.jsx
@@ -53,7 +53,12 @@ describe('formatLocallyDistanceToNow', () => {
 })
 
 describe('formatLocallyDistanceToNowStrict', () => {
+  afterEach(() => {
+    MockDate.reset()
+  })
+
   it('should formatDistanceToNowStrict with small value', () => {
+    MockDate.set('2023-01-01T00:00:00')
     const date = Date.now() + 29 * 1000 // 29s
 
     const result = formatLocallyDistanceToNowStrict(date)
@@ -62,6 +67,7 @@ describe('formatLocallyDistanceToNowStrict', () => {
   })
 
   it('should formatDistanceToNowStrict with medium value', () => {
+    MockDate.set('2023-01-01T00:00:00')
     const date = Date.now() + (44 * 60 + 31) * 1000 // 44min 31s
 
     const result = formatLocallyDistanceToNowStrict(date)
@@ -70,6 +76,7 @@ describe('formatLocallyDistanceToNowStrict', () => {
   })
 
   it('should formatDistanceToNowStrict with high value', () => {
+    MockDate.set('2023-01-01T00:00:00')
     const date = Date.now() + (89 * 60 + 31) * 1000 // 89min 31s
 
     const result = formatLocallyDistanceToNowStrict(date)
@@ -78,6 +85,7 @@ describe('formatLocallyDistanceToNowStrict', () => {
   })
 
   it('should formatDistanceToNowStrict with one day', () => {
+    MockDate.set('2023-01-01T00:00:00')
     const date = Date.now() + 24 * 60 * 60 * 1000 // 1d
 
     const result = formatLocallyDistanceToNowStrict(date)
@@ -86,6 +94,7 @@ describe('formatLocallyDistanceToNowStrict', () => {
   })
 
   it('should formatDistanceToNowStrict with two days', () => {
+    MockDate.set('2023-01-01T00:00:00')
     const date = Date.now() + 2 * 24 * 60 * 60 * 1000 // 2d
 
     const result = formatLocallyDistanceToNowStrict(date)
@@ -94,6 +103,7 @@ describe('formatLocallyDistanceToNowStrict', () => {
   })
 
   it('should formatDistanceToNowStrict with very high value', () => {
+    MockDate.set('2023-01-01T00:00:00')
     const date = Date.now() + 42 * 24 * 60 * 60 * 1000 // 42d
 
     const result = formatLocallyDistanceToNowStrict(date)

--- a/react/MuiCozyTheme/TextField/index.jsx
+++ b/react/MuiCozyTheme/TextField/index.jsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react'
 import MuiTextField from '@material-ui/core/TextField'
+import { getRandomUUID } from '../../helpers/getRandomUUID'
 
 const TextField = forwardRef(({ children, ...props }, ref) => {
   // A11Y, https://v4.mui.com/api/text-field/#props
-  const uuid = crypto.randomUUID()
+  const uuid = getRandomUUID()
 
   return (
     <MuiTextField ref={ref} id={uuid} {...props}>

--- a/react/helpers/getRandomUUID.js
+++ b/react/helpers/getRandomUUID.js
@@ -1,0 +1,11 @@
+/**
+ *  Returns a random UUID
+ * @returns {string} a random UUID
+ */
+export const getRandomUUID = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return 'random-uuid-for-jest'
+  }
+
+  return window.crypto.randomUUID()
+}

--- a/react/helpers/getRandomUUID.spec.js
+++ b/react/helpers/getRandomUUID.spec.js
@@ -1,0 +1,9 @@
+import { getRandomUUID } from './getRandomUUID'
+
+describe('getRandomUUID', () => {
+  it('returns a random uuid', () => {
+    const uuid = getRandomUUID()
+
+    expect(uuid).toBe('random-uuid-for-jest')
+  })
+})

--- a/test/jestsetup.js
+++ b/test/jestsetup.js
@@ -1,15 +1,8 @@
 import '@testing-library/jest-dom/extend-expect'
 import { configure, mount, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import nodeCrypto from 'crypto'
 
 configure({ adapter: new Adapter() })
-
-Object.defineProperty(global, 'crypto', {
-  value: {
-    randomUUID: () => nodeCrypto.randomUUID()
-  }
-})
 
 global.mount = mount
 global.shallow = shallow


### PR DESCRIPTION
We recently used the `randomUUID` method of `crypto`, and added a special configuration for testing with `Jest`. We should have added a BC at that time, because e2e tests of applications can fail if they also do not have the correct Jest configuration.

I propose here a better approach, which will avoid a BC and changes on the application side