### PR TITLE
fix(SelectionBar): Limit the number of actions displayed

### DIFF
--- a/react/SelectionBar/Readme.md
+++ b/react/SelectionBar/Readme.md
@@ -1,5 +1,3 @@
-SelectionBar 
-
 ### Usage
 
 ```jsx
@@ -8,6 +6,7 @@ import I18n from 'cozy-ui/transpiled/react/I18n';
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints';
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 
 const selectedItem = {
     _id: 1,
@@ -40,6 +39,11 @@ const actions = {
     action: selections => alert(JSON.stringify(selections)),
     displayCondition: selections => selections.length > 1,
     icon: RenameIcon
+  },
+  share: {
+    action: selections => alert(JSON.stringify(selections)),
+    displayCondition: selections => selections.length > 1,
+    icon: ShareIcon
   }
 };
 
@@ -52,6 +56,7 @@ const actions = {
         actions={actions}
         selected={state.selected}
         hideSelectionBar={() => setState({selected: []})}
+        maxAction={2}
         />
     </div>
     }

--- a/react/SelectionBar/SelectionBarAction.jsx
+++ b/react/SelectionBar/SelectionBarAction.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import cx from 'classnames'
+
+import Button from '../MuiCozyTheme/Buttons'
+import useBreakpoints from '../hooks/useBreakpoints'
+import Icon from '../Icon'
+import IconButton from '../IconButton'
+import { useI18n } from '../I18n'
+
+import styles from './styles.styl'
+
+const SelectionBarAction = ({ selectedCount, selected, action }) => {
+  const { isDesktop } = useBreakpoints()
+  const { t } = useI18n()
+
+  if (isDesktop) {
+    return (
+      <Button
+        data-testid={`selectionBar-action-${action.name}`}
+        className={cx(
+          styles['SelectionBar-action'],
+          styles['SelectionBar-action--withLabel']
+        )}
+        variant="text"
+        disabled={
+          action.disabled === undefined
+            ? selectedCount < 1 // to avoid breaking change
+            : action.disabled(selected)
+        }
+        onClick={() => action.action(selected)}
+        startIcon={<Icon icon={action.icon || action.name.toLowerCase()} />}
+      >
+        {t('SelectionBar.' + action.name)}
+      </Button>
+    )
+  }
+
+  return (
+    <IconButton
+      data-testid={`selectionBar-action-${action.name}`}
+      className={styles['SelectionBar-action']}
+      label={t('SelectionBar.' + action.name)}
+      disabled={
+        action.disabled === undefined
+          ? selectedCount < 1 // to avoid breaking change
+          : action.disabled(selected)
+      }
+      size="medium"
+      onClick={() => action.action(selected)}
+    >
+      <Icon icon={action.icon || action.name.toLowerCase()} />
+    </IconButton>
+  )
+}
+
+export default SelectionBarAction

--- a/react/SelectionBar/SelectionBarAction.jsx
+++ b/react/SelectionBar/SelectionBarAction.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+import PropTypes from 'prop-types'
 
 import Button from '../MuiCozyTheme/Buttons'
 import useBreakpoints from '../hooks/useBreakpoints'
@@ -51,6 +52,21 @@ const SelectionBarAction = ({ selectedCount, selected, action }) => {
       <Icon icon={action.icon || action.name.toLowerCase()} />
     </IconButton>
   )
+}
+
+SelectionBarAction.propTypes = {
+  /**
+   * Number of item selected
+   */
+  selectedCount: PropTypes.number.isRequired,
+  /**
+   * List of ids of the selected items
+   */
+  selected: PropTypes.array.isRequired,
+  /**
+   * List of object with the property of action and a name
+   */
+  action: PropTypes.object.isRequired
 }
 
 export default SelectionBarAction

--- a/react/SelectionBar/SelectionBarMore.jsx
+++ b/react/SelectionBar/SelectionBarMore.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react'
+import PropTypes from 'prop-types'
 
 import Icon from '../Icon'
 import IconButton from '../IconButton'
@@ -55,6 +56,21 @@ const SelectionBarMore = ({ actions, selectedCount, selected }) => {
       )}
     </>
   )
+}
+
+SelectionBarMore.propTypes = {
+  /**
+   * List of object with the property of action and a name
+   */
+  actions: PropTypes.array.isRequired,
+  /**
+   * Number of item selected
+   */
+  selectedCount: PropTypes.number.isRequired,
+  /**
+   * List of ids of the selected items
+   */
+  selected: PropTypes.array.isRequired
 }
 
 export default SelectionBarMore

--- a/react/SelectionBar/SelectionBarMore.jsx
+++ b/react/SelectionBar/SelectionBarMore.jsx
@@ -1,0 +1,60 @@
+import React, { useState, useRef } from 'react'
+
+import Icon from '../Icon'
+import IconButton from '../IconButton'
+import DotsIcon from '../Icons/Dots'
+import { ActionMenuWithClose, ActionMenuItem } from '../ActionMenu'
+import { useI18n } from '../I18n'
+
+import styles from './styles.styl'
+
+const SelectionBarMore = ({ actions, selectedCount, selected }) => {
+  const { t } = useI18n()
+  const [isMenuDisplayed, setMenuDisplayed] = useState(false)
+  const anchorRef = useRef(null)
+
+  const toggleMenu = () => setMenuDisplayed(!isMenuDisplayed)
+  const hideMenu = () => setMenuDisplayed(false)
+
+  return (
+    <>
+      <IconButton
+        className={styles['SelectionBar-action']}
+        label={t('SelectionBar.more')}
+        size="medium"
+        onClick={toggleMenu}
+        ref={anchorRef}
+        aria-haspopup="true"
+        aria-controls="selection-bar--more"
+      >
+        <Icon icon={DotsIcon} />
+      </IconButton>
+      {isMenuDisplayed && (
+        <ActionMenuWithClose
+          id="selection-bar--more"
+          ref={anchorRef}
+          onClose={hideMenu}
+        >
+          {actions.map((action, index) => {
+            return (
+              <ActionMenuItem
+                key={index}
+                left={<Icon icon={action.icon || action.name.toLowerCase()} />}
+                disabled={
+                  action.disabled === undefined
+                    ? selectedCount < 1 // to avoid breaking change
+                    : action.disabled(selected)
+                }
+                onClick={() => action.action(selected)}
+              >
+                {t('SelectionBar.' + action.name)}
+              </ActionMenuItem>
+            )
+          })}
+        </ActionMenuWithClose>
+      )}
+    </>
+  )
+}
+
+export default SelectionBarMore

--- a/react/SelectionBar/helpers.js
+++ b/react/SelectionBar/helpers.js
@@ -1,0 +1,22 @@
+/**
+ * Compute the maximum number of actions to display according to the breakpoint
+ * @param {number|object} maxAction an number or a set of maximum for each breakpoint
+ * @param {object} breakpoints a set of breakpoints with a boolean to know if it is active or not
+ * @returns the maximum number or undefined if there is no matching result
+ */
+export function computeMaxAction(maxAction, breakpoints) {
+  if (typeof maxAction === 'object' && maxAction !== null && breakpoints) {
+    const maxActionKeys = Object.keys(maxAction)
+    const currentMaxAction = Object.keys(breakpoints)
+      .filter(key => breakpoints[key])
+      .filter(key => maxActionKeys.includes(key))
+
+    if (currentMaxAction.length > 0) {
+      return maxAction[currentMaxAction[0]]
+    }
+  }
+
+  if (typeof maxAction === 'number') return maxAction
+
+  return undefined
+}

--- a/react/SelectionBar/helpers.spec.js
+++ b/react/SelectionBar/helpers.spec.js
@@ -1,0 +1,54 @@
+import { computeMaxAction } from './helpers'
+
+describe('computeMaxAction', () => {
+  it('should return maxAction directly if it is a number', () => {
+    expect(computeMaxAction(3)).toBe(3)
+  })
+
+  it('should return isMedium maximum if the corresponding breakpoint is true', () => {
+    expect(
+      computeMaxAction(
+        {
+          isLarge: 4,
+          isMedium: 3,
+          isSmall: 2,
+          isTiny: 1
+        },
+        {
+          isLarge: false,
+          isMedium: true,
+          isSmall: true
+        }
+      )
+    ).toBe(3)
+  })
+
+  it('should return an undefined value if no breakpoint matches maximum values', () => {
+    expect(
+      computeMaxAction(
+        {
+          isLarge: 4,
+          isMedium: 3,
+          isSmall: 2,
+          isTiny: 1
+        },
+        {
+          isLarge: false,
+          isMedium: false
+        }
+      )
+    ).toBe(undefined)
+  })
+
+  it('should return undefined when there is no breakpoint', () => {
+    expect(
+      computeMaxAction({
+        isLarge: 4
+      })
+    ).toBe(undefined)
+  })
+
+  it('should return an undefined value when maxAction is null', () => {
+    expect(computeMaxAction(null)).toBe(undefined)
+  })
+})

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -12,6 +12,8 @@ import useBreakpoints from '../hooks/useBreakpoints'
 
 import styles from './styles.styl'
 import SelectionBarAction from './SelectionBarAction'
+import SelectionBarMore from './SelectionBarMore'
+import { computeMaxAction } from './helpers'
 
 /*
 
@@ -30,7 +32,15 @@ actions = {
 
 */
 
-const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
+const SelectionBar = ({
+  actions,
+  selected,
+  hideSelectionBar,
+  maxAction = {
+    isLarge: 6,
+    isTiny: 3
+  }
+}) => {
   const { t } = useI18n()
   const webviewIntent = useWebviewIntent()
   const theme = useTheme()
@@ -50,6 +60,8 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
       name: actionName,
       ...actions[actionName]
     }))
+
+  const maxActionDisplayed = computeMaxAction(maxAction, breakpoints)
 
   // This component is always rendered but hidden with CSS if there is no selection
   // That is why we do not use useSetFlagship API here because that hook can not accept changing values
@@ -104,7 +116,7 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
         )}
       </span>
       <div>
-        {actionList.map((action, idx) => (
+        {actionList.slice(0, maxActionDisplayed).map((action, idx) => (
           <SelectionBarAction
             key={idx}
             selectedCount={selectedCount}
@@ -112,6 +124,13 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
             action={action}
           />
         ))}
+        {actionList.length > maxActionDisplayed && (
+          <SelectionBarMore
+            actions={actionList.slice(maxActionDisplayed)}
+            selectedCount={selectedCount}
+            selected={selected}
+          />
+        )}
       </div>
       <IconButton
         data-testid="selectionBar-action-close"

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -146,9 +146,24 @@ const SelectionBar = ({
 }
 
 SelectionBar.propTypes = {
-  actions: PropTypes.object.isRequired, // An object with actions
-  selected: PropTypes.array.isRequired, // selected items id.
-  hideSelectionBar: PropTypes.func.isRequired // function to close SelectionBar.
+  /**
+   * An object with actions
+   */
+  actions: PropTypes.object.isRequired,
+  /**
+   * List of ids of the selected items
+   */
+  selected: PropTypes.array.isRequired,
+  /**
+   * function to close SelectionBar.
+   */
+  hideSelectionBar: PropTypes.func.isRequired,
+  /**
+   * A number corresponding to the display of the maximum number of items.
+   * The other actions will be displayed in an additional menu.
+   * With an object, they can be detailed according to the breakpoints
+   */
+  maxAction: PropTypes.oneOfType([PropTypes.number, PropTypes.object])
 }
 
 export default SelectionBar

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -9,10 +9,9 @@ import { useI18n } from '../I18n'
 import Icon from '../Icon'
 import IconButton from '../IconButton'
 import CrossIcon from '../Icons/Cross'
-import Button from '../MuiCozyTheme/Buttons'
-import useBreakpoints from '../hooks/useBreakpoints'
 
 import styles from './styles.styl'
+import SelectionBarAction from './SelectionBarAction'
 
 /*
 
@@ -33,16 +32,23 @@ actions = {
 
 const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
   const { t } = useI18n()
-  const { isDesktop } = useBreakpoints()
-  const selectedCount = selected.length
-  const actionNames = Object.keys(actions).filter(actionName => {
-    const action = actions[actionName]
-    return (
-      action.displayCondition === undefined || action.displayCondition(selected)
-    )
-  })
   const webviewIntent = useWebviewIntent()
   const theme = useTheme()
+
+  const selectedCount = selected.length
+
+  const actionList = Object.keys(actions)
+    .filter(actionName => {
+      const action = actions[actionName]
+      return (
+        action.displayCondition === undefined ||
+        action.displayCondition(selected)
+      )
+    })
+    .map(actionName => ({
+      name: actionName,
+      ...actions[actionName]
+    }))
 
   // This component is always rendered but hidden with CSS if there is no selection
   // That is why we do not use useSetFlagship API here because that hook can not accept changing values
@@ -95,48 +101,14 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
         </span>
       </span>
       <span className={styles['SelectionBar-separator']} />
-      {actionNames.map((actionName, index) =>
-        isDesktop ? (
-          <Button
-            data-testid={`selectionBar-action-${actionName}`}
-            className={cx(
-              styles['SelectionBar-action'],
-              styles['SelectionBar-action--withLabel']
-            )}
-            variant="text"
-            key={index}
-            disabled={
-              actions[actionName].disabled === undefined
-                ? selectedCount < 1 // to avoid breaking change
-                : actions[actionName].disabled(selected)
-            }
-            onClick={() => actions[actionName].action(selected)}
-            startIcon={
-              <Icon
-                icon={actions[actionName].icon || actionName.toLowerCase()}
-              />
-            }
-          >
-            {t('SelectionBar.' + actionName)}
-          </Button>
-        ) : (
-          <IconButton
-            data-testid={`selectionBar-action-${actionName}`}
-            className={styles['SelectionBar-action']}
-            label={t('SelectionBar.' + actionName)}
-            key={index}
-            disabled={
-              actions[actionName].disabled === undefined
-                ? selectedCount < 1 // to avoid breaking change
-                : actions[actionName].disabled(selected)
-            }
-            size="medium"
-            onClick={() => actions[actionName].action(selected)}
-          >
-            <Icon icon={actions[actionName].icon || actionName.toLowerCase()} />
-          </IconButton>
-        )
-      )}
+      {actionList.map((action, idx) => (
+        <SelectionBarAction
+          key={idx}
+          selectedCount={selectedCount}
+          selected={selected}
+          action={action}
+        />
+      ))}
       <IconButton
         data-testid="selectionBar-action-close"
         className={cx(

--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 import { useTheme } from '@material-ui/core'
 
 import { useWebviewIntent } from 'cozy-intent'
@@ -9,6 +8,7 @@ import { useI18n } from '../I18n'
 import Icon from '../Icon'
 import IconButton from '../IconButton'
 import CrossIcon from '../Icons/Cross'
+import useBreakpoints from '../hooks/useBreakpoints'
 
 import styles from './styles.styl'
 import SelectionBarAction from './SelectionBarAction'
@@ -34,6 +34,7 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
   const { t } = useI18n()
   const webviewIntent = useWebviewIntent()
   const theme = useTheme()
+  const breakpoints = useBreakpoints()
 
   const selectedCount = selected.length
 
@@ -95,26 +96,26 @@ const SelectionBar = ({ actions, selected, hideSelectionBar }) => {
         className={styles['SelectionBar-count']}
       >
         {selectedCount}
-        <span>
-          {' '}
-          {t('SelectionBar.selected_count', { smart_count: selectedCount })}
-        </span>
+        {!breakpoints.isMobile && (
+          <span>
+            {' '}
+            {t('SelectionBar.selected_count', { smart_count: selectedCount })}
+          </span>
+        )}
       </span>
-      <span className={styles['SelectionBar-separator']} />
-      {actionList.map((action, idx) => (
-        <SelectionBarAction
-          key={idx}
-          selectedCount={selectedCount}
-          selected={selected}
-          action={action}
-        />
-      ))}
+      <div>
+        {actionList.map((action, idx) => (
+          <SelectionBarAction
+            key={idx}
+            selectedCount={selectedCount}
+            selected={selected}
+            action={action}
+          />
+        ))}
+      </div>
       <IconButton
         data-testid="selectionBar-action-close"
-        className={cx(
-          styles['SelectionBar-action'],
-          styles['SelectionBar-action--close']
-        )}
+        className={styles['SelectionBar-action']}
         label={t('SelectionBar.close')}
         size="medium"
         onClick={hideSelectionBar}

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -10,7 +10,7 @@ $selectionbar
     left              0
     box-sizing        border-box
     display           flex
-    justify-content   center
+    justify-content   space-between
     align-items       center
     width             100%
     height            rem(52)
@@ -18,12 +18,14 @@ $selectionbar
     background-color  var(--slateGrey)
     font-weight       bold
 
-    .SelectionBar-separator
-        margin            0 1rem 0 2rem
-        width             rem(4)
-        height            rem(4)
-        border-radius     50%
-        background-color  var(--black)
+    .SelectionBar-count
+        padding 0 1rem
+        min-width 3rem
+
+        +mobile()
+            &
+                padding 0
+                text-align center
 
     .SelectionBar-action
         margin 0 .25rem
@@ -34,30 +36,11 @@ $selectionbar
         &--withLabel
             margin 0 .5rem
 
-        &--close
-            position absolute
-            top 50%
-            right 0
-            transform translateY(-50%)
-            margin 0 .5rem
-
     +medium-screen()
         &
             top              auto
             bottom           0
-            justify-content  flex-start
             box-sizing       content-box
-            width            calc(100% - 2rem)
             height           3rem
-            padding-left     1rem
-            padding-right    1rem
             // iPhone X environment tweak
-            padding-bottom env(safe-area-inset-bottom)
-
-            .SelectionBar-separator
-                margin 0 0 0 1rem
-
-            .SelectionBar-action--close
-                top auto
-                transform none
-                margin 0 .5rem
+            padding-bottom   env(safe-area-inset-bottom)


### PR DESCRIPTION
In cozy-drive, up to 8 or more actions can be displayed at the same time. On both large and tiny screens, the actions overflow behind the close button. To solve this problem, we decided to limit the number of actions displayed for certain screen sizes. Actions exceeding this limit are displayed in an additional menu. 

![problem](https://user-images.githubusercontent.com/7434420/230415052-3ac91326-df0c-48d1-ae31-3e624b88f0f6.png)

**Live preview:** https://cballevre.github.io/cozy-ui/react/#!/SelectionBar/

**Some examples on Drive:**

Large screen size:
![isLarge](https://user-images.githubusercontent.com/7434420/231174694-a813aaa8-348a-4644-bfd8-af6b68e8eea4.png)

Medium screen size:
![isMedium](https://user-images.githubusercontent.com/7434420/231174703-fb228c99-fa88-4673-872b-9b7fceb22bf6.png)

Tiny screen size: 
<img width="320" src="https://user-images.githubusercontent.com/7434420/231174680-2848a49d-ce1b-4072-99b2-de5b5444fbce.png"  />

Large screen size on banks : 
![banks-large](https://user-images.githubusercontent.com/7434420/231174710-8a048802-7be1-42f4-8bbc-860b52926ac5.png)