### PR TITLE
fix: Delete `max-width` on Input component

### DIFF
--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -252,7 +252,6 @@ $input--disabled
 $input-text
     display inline-block
     width 100%
-    max-width rem(512)
     padding rem(13 16)
     box-sizing border-box
     border-radius rem(3)


### PR DESCRIPTION
Removal of the maximum width of the Input component, because in the case where the Input is very wide, not all of it can be clicked