### PR TITLE
Navigate between pdf pages with keyboard

### DIFF
--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -60,6 +60,7 @@ import { isValidForPanel } from 'cozy-ui/transpiled/react/Viewer/helpers'
 import getPanelBlocks, { panelBlocksSpecs } from 'cozy-ui/transpiled/react/Viewer/Panel/getPanelBlocks'
 import FooterActionButtons from 'cozy-ui/transpiled/react/Viewer/Footer/FooterActionButtons'
 import ForwardOrDownloadButton from 'cozy-ui/transpiled/react/Viewer/Footer/ForwardOrDownloadButton'
+import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 
 // We provide a collection of (fake) io.cozy.files to be rendered
 const files = [
@@ -237,6 +238,7 @@ const editPathByModelProps = {
       )
     }
   </Variants>
+  <Sprite />
 </DemoProvider>
 ```
 

--- a/react/Viewer/ViewersByFile/PdfJsViewer.jsx
+++ b/react/Viewer/ViewersByFile/PdfJsViewer.jsx
@@ -16,6 +16,8 @@ import styles from './styles.styl'
 export const MIN_SCALE = 0.25
 export const MAX_SCALE = 3
 export const MAX_PAGES = 3
+const KEY_CODE_UP = 38
+const KEY_CODE_DOWN = 40
 
 export class PdfJsViewer extends Component {
   state = {
@@ -32,10 +34,17 @@ export class PdfJsViewer extends Component {
     this.setWrapperSize()
     this.resizeListener = throttle(this.setWrapperSize, 500)
     window.addEventListener('resize', this.resizeListener)
+    document.addEventListener('keyup', this.onKeyUp, false)
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.resizeListener)
+    document.removeEventListener('keyup', this.onKeyUp, false)
+  }
+
+  onKeyUp = e => {
+    if (e.keyCode === KEY_CODE_UP) this.previousPage()
+    else if (e.keyCode === KEY_CODE_DOWN) this.nextPage()
   }
 
   toggleGestures(enable) {

--- a/react/Viewer/docs/DemoProvider.jsx
+++ b/react/Viewer/docs/DemoProvider.jsx
@@ -11,7 +11,7 @@ const demoTextFileResponse = {
 
 const demoFilesByClass = {
   pdf:
-    'https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/examples/learning/helloworld.pdf',
+    'https://raw.githubusercontent.com/rospdf/pdf-php/2ccf7591fc2f18e63342ebfedad7997b08c34ed2/readme.pdf',
   audio: 'https://viewerdemo.cozycloud.cc/Z.mp3',
   video: 'https://viewerdemo.cozycloud.cc/Nextcloud.mp4',
   text: 'https://viewerdemo.cozycloud.cc/notes.md'


### PR DESCRIPTION
Quick feature to improve viewer usability for large pdf :
- key up to go to previous page
- key down to go to next page

Live demo : https://zatteo.github.io/cozy-ui/react/#!/Viewer