### PR TITLE
feat: Add isExtraExtraLarge breakpoint

### DIFF
--- a/react/helpers/breakpoints.js
+++ b/react/helpers/breakpoints.js
@@ -1,12 +1,14 @@
 import mapValues from 'lodash/mapValues'
 
+const extraLarge = 1400
 const large = 1200
 const medium = 1023
 const small = 768
 const tiny = 543
 
 const breakpoints = {
-  isExtraLarge: [large + 1],
+  isExtraExtraLarge: [extraLarge + 1],
+  isExtraLarge: [large + 1, extraLarge],
   isLarge: [medium + 1, large],
   isMedium: [small + 1, medium],
   isSmall: [tiny + 1, small],


### PR DESCRIPTION
This allows more granularity in the breakpoint for extra large devices between 1200px and 1400px. This change follows the device ranges used by bootstrap (cf: [documentation](https://getbootstrap.com/docs/5.0/layout/breakpoints/))

BREAKING CHANGE : Before, we used `isExtraLarge` to get the same result now we have to use `isExtraLarge || isExtraExtraLarge` because `isExtraLarge` has a limit now and not `isExtraExtraLarge`

From my research, this break change has relatively low impact (cf: [research](https://github.com/search?q=org%3Acozy+isExtraLarge&type=code). It is used once in cozy-drive and 3 times in cozy-banks.