### PR TITLE
Fix Success and Failure Icons Only Displaying for First Occurrence

### DIFF
--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -78,7 +78,7 @@ export const SquareAppIcon = ({
   const [animationState, setAnimationState] = useState()
 
   const handleAnimationEnd = e => {
-    if (e.animationName.startsWith('end')) setAnimationState()
+    if (e.animationName.includes('end')) setAnimationState()
   }
 
   useEffect(() => {


### PR DESCRIPTION
This hotfix addresses an issue where the success and failure icons would only display for the first occurrence across different features. The root cause of the problem was found in the animation event handling logic.

Changes:

- Updated the `handleAnimationEnd` function to use `includes` instead of `startsWith` when checking for the `end-animation` event. This change ensures that the animation state is reset correctly after the animation ends, even when the animation name has a prefix, such as in production.

Testing:

- Tested manually the updated implementation to ensure that the success and failure icons display correctly for each occurrence across different features.

This hotfix resolves the issue with the success and failure icons and improves the overall user experience.