### PR TITLE
chore(travis): Use default cache directory for yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 dist: jammy
-cache:
-  yarn: true
-  directories:
-    - node_modules
+cache: yarn
 env:
   global:
     - PR_TITLE=$(curl https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST} 2> /dev/null | grep "title" | head -1)


### PR DESCRIPTION
Il y a parfois des soucis avec les `node_modules` et le cache, qui fait que certains builds plantent car utilisent une version erronés (provenant d'un autre build) des `nodes_modules`. Le vidage du cache résout le souci.

Ici https://stackoverflow.com/questions/42521884/should-i-have-travis-cache-node-modules-or-home-npm on découvre que mettre en cache le dossier `node_modules` est déprécié et qu'il faut préférer `$HOME/.npm`

Cependant à la lecture de ces documents https://docs.travis-ci.com/user/caching/#npm-cache et https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#npm-ci-support je pense qu'on peut d'abord essayer en utilisant le cache par défaut de yarn à savoir `$HOME/.cache/yarn`.

L'idée initiale était de forcer l'install des `node_modules` PAR build, et de n'avoir un cache que pour les jobs, mais pas inter-build (ce qui est bien le fonctionnement de travis https://docs.travis-ci.com/user/caching/#caching-directories-bundler-dependencies ), on va d'abord voir ce que ça donne avec un config plus proche de celle par défaut...