### PR TITLE
fix(MenuItem): Override `component` prop

### DIFF
--- a/react/MenuItem/index.js
+++ b/react/MenuItem/index.js
@@ -3,9 +3,15 @@ import MuiMenuItem from '@material-ui/core/MenuItem'
 
 import ListItem, { LitItemPropTypes } from '../MuiCozyTheme/ListItem'
 
-const MenuItem = forwardRef((props, ref) => {
+const MenuItem = forwardRef(({ component, ...props }, ref) => {
   return (
-    <MuiMenuItem ref={ref} component={ListItem} gutters="disabled" {...props} />
+    <MuiMenuItem
+      ref={ref}
+      component={ListItem}
+      componentElement={component}
+      gutters="disabled"
+      {...props}
+    />
   )
 })
 

--- a/react/MuiCozyTheme/ListItem/index.js
+++ b/react/MuiCozyTheme/ListItem/index.js
@@ -80,7 +80,7 @@ const useOverridenChildren = ({ gutters, ellipsis, ...props }) => {
 }
 
 const ListItem = forwardRef(
-  ({ className, gutters, ellipsis, ...props }, ref) => {
+  ({ className, gutters, ellipsis, componentElement, ...props }, ref) => {
     const secondaryActionPaddingRight = useSecondaryAction({
       gutters,
       ...props
@@ -97,6 +97,7 @@ const ListItem = forwardRef(
     return (
       <MuiListItem
         {...props}
+        component={componentElement || props.component}
         ref={ref}
         classes={merge(props.classes, styles)}
         className={cx(className, props.size)}
@@ -118,7 +119,9 @@ ListItem.defaultProps = {
 export const LitItemPropTypes = {
   gutters: PropTypes.oneOf(['disabled', 'double', 'default']),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  ellipsis: PropTypes.bool
+  ellipsis: PropTypes.bool,
+  /** If the `component` prop is already used to return `ListItem`, this prop still allows you to choose a component to render in `ListItem`. cf:`MenuItem` component */
+  componentElement: PropTypes.elementType
 }
 
 ListItem.propTypes = LitItemPropTypes


### PR DESCRIPTION
We use the `component` prop on the `MenuItem` component for use our `ListItem` component instead of the MUI one.
If we want to use this same prop on the `ActionsMenuItem` component while using the `MenuItem` child component (to use the `a` tag for example),
we must intercept the `component` prop and pass it directly to the `ListItem` component.

Thus we do not modify the MUI API of the `ListItem` component.