### PR TITLE
fix: Apply flagship style to closebutton higher

### DIFF
--- a/react/CozyDialogs/styles.styl
+++ b/react/CozyDialogs/styles.styl
@@ -5,7 +5,6 @@
     top 1.15rem
     right 1.15rem
     z-index 1
-    transform translateY(var(--flagship-top-height))
     +small-screen()
         top 0.25rem
         right 0.25rem

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -627,6 +627,9 @@ const makeOverrides = theme => ({
     paperFullScreen: {
       '& .cozyDialogActions': {
         paddingBottom: 'env(safe-area-inset-bottom)'
+      },
+      '& [class*="DialogCloseButton"]': {
+        transform: 'translateY(var(--flagship-top-height))'
       }
     }
   },


### PR DESCRIPTION
It only needs to be applied when displayed in a full screen modal,
so we are changing where the style is defined.
This will fix small modals appearing in flagship app with
pushed down buttons