### PR TITLE
feat: Make SquareAppIcon compatible with normal and inverted themes

### DIFF
--- a/react/SquareAppIcon/Readme.md
+++ b/react/SquareAppIcon/Readme.md
@@ -23,7 +23,7 @@ const [isError, setIsError] = React.useState(false)
   <Button className="u-mb-1 u-mr-1" label="Toggle Loading" onClick={() => setLoading(!isLoading)} />
   <Button className="u-mb-1" label="Toggle Loading Error" onClick={() => setIsError(!isError)} />
 
-  <Grid container spacing={1} style={{ background: `center / cover no-repeat url(${cloudWallpaper})` }}
+  <Grid container spacing={1} style={{ background: theme === 'inverted' ? `center / cover no-repeat url(${cloudWallpaper})` : 'white' }}
   >
     <Grid item>
       <SquareAppIcon app={app} name="Normal" />

--- a/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
+++ b/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
@@ -2,65 +2,69 @@
 
 exports[`SquareAppIcon component should render an app correctly with the app name 1`] = `
 <div
-  class="makeStyles-tileWrapper-11"
+  class="makeStyles-tileWrapper-38"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
-    <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
-    >
-      <svg
-        aria-busy="true"
-        class="styles__icon___23x3R styles__icon--spin___ybfC1"
-        height="16"
-        role="progressbar"
-        style="fill: var(--spinnerColor);"
-        viewBox="0 0 32 32"
-        width="16"
-      >
-        <path
-          d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
-          opacity="0.25"
-        />
-        <path
-          d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
-        />
-      </svg>
-      
-    </div>
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-9"
+      class="MuiBadge-root-40"
     >
       <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+        class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
       >
-        <div
-          class="styles__onEnd___1O6Q7"
-        />
         <svg
-          class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
-          height="100%"
-          style="fill: var(--coolGrey);"
-          viewBox="0 0 16 16"
-          width="100%"
+          aria-busy="true"
+          class="styles__icon___23x3R styles__icon--spin___ybfC1"
+          height="16"
+          role="progressbar"
+          style="fill: var(--spinnerColor);"
+          viewBox="0 0 32 32"
+          width="16"
         >
           <path
-            d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
+            opacity="0.25"
+          />
+          <path
+            d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
           />
         </svg>
+        
       </div>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-root-40 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-36"
+      >
+        <div
+          class="styles__SquareAppIcon-icon-container___39MRl"
+        >
+          <div
+            class="styles__onEnd___1O6Q7"
+          />
+          <svg
+            class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
+            height="100%"
+            style="fill: var(--coolGrey);"
+            viewBox="0 0 16 16"
+            width="100%"
+          >
+            <path
+              d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-41 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-47"
+        />
+      </span>
+      <span
+        class="MuiBadge-badge-41 Component-qualifier-39 MuiBadge-anchorOriginBottomRightRectangular-49 MuiBadge-invisible-62"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-12 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-7 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-32 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     Test
   </h6>
@@ -69,63 +73,67 @@ exports[`SquareAppIcon component should render an app correctly with the app nam
 
 exports[`SquareAppIcon component should render an app correctly with the given name 1`] = `
 <div
-  class="makeStyles-tileWrapper-5"
+  class="makeStyles-tileWrapper-7"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
-    <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
-    >
-      <svg
-        aria-busy="true"
-        class="styles__icon___23x3R styles__icon--spin___ybfC1"
-        height="16"
-        role="progressbar"
-        style="fill: var(--spinnerColor);"
-        viewBox="0 0 32 32"
-        width="16"
-      >
-        <path
-          d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
-          opacity="0.25"
-        />
-        <path
-          d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
-        />
-      </svg>
-      
-    </div>
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-3"
+      class="MuiBadge-root-9"
     >
       <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+        class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
       >
-        <div
-          class="styles__onEnd___1O6Q7"
-        />
         <svg
-          class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
-          height="100%"
-          style="fill: var(--coolGrey);"
-          viewBox="0 0 16 16"
-          width="100%"
+          aria-busy="true"
+          class="styles__icon___23x3R styles__icon--spin___ybfC1"
+          height="16"
+          role="progressbar"
+          style="fill: var(--spinnerColor);"
+          viewBox="0 0 32 32"
+          width="16"
         >
           <path
-            d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
+            opacity="0.25"
+          />
+          <path
+            d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
           />
         </svg>
+        
       </div>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-root-9 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-5"
+      >
+        <div
+          class="styles__SquareAppIcon-icon-container___39MRl"
+        >
+          <div
+            class="styles__onEnd___1O6Q7"
+          />
+          <svg
+            class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
+            height="100%"
+            style="fill: var(--coolGrey);"
+            viewBox="0 0 16 16"
+            width="100%"
+          >
+            <path
+              d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-10 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-16"
+        />
+      </span>
+      <span
+        class="MuiBadge-badge-10 Component-qualifier-8 MuiBadge-anchorOriginBottomRightRectangular-18 MuiBadge-invisible-31"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-6 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
     class="MuiTypography-root makeStyles-name-1 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
@@ -136,65 +144,69 @@ exports[`SquareAppIcon component should render an app correctly with the given n
 
 exports[`SquareAppIcon component should render an app with the app slug if no name prop and app is a string 1`] = `
 <div
-  class="makeStyles-tileWrapper-17"
+  class="makeStyles-tileWrapper-69"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
-    <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
-    >
-      <svg
-        aria-busy="true"
-        class="styles__icon___23x3R styles__icon--spin___ybfC1"
-        height="16"
-        role="progressbar"
-        style="fill: var(--spinnerColor);"
-        viewBox="0 0 32 32"
-        width="16"
-      >
-        <path
-          d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
-          opacity="0.25"
-        />
-        <path
-          d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
-        />
-      </svg>
-      
-    </div>
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-15"
+      class="MuiBadge-root-71"
     >
       <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+        class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
       >
-        <div
-          class="styles__onEnd___1O6Q7"
-        />
         <svg
-          class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
-          height="100%"
-          style="fill: var(--coolGrey);"
-          viewBox="0 0 16 16"
-          width="100%"
+          aria-busy="true"
+          class="styles__icon___23x3R styles__icon--spin___ybfC1"
+          height="16"
+          role="progressbar"
+          style="fill: var(--spinnerColor);"
+          viewBox="0 0 32 32"
+          width="16"
         >
           <path
-            d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
+            opacity="0.25"
+          />
+          <path
+            d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
           />
         </svg>
+        
       </div>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-root-71 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-67"
+      >
+        <div
+          class="styles__SquareAppIcon-icon-container___39MRl"
+        >
+          <div
+            class="styles__onEnd___1O6Q7"
+          />
+          <svg
+            class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
+            height="100%"
+            style="fill: var(--coolGrey);"
+            viewBox="0 0 16 16"
+            width="100%"
+          >
+            <path
+              d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-72 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-78"
+        />
+      </span>
+      <span
+        class="MuiBadge-badge-72 Component-qualifier-70 MuiBadge-anchorOriginBottomRightRectangular-80 MuiBadge-invisible-93"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-18 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-13 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-63 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     testslug
   </h6>
@@ -203,127 +215,135 @@ exports[`SquareAppIcon component should render an app with the app slug if no na
 
 exports[`SquareAppIcon component should render correctly an app in add state 1`] = `
 <div
-  class="makeStyles-tileWrapper-41"
+  class="makeStyles-tileWrapper-193"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class=""
   >
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM styles__SquareAppIcon-wrapper-fx___3rcF6"
+      class="MuiBadge-root-195"
     >
-      <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+      <span
+        class="MuiBadge-root-195 styles__SquareAppIcon-wrapper___2SEuM makeStyles-squareAppIconGhost-189"
       >
         <div
-          class="styles__onEnd___1O6Q7"
-        />
-        <svg
-          class="styles__icon___23x3R"
-          height="16"
-          style="fill: #fff;"
-          viewBox="0 0 16 16"
-          width="16"
+          class="styles__SquareAppIcon-icon-container___39MRl"
         >
-          <defs>
-            <path
-              d="M7 0h2v7h7v2H9v7H7V9H0V7h7z"
-              id="plus_svg__a"
-            />
-          </defs>
-          <use
-            fill-rule="evenodd"
-            xlink:href="#plus_svg__a"
+          <div
+            class="styles__onEnd___1O6Q7"
           />
-        </svg>
-      </div>
+          <svg
+            class="styles__icon___23x3R"
+            height="16"
+            style="fill: var(--primaryColor);"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <defs>
+              <path
+                d="M7 0h2v7h7v2H9v7H7V9H0V7h7z"
+                id="plus_svg__a"
+              />
+            </defs>
+            <use
+              fill-rule="evenodd"
+              xlink:href="#plus_svg__a"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-196 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-202"
+        />
+      </span>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-badge-196 Component-qualifier-194 MuiBadge-anchorOriginBottomRightRectangular-204 MuiBadge-invisible-217"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-42 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-37 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-187 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   />
 </div>
 `;
 
 exports[`SquareAppIcon component should render correctly an app in error state 1`] = `
 <div
-  class="makeStyles-tileWrapper-35"
+  class="makeStyles-tileWrapper-162"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
-    <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
-    >
-      <svg
-        aria-busy="true"
-        class="styles__icon___23x3R styles__icon--spin___ybfC1"
-        height="16"
-        role="progressbar"
-        style="fill: var(--spinnerColor);"
-        viewBox="0 0 32 32"
-        width="16"
-      >
-        <path
-          d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
-          opacity="0.25"
-        />
-        <path
-          d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
-        />
-      </svg>
-      
-    </div>
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-33"
+      class="MuiBadge-root-164"
     >
       <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
-      >
-        <div
-          class="styles__onEnd___1O6Q7"
-        />
-        <svg
-          class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
-          height="100%"
-          style="fill: var(--coolGrey);"
-          viewBox="0 0 16 16"
-          width="100%"
-        >
-          <path
-            d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
-          />
-        </svg>
-      </div>
-      <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular MuiBadge-colorError"
+        class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
       >
         <svg
-          class="makeStyles-errorIcon-34 styles__icon___23x3R"
+          aria-busy="true"
+          class="styles__icon___23x3R styles__icon--spin___ybfC1"
           height="16"
-          viewBox="0 0 16 16"
+          role="progressbar"
+          style="fill: var(--spinnerColor);"
+          viewBox="0 0 32 32"
           width="16"
         >
           <path
-            d="M8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0ZM8 9.75C7.30964 9.75 6.75 10.3096 6.75 11C6.75 11.6904 7.30964 12.25 8 12.25C8.69036 12.25 9.25 11.6904 9.25 11C9.25 10.3096 8.69036 9.75 8 9.75ZM8 4C7.48716 4 7.06449 4.38604 7.00673 4.88338L7 5V8C7 8.55228 7.44772 9 8 9C8.51284 9 8.93551 8.61396 8.99327 8.11662L9 8V5C9 4.44772 8.55228 4 8 4Z"
-            fill-rule="evenodd"
+            d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
+            opacity="0.25"
+          />
+          <path
+            d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
           />
         </svg>
+        
+      </div>
+      <span
+        class="MuiBadge-root-164 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-160"
+      >
+        <div
+          class="styles__SquareAppIcon-icon-container___39MRl"
+        >
+          <div
+            class="styles__onEnd___1O6Q7"
+          />
+          <svg
+            class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
+            height="100%"
+            style="fill: var(--coolGrey);"
+            viewBox="0 0 16 16"
+            width="100%"
+          >
+            <path
+              d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-165 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-171 MuiBadge-colorError-168"
+        >
+          <svg
+            class="makeStyles-errorIcon-161 styles__icon___23x3R"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0ZM8 9.75C7.30964 9.75 6.75 10.3096 6.75 11C6.75 11.6904 7.30964 12.25 8 12.25C8.69036 12.25 9.25 11.6904 9.25 11C9.25 10.3096 8.69036 9.75 8 9.75ZM8 4C7.48716 4 7.06449 4.38604 7.00673 4.88338L7 5V8C7 8.55228 7.44772 9 8 9C8.51284 9 8.93551 8.61396 8.99327 8.11662L9 8V5C9 4.44772 8.55228 4 8 4Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
       </span>
+      <span
+        class="MuiBadge-badge-165 Component-qualifier-163 MuiBadge-anchorOriginBottomRightRectangular-173 MuiBadge-invisible-186"
+      />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-36 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-156 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     Test
   </h6>
@@ -332,43 +352,47 @@ exports[`SquareAppIcon component should render correctly an app in error state 1
 
 exports[`SquareAppIcon component should render correctly an app in ghost state 1`] = `
 <div
-  class="makeStyles-tileWrapper-29"
+  class="makeStyles-tileWrapper-131"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class=""
   >
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM styles__SquareAppIcon-wrapper-ghost___1ZALZ styles__SquareAppIcon-wrapper-fx___3rcF6"
+      class="MuiBadge-root-133"
     >
-      <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+      <span
+        class="MuiBadge-root-133 styles__SquareAppIcon-wrapper___2SEuM styles__SquareAppIcon-wrapper-ghost___1ZALZ makeStyles-squareAppIconGhost-127"
       >
         <div
-          class="styles__onEnd___1O6Q7"
-        />
-        <svg
-          class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
-          height="100%"
-          style="fill: var(--coolGrey);"
-          viewBox="0 0 16 16"
-          width="100%"
+          class="styles__SquareAppIcon-icon-container___39MRl"
         >
-          <path
-            d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+          <div
+            class="styles__onEnd___1O6Q7"
           />
-        </svg>
-      </div>
+          <svg
+            class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
+            height="100%"
+            style="fill: var(--coolGrey);"
+            viewBox="0 0 16 16"
+            width="100%"
+          >
+            <path
+              d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-134 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-140"
+        />
+      </span>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-badge-134 Component-qualifier-132 MuiBadge-anchorOriginBottomRightRectangular-142 MuiBadge-invisible-155"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-30 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-25 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-125 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     Test
   </h6>
@@ -377,43 +401,47 @@ exports[`SquareAppIcon component should render correctly an app in ghost state 1
 
 exports[`SquareAppIcon component should render correctly an app in maintenance state 1`] = `
 <div
-  class="makeStyles-tileWrapper-23"
+  class="makeStyles-tileWrapper-100"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM styles__SquareAppIcon-wrapper-maintenance___2ne2n makeStyles-shadow-21"
+      class="MuiBadge-root-102"
     >
-      <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+      <span
+        class="MuiBadge-root-102 styles__SquareAppIcon-wrapper___2SEuM styles__SquareAppIcon-wrapper-maintenance___2ne2n makeStyles-shadow-98"
       >
         <div
-          class="styles__onEnd___1O6Q7"
-        />
-        <svg
-          class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
-          height="100%"
-          style="fill: var(--coolGrey);"
-          viewBox="0 0 16 16"
-          width="100%"
+          class="styles__SquareAppIcon-icon-container___39MRl"
         >
-          <path
-            d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+          <div
+            class="styles__onEnd___1O6Q7"
           />
-        </svg>
-      </div>
+          <svg
+            class="styles__c-app-icon___2_O40 styles__c-app-icon-default___3CEmt styles__icon___23x3R"
+            height="100%"
+            style="fill: var(--coolGrey);"
+            viewBox="0 0 16 16"
+            width="100%"
+          >
+            <path
+              d="M1 11.009V5.5c0-.55.39-.773.872-.498l5.256 3.003c.476.272.872.944.872 1.495v5.508c0 .549-.39.772-.872.497l-5.256-3.003C1.396 12.231 1 11.56 1 11.01zm15 0c0 .55-.396 1.222-.872 1.494l-5.256 3.003c-.481.275-.872.052-.872-.497V9.5c0-.55.396-1.223.872-1.495l5.256-3.003c.481-.275.872-.052.872.498v5.508zM9.35 6.982c-.47.288-1.237.284-1.7 0l-4.8-2.954c-.47-.29-.463-.732.027-.995L7.623.477c.485-.261 1.264-.264 1.754 0l4.746 2.556c.485.26.49.71.027.995l-4.8 2.954z"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-103 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-109"
+        />
+      </span>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-badge-103 Component-qualifier-101 MuiBadge-anchorOriginBottomRightRectangular-111 MuiBadge-invisible-124"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-24 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-19 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-94 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     Test
   </h6>
@@ -422,43 +450,47 @@ exports[`SquareAppIcon component should render correctly an app in maintenance s
 
 exports[`SquareAppIcon component should render correctly an app in shortcut state 1`] = `
 <div
-  class="makeStyles-tileWrapper-47"
+  class="makeStyles-tileWrapper-224"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-45"
-      style="background-color: rgb(61, 166, 126);"
+      class="MuiBadge-root-226"
     >
-      <h2
-        class="MuiTypography-root makeStyles-letter-44 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-      >
-        S
-      </h2>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-      />
-    </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-48 MuiBadge-anchorOriginBottomRightRectangular"
-    >
-      <svg
-        class="styles__icon___23x3R"
-        height="10"
-        viewBox="0 0 16 16"
-        width="10"
+        class="MuiBadge-root-226 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-222"
+        style="background-color: rgb(61, 166, 126);"
       >
-        <path
-          d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-          fill-rule="evenodd"
+        <h2
+          class="MuiTypography-root-249 makeStyles-letter-221 MuiTypography-h2-255 MuiTypography-colorTextPrimary-274 MuiTypography-alignCenter-265"
+        >
+          S
+        </h2>
+        <span
+          class="MuiBadge-badge-227 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-233"
         />
-      </svg>
+      </span>
+      <span
+        class="MuiBadge-badge-227 Component-qualifier-225 MuiBadge-anchorOriginBottomRightRectangular-235"
+      >
+        <svg
+          class="styles__icon___23x3R"
+          height="10"
+          viewBox="0 0 16 16"
+          width="10"
+        >
+          <path
+            d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
     </span>
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-43 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-218 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     shortcut
   </h6>
@@ -467,66 +499,70 @@ exports[`SquareAppIcon component should render correctly an app in shortcut stat
 
 exports[`SquareAppIcon component should render correctly an app with custom content 1`] = `
 <div
-  class="makeStyles-tileWrapper-59"
+  class="makeStyles-tileWrapper-316"
   data-testid="square-app-icon"
 >
-  <span
-    class="MuiBadge-root"
+  <div
+    class="palette__CozyTheme--normal___3UmMb"
   >
-    <div
-      class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
-    >
-      <svg
-        aria-busy="true"
-        class="styles__icon___23x3R styles__icon--spin___ybfC1"
-        height="16"
-        role="progressbar"
-        style="fill: var(--spinnerColor);"
-        viewBox="0 0 32 32"
-        width="16"
-      >
-        <path
-          d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
-          opacity="0.25"
-        />
-        <path
-          d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
-        />
-      </svg>
-      
-    </div>
     <span
-      class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-57"
+      class="MuiBadge-root-318"
     >
       <div
-        class="styles__SquareAppIcon-icon-container___39MRl"
+        class="styles__c-spinner___1snK7 styles__SquareAppIcon-spinner___o0LO1 u-m-0"
       >
-        <div
-          class="styles__onEnd___1O6Q7"
-        />
         <svg
-          class="styles__icon___23x3R"
+          aria-busy="true"
+          class="styles__icon___23x3R styles__icon--spin___ybfC1"
           height="16"
-          viewBox="0 0 52 52"
+          role="progressbar"
+          style="fill: var(--spinnerColor);"
+          viewBox="0 0 32 32"
           width="16"
         >
           <path
-            d="M38.231 44H13.769C6.175 44 0 37.756 0 30.08c0-3.66 1.394-7.117 3.927-9.733 2.219-2.29 5.093-3.715 8.203-4.086a13.887 13.887 0 014.042-8.292A13.608 13.608 0 0125.801 4c3.62 0 7.04 1.407 9.629 3.968a13.897 13.897 0 014.038 8.25C46.482 16.853 52 22.828 52 30.082 52 37.756 45.82 44 38.23 44h.001zm-.163-3.001h.104c5.97 0 10.828-4.91 10.828-10.947 0-6.035-4.857-10.946-10.828-10.946h-.11c-.779 0-1.417-.627-1.435-1.417C36.492 11.794 31.637 7 25.803 7c-5.835 0-10.692 4.796-10.826 10.69a1.445 1.445 0 01-1.403 1.42C7.744 19.244 3 24.153 3 30.052 3 36.09 7.857 41 13.828 41h.088l.035-.002c.03 0 .062 0 .093.002h24.021l.003-.001zm-4.302-11.776c-.875-.585-.918-1.659-.92-1.706A.52.52 0 0032.32 27a.523.523 0 00-.506.536c.002.039.016.543.251 1.137a7.99 7.99 0 01-11.138.019 3.554 3.554 0 00.257-1.155.523.523 0 00-.503-.536.526.526 0 00-.528.515c0 .043-.042 1.121-.92 1.706a.536.536 0 00-.15.731.51.51 0 00.714.154c.225-.15.414-.322.572-.505a9.006 9.006 0 0012.251-.01c.16.184.35.36.582.515a.503.503 0 00.281.085.516.516 0 00.432-.24.537.537 0 00-.15-.731v.002z"
-            fill="#297EF2"
-            fill-rule="evenodd"
+            d="M16 0a16 16 0 000 32 16 16 0 000-32m0 4a12 12 0 010 24 12 12 0 010-24"
+            opacity="0.25"
+          />
+          <path
+            d="M16 0a16 16 0 0116 16h-4A12 12 0 0016 4z"
           />
         </svg>
+        
       </div>
       <span
-        class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
+        class="MuiBadge-root-318 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-314"
+      >
+        <div
+          class="styles__SquareAppIcon-icon-container___39MRl"
+        >
+          <div
+            class="styles__onEnd___1O6Q7"
+          />
+          <svg
+            class="styles__icon___23x3R"
+            height="16"
+            viewBox="0 0 52 52"
+            width="16"
+          >
+            <path
+              d="M38.231 44H13.769C6.175 44 0 37.756 0 30.08c0-3.66 1.394-7.117 3.927-9.733 2.219-2.29 5.093-3.715 8.203-4.086a13.887 13.887 0 014.042-8.292A13.608 13.608 0 0125.801 4c3.62 0 7.04 1.407 9.629 3.968a13.897 13.897 0 014.038 8.25C46.482 16.853 52 22.828 52 30.082 52 37.756 45.82 44 38.23 44h.001zm-.163-3.001h.104c5.97 0 10.828-4.91 10.828-10.947 0-6.035-4.857-10.946-10.828-10.946h-.11c-.779 0-1.417-.627-1.435-1.417C36.492 11.794 31.637 7 25.803 7c-5.835 0-10.692 4.796-10.826 10.69a1.445 1.445 0 01-1.403 1.42C7.744 19.244 3 24.153 3 30.052 3 36.09 7.857 41 13.828 41h.088l.035-.002c.03 0 .062 0 .093.002h24.021l.003-.001zm-4.302-11.776c-.875-.585-.918-1.659-.92-1.706A.52.52 0 0032.32 27a.523.523 0 00-.506.536c.002.039.016.543.251 1.137a7.99 7.99 0 01-11.138.019 3.554 3.554 0 00.257-1.155.523.523 0 00-.503-.536.526.526 0 00-.528.515c0 .043-.042 1.121-.92 1.706a.536.536 0 00-.15.731.51.51 0 00.714.154c.225-.15.414-.322.572-.505a9.006 9.006 0 0012.251-.01c.16.184.35.36.582.515a.503.503 0 00.281.085.516.516 0 00.432-.24.537.537 0 00-.15-.731v.002z"
+              fill="#297EF2"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <span
+          class="MuiBadge-badge-319 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-325"
+        />
+      </span>
+      <span
+        class="MuiBadge-badge-319 Component-qualifier-317 MuiBadge-anchorOriginBottomRightRectangular-327 MuiBadge-invisible-340"
       />
     </span>
-    <span
-      class="MuiBadge-badge Component-qualifier-60 MuiBadge-anchorOriginBottomRightRectangular MuiBadge-invisible"
-    />
-  </span>
+  </div>
   <h6
-    class="MuiTypography-root makeStyles-name-55 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+    class="MuiTypography-root makeStyles-name-310 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
   >
     custom icon
   </h6>

--- a/react/SquareAppIcon/constants.json
+++ b/react/SquareAppIcon/constants.json
@@ -2,6 +2,5 @@
   "iconSize": "4rem",
   "iconPadding": "0.625rem",
   "mobileIconSize": "3rem",
-  "mobileIconPadding": "0.5rem",
-  "color": "#fff"
+  "mobileIconPadding": "0.5rem"
 }

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -14,11 +14,10 @@ import Typography from '../Typography'
 import iconOut from '../Icons/LinkOut'
 import iconPlus from '../Icons/Plus'
 import iconWarning from '../Icons/WarningCircle'
-import { makeStyles } from '../styles'
+import { alpha, makeStyles } from '../styles'
 import { nameToColor } from '../Avatar'
 import CozyTheme, { useCozyTheme } from '../CozyTheme'
 
-import { color } from './constants.json'
 import styles from './styles.styl'
 
 const useStyles = makeStyles(theme => ({
@@ -41,6 +40,16 @@ const useStyles = makeStyles(theme => ({
       margin: '0.25rem 0.25rem 0 0.25rem',
       height: '2rem'
     }
+  },
+  squareAppIconGhost: {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.ghostOpacity
+    ),
+    border: `1px dashed ${alpha(
+      theme.palette.primary.main,
+      theme.palette.border.ghostOpacity
+    )}`
   },
   letter: {
     color: 'white',
@@ -114,10 +123,9 @@ export const SquareAppIcon = ({
               styles['SquareAppIcon-wrapper'],
               styles[`SquareAppIcon-wrapper-${variant}`],
               {
-                [`${styles['SquareAppIcon-wrapper-fx']}`]: [
-                  'ghost',
-                  'add'
-                ].includes(variant),
+                [classes.squareAppIconGhost]: ['ghost', 'add'].includes(
+                  variant
+                ),
                 [classes.shadow]: !['add', 'ghost'].includes(variant)
               }
             )}
@@ -173,7 +181,7 @@ export const SquareAppIcon = ({
                 </div>
 
                 {variant === 'add' ? (
-                  <Icon icon={iconPlus} color={color} />
+                  <Icon icon={iconPlus} color="var(--primaryColor)" />
                 ) : IconContent ? (
                   IconContent
                 ) : (

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -16,6 +16,7 @@ import iconPlus from '../Icons/Plus'
 import iconWarning from '../Icons/WarningCircle'
 import { makeStyles } from '../styles'
 import { nameToColor } from '../Avatar'
+import CozyTheme, { useCozyTheme } from '../CozyTheme'
 
 import { color } from './constants.json'
 import styles from './styles.styl'
@@ -70,6 +71,7 @@ export const SquareAppIcon = ({
   IconContent,
   ...appIconProps
 }) => {
+  const theme = useCozyTheme()
   const classes = useStyles()
   const appName =
     name || get(appIconProps, 'app.name') || get(appIconProps, 'app') || ''
@@ -92,88 +94,96 @@ export const SquareAppIcon = ({
     prevVariant.current = variant
   }, [variant])
 
+  const squareTheme = ['add', 'ghost'].includes(variant) ? theme : 'normal'
+
   return (
     <div data-testid="square-app-icon" className={cx(classes.tileWrapper)}>
-      <InfosBadge
-        badgeContent={
-          variant === 'shortcut' ? <Icon size="10" icon={iconOut} /> : null
-        }
-        overlap="rectangular"
-        invisible={variant !== 'shortcut'}
-      >
-        {['default', 'loading', 'error'].includes(variant) && (
-          <Spinner className={cx(styles['SquareAppIcon-spinner'], 'u-m-0')} />
-        )}
-        <Badge
-          className={cx(
-            styles['SquareAppIcon-wrapper'],
-            styles[`SquareAppIcon-wrapper-${variant}`],
-            {
-              [`${styles['SquareAppIcon-wrapper-fx']}`]: [
-                'ghost',
-                'add'
-              ].includes(variant),
-              [classes.shadow]: !['add', 'ghost'].includes(variant)
-            }
-          )}
+      <CozyTheme variant={squareTheme}>
+        <InfosBadge
           badgeContent={
-            variant === 'error' ? (
-              <Icon
-                size="16"
-                className={cx(classes.errorIcon)}
-                icon={iconWarning}
-              />
-            ) : (
-              ''
-            )
+            variant === 'shortcut' ? <Icon size="10" icon={iconOut} /> : null
           }
-          color={variant === 'error' ? 'error' : undefined}
-          withBorder={false}
-          size="large"
           overlap="rectangular"
-          style={
-            variant === 'shortcut' && !IconContent
-              ? { backgroundColor: nameToColor(name) }
-              : null
-          }
+          invisible={variant !== 'shortcut'}
         >
-          {variant === 'shortcut' && !IconContent ? (
-            <Typography className={classes.letter} variant="h2" align="center">
-              {letter.toUpperCase()}
-            </Typography>
-          ) : (
-            <div className={styles['SquareAppIcon-icon-container']}>
-              <div
-                className={cx(
-                  styles['onEnd'],
-                  { [styles['isSuccess']]: animationState === 'success' },
-                  { [styles['isFailed']]: animationState === 'failed' }
-                )}
-                onAnimationEnd={handleAnimationEnd}
+          {['default', 'loading', 'error'].includes(variant) && (
+            <Spinner className={cx(styles['SquareAppIcon-spinner'], 'u-m-0')} />
+          )}
+          <Badge
+            className={cx(
+              styles['SquareAppIcon-wrapper'],
+              styles[`SquareAppIcon-wrapper-${variant}`],
+              {
+                [`${styles['SquareAppIcon-wrapper-fx']}`]: [
+                  'ghost',
+                  'add'
+                ].includes(variant),
+                [classes.shadow]: !['add', 'ghost'].includes(variant)
+              }
+            )}
+            badgeContent={
+              variant === 'error' ? (
+                <Icon
+                  size="16"
+                  className={cx(classes.errorIcon)}
+                  icon={iconWarning}
+                />
+              ) : (
+                ''
+              )
+            }
+            color={variant === 'error' ? 'error' : undefined}
+            withBorder={false}
+            size="large"
+            overlap="rectangular"
+            style={
+              variant === 'shortcut' && !IconContent
+                ? { backgroundColor: nameToColor(name) }
+                : null
+            }
+          >
+            {variant === 'shortcut' && !IconContent ? (
+              <Typography
+                className={classes.letter}
+                variant="h2"
+                align="center"
               >
-                {animationState && (
-                  <Icon
-                    size="32"
-                    icon={
-                      animationState === 'success'
-                        ? IconCheckAnimated
-                        : SvgIconCrossAnimated
-                    }
-                  />
+                {letter.toUpperCase()}
+              </Typography>
+            ) : (
+              <div className={styles['SquareAppIcon-icon-container']}>
+                <div
+                  className={cx(
+                    styles['onEnd'],
+                    { [styles['isSuccess']]: animationState === 'success' },
+                    { [styles['isFailed']]: animationState === 'failed' }
+                  )}
+                  onAnimationEnd={handleAnimationEnd}
+                >
+                  {animationState && (
+                    <Icon
+                      size="32"
+                      icon={
+                        animationState === 'success'
+                          ? IconCheckAnimated
+                          : SvgIconCrossAnimated
+                      }
+                    />
+                  )}
+                </div>
+
+                {variant === 'add' ? (
+                  <Icon icon={iconPlus} color={color} />
+                ) : IconContent ? (
+                  IconContent
+                ) : (
+                  <AppIcon {...appIconProps} />
                 )}
               </div>
-
-              {variant === 'add' ? (
-                <Icon icon={iconPlus} color={color} />
-              ) : IconContent ? (
-                IconContent
-              ) : (
-                <AppIcon {...appIconProps} />
-              )}
-            </div>
-          )}
-        </Badge>
-      </InfosBadge>
+            )}
+          </Badge>
+        </InfosBadge>
+      </CozyTheme>
       <Typography
         className={cx(classes.name, 'u-spacellipsis')}
         variant="h6"

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -161,7 +161,12 @@ export const SquareAppIcon = ({
                 {letter.toUpperCase()}
               </Typography>
             ) : (
-              <div className={styles['SquareAppIcon-icon-container']}>
+              <div
+                className={cx(styles['SquareAppIcon-icon-container'], {
+                  [styles['SquareAppIcon-icon-container-normal']]:
+                    theme === 'normal'
+                })}
+              >
                 <div
                   className={cx(
                     styles['onEnd'],

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles(theme => ({
     }
   },
   letter: {
-    color,
+    color: 'white',
     margin: 'auto'
   },
   shadow: {

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -23,7 +23,7 @@ import styles from './styles.styl'
 
 const useStyles = makeStyles(theme => ({
   name: {
-    color,
+    color: 'var(--primaryTextColor)',
     width: '5.5rem',
     textAlign: 'center',
     fontSize: '0.875rem',

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -28,7 +28,6 @@ const useStyles = makeStyles(theme => ({
     fontSize: '0.875rem',
     lineHeight: '1.188rem',
     margin: '0.5rem 0.25rem 0 0.25rem',
-    textShadow: theme.textShadows[1],
     lineClamp: '2',
     boxOrient: 'vertical',
     display: '-webkit-box',
@@ -40,6 +39,9 @@ const useStyles = makeStyles(theme => ({
       margin: '0.25rem 0.25rem 0 0.25rem',
       height: '2rem'
     }
+  },
+  nameInverted: {
+    textShadow: theme.textShadows[1]
   },
   squareAppIconGhost: {
     backgroundColor: alpha(
@@ -193,7 +195,11 @@ export const SquareAppIcon = ({
         </InfosBadge>
       </CozyTheme>
       <Typography
-        className={cx(classes.name, 'u-spacellipsis')}
+        className={cx(
+          classes.name,
+          { [classes.nameInverted]: theme === 'inverted' },
+          'u-spacellipsis'
+        )}
         variant="h6"
         align="center"
       >

--- a/react/SquareAppIcon/styles.styl
+++ b/react/SquareAppIcon/styles.styl
@@ -31,11 +31,6 @@ $color = constants['color'] // hard-coded color, because the component is curren
     svg, img
         width 100%
 
-.SquareAppIcon-wrapper-fx
-    background-color alpha($color, .32)
-    border 1px dashed var(--white)
-    background-color alpha($color, .48)
-
 .SquareAppIcon-wrapper-ghost
     .SquareAppIcon-icon-container
         mix-blend-mode screen

--- a/react/SquareAppIcon/styles.styl
+++ b/react/SquareAppIcon/styles.styl
@@ -36,6 +36,10 @@ $color = constants['color'] // hard-coded color, because the component is curren
         mix-blend-mode screen
         svg, img
             filter saturate(0%)
+    .SquareAppIcon-icon-container-normal
+        mix-blend-mode luminosity
+        svg, img
+            opacity .5
 
 .SquareAppIcon-wrapper-maintenance
     .SquareAppIcon-icon-container


### PR DESCRIPTION
We want to implement an inverted theme for SquareAppIcon

In previous implementation, SquareAppIcon would be displayed identically on both inverted and normal theme

The new usage is that normal theme should be used on light backgrounds and inverted theme should be used on dark background or on backgrounds that may have many details on theme (i.e. photo based backgrounds)

BREAKING CHANGE: To keep previous SquareAppIcon render, you should display it inside of an inverted Cozy Theme

___

Related PR: cozy/cozy-home#1939