### PR TITLE
fix(SelectionBar): Mismatch between max action key

### DIFF
--- a/react/SelectionBar/index.jsx
+++ b/react/SelectionBar/index.jsx
@@ -37,7 +37,7 @@ const SelectionBar = ({
   selected,
   hideSelectionBar,
   maxAction = {
-    isWide: 6,
+    isHuge: 6,
     isLarge: 5,
     isMedium: 8,
     isSmall: 8,


### PR DESCRIPTION
This PR fixes a silly mistake. I was using the wrong key between breakpoints (cf: [definitions](https://github.com/cozy/cozy-ui/blob/45bc4bb5b57f58b69fd9c91b06ff7d621d7c639c/react/SelectionBar/useMaxActions.jsx#LL12C3-L12C9)) and max actions for huge device