### PR TITLE
docs: Extract flagship button from CozyDialogs into main Wrapper

### DIFF
--- a/docs/components/Wrapper.jsx
+++ b/docs/components/Wrapper.jsx
@@ -1,34 +1,14 @@
 import React, { useState } from 'react'
 import CozyTheme from '../../react/CozyTheme'
 import Paper from '../../react/Paper'
-import Button from '../../react/Button'
+import Button from '../../react/Buttons'
 import isTesting from '../../react/helpers/isTesting'
 import themes from '../../theme/themes'
-import palette from '../../theme/palette.json'
 import Typography from '../../react/Typography'
 import Divider from '../../react/MuiCozyTheme/Divider'
+import Box from '../../react/Box'
 import { isUsingDevStyleguidist } from '../../scripts/build-utils'
-
-const styles = {
-  button: {
-    position: 'absolute',
-    top: '0.75rem',
-    right: '0.75rem',
-    marginRight: 0,
-    zIndex: 10
-  },
-  buttonLang: {
-    position: 'absolute',
-    top: '0.75rem',
-    right: '6.75rem',
-    marginRight: 0,
-    zIndex: 10
-  },
-  paper: {
-    position: 'relative',
-    padding: '1rem'
-  }
-}
+import { addFlagshipElements, removeFlagshipElements } from './helpers'
 
 const ThemeLabel = ({ theme }) => {
   return (
@@ -38,45 +18,66 @@ const ThemeLabel = ({ theme }) => {
   )
 }
 
-const paperStyle = theme => ({
-  ...styles.paper,
-  backgroundColor: theme === themes.normal ? 'white' : palette.Primary['600']
-})
-
 export default ({ children }) => {
   const [theme, setTheme] = useState(
     localStorage.getItem('theme') || themes.normal
   )
-  const handleClick = () => {
+  const [lang, setLang] = useState(localStorage.getItem('lang') || 'en')
+  const [flagship, setFlagship] = useState(
+    localStorage.getItem('flagship') || 'off'
+  )
+
+  const otherThemes = Object.keys(themes).filter(v => v !== theme)
+
+  const handleThemeClick = () => {
     setTheme(theme === themes.normal ? themes.inverted : themes.normal)
   }
-  const otherThemes = Object.keys(themes).filter(v => v !== theme)
-  const [lang, setLang] = useState(localStorage.getItem('lang') || 'en')
+
   const handleLangClick = () => {
     const newLang = lang === 'fr' ? 'en' : 'fr'
     setLang(newLang)
     localStorage.setItem('lang', newLang)
   }
+
+  const handleFlagshipClick = () => {
+    const newFlagship = flagship === 'on' ? 'off' : 'on'
+    if (newFlagship === 'on') {
+      addFlagshipElements()
+    } else {
+      removeFlagshipElements()
+    }
+    setFlagship(newFlagship)
+    localStorage.setItem('flagship', newFlagship)
+  }
+
   return (
     <CozyTheme>
       <CozyTheme variant={theme}>
-        <Paper elevation={0} square style={paperStyle(theme)}>
-          <Button
-            size="tiny"
-            theme="secondary"
-            label={lang}
-            style={styles.buttonLang}
-            onClick={handleLangClick}
-          />
-          {isTesting() || isUsingDevStyleguidist() ? null : (
+        <Paper className="u-p-1" elevation={0} square>
+          <Box display="flex" justifyContent="end" gridGap={10}>
             <Button
-              size="tiny"
-              theme="secondary"
-              label={theme === themes.normal ? themes.inverted : themes.normal}
-              style={styles.button}
-              onClick={handleClick}
+              size="small"
+              variant="secondary"
+              label={flagship === 'on' ? 'Flagship Off' : 'Flagship On'}
+              onClick={handleFlagshipClick}
             />
-          )}
+            <Button
+              size="small"
+              variant="secondary"
+              label={lang}
+              onClick={handleLangClick}
+            />
+            {isTesting() || isUsingDevStyleguidist() ? null : (
+              <Button
+                size="small"
+                variant="secondary"
+                label={
+                  theme === themes.normal ? themes.inverted : themes.normal
+                }
+                onClick={handleThemeClick}
+              />
+            )}
+          </Box>
           {isUsingDevStyleguidist() && <ThemeLabel theme={theme} />}
           {children}
         </Paper>
@@ -86,7 +87,7 @@ export default ({ children }) => {
           <React.Fragment key={i}>
             <Divider />
             <CozyTheme key={otherTheme} variant={otherTheme}>
-              <Paper elevation={0} square style={paperStyle(otherTheme)}>
+              <Paper className="u-p-1" elevation={0} square>
                 <ThemeLabel theme={otherTheme} />
                 {children}
               </Paper>

--- a/docs/components/helpers.js
+++ b/docs/components/helpers.js
@@ -1,0 +1,47 @@
+// The goal of this method is to simulate the immersive mode of the flagship app.
+// So we add the flagship-app class to the body and we set 2 css variables:
+// flagship-top-height
+// flagship-bottom-height
+export const addFlagshipElements = () => {
+  const root = document.getElementsByTagName('body')[0]
+  root.style.setProperty('--flagship-top-height', '40px')
+  root.style.setProperty('--flagship-bottom-height', '40px')
+  root.classList.add('flagship-app')
+
+  const statusBarDiv = document.createElement('div')
+  statusBarDiv.setAttribute('id', 'flagshipStatusBar')
+  statusBarDiv.style.cssText =
+    'position:fixed;top:0;height:40px;z-index:10000000;background-color:red;width:100%;display:flex;align-items:center;justify-content:center'
+  // and give it some content
+  const statusBarDivContent = document.createTextNode(
+    'Top Status Bar with clock'
+  )
+
+  // add the text node to the newly created div
+  statusBarDiv.appendChild(statusBarDivContent)
+
+  const bottomBarDiv = document.createElement('div')
+  bottomBarDiv.setAttribute('id', 'flagshipBottomBar')
+  bottomBarDiv.style.cssText =
+    'position:fixed;bottom:0;height:40px;z-index:10000000;background-color:red;width:100%;display:flex;align-items:center;justify-content:center'
+  // and give it some content
+  const bottomBarDivContent = document.createTextNode('Bottom Bar')
+
+  // add the text node to the newly created div
+  bottomBarDiv.appendChild(bottomBarDivContent)
+
+  // add the newly created element and its content into the DOM
+  const currentDiv = document.getElementById('rsg-root')
+  document.body.insertBefore(statusBarDiv, currentDiv)
+  document.body.insertBefore(bottomBarDiv, currentDiv)
+}
+
+export const removeFlagshipElements = () => {
+  const root = document.getElementsByTagName('body')[0]
+  root.style.removeProperty('--flagship-top-height')
+  root.style.removeProperty('--flagship-bottom-height')
+  root.classList.remove('flagship-app')
+
+  document.getElementById('flagshipStatusBar')?.remove()
+  document.getElementById('flagshipBottomBar')?.remove()
+}

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -201,47 +201,9 @@ const initialVariants = [{
   withBackground: false
 }]
 
-// The goal of this method is to simulate the
-// immersive mode of the flagship app. So we
-// add the flagship-app class to the body and
-// we set 2 css variables:
-// flagship-top-height
-// flagship-bottom-height
-const setFlagshipVars = () => {
-  const root = document.getElementsByTagName('body')[0]
-  root.style.setProperty('--flagship-top-height',  "40px");
-  root.style.setProperty('--flagship-bottom-height',  "40px");
-  root.classList.add('flagship-app')
-
-  const statusBarDiv = document.createElement("div");
-  statusBarDiv.style.cssText = "position:fixed;top:0;height:40px;z-index:10000000;background-color:red;width:100%"
-  // and give it some content
-  const statusBarDivContent = document.createTextNode("Top Status Bar with clock");
-
-  // add the text node to the newly created div
-  statusBarDiv.appendChild(statusBarDivContent);
-
-
-  const bottomBarDiv = document.createElement("div");
-  bottomBarDiv.style.cssText = "position:fixed;bottom:0;height:40px;z-index:10000000;background-color:red;width:100%"
-  // and give it some content
-  const bottomBarDivContent = document.createTextNode("BottomBar");
-
-  // add the text node to the newly created div
-  bottomBarDiv.appendChild(bottomBarDivContent);
-
-  // add the newly created element and its content into the DOM
-  const currentDiv = document.getElementById("rsg-root");
-  document.body.insertBefore(statusBarDiv, currentDiv);
-  document.body.insertBefore(bottomBarDiv, currentDiv);
-}
 ;
 
 <BreakpointsProvider>
-  <Button 
-    onClick={() => setFlagshipVars()}   
-    variant="secondary"        
-    label={'Simulate Immersive Flagship Mode'} />
   <Variants initialVariants={initialVariants}>
     {variant => (
       <>


### PR DESCRIPTION
On a ajouté un bouton dans les cozy-dialogs pour simuler la présence de flagship. Ici on reprend l'idée, qu'on généralise. Un nouveau bouton fait donc son apparition dans les options 

![image](https://github.com/cozy/cozy-ui/assets/67680939/51c07f27-5988-4737-bd01-c6c34dadda2b)


demo : https://jf-cozy.github.io/cozy-ui/react/