### PR TITLE
fix(Viewer): ContractType metadata must display default value

### DIFF
--- a/react/Viewer/Panel/QualificationListItemInformation.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.jsx
@@ -24,7 +24,7 @@ export const makeInformationValue = ({ name, value, t, scannerT }) => {
     })}`
   }
   if (name === 'contractType') {
-    return scannerT(`Scan.attributes.contractType.${value}`)
+    return scannerT(`Scan.attributes.contractType.${value}`, { _: value })
   }
   if (name === 'refTaxIncome') {
     return `${value} €`


### PR DESCRIPTION
In the case where the user enters a type of contract manually, the translation key cannot correspond, and in this case we want to display the value entered directly.