### PR TITLE
Rework cozy-ui css to avoid massive duplication

### DIFF
--- a/react/Alerter/styles.styl
+++ b/react/Alerter/styles.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/tools/mixins'
-@require '../../stylus/settings/palette'
 @require '../../stylus/components/alerts'
 @require '../../stylus/components/button'
 

--- a/react/Checkbox/styles.styl
+++ b/react/Checkbox/styles.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/components/forms'
-@require '../../stylus/settings/palette'
 
 .c-input-checkbox
     @extend $checkbox

--- a/react/CozyTheme/index.jsx
+++ b/react/CozyTheme/index.jsx
@@ -2,19 +2,17 @@ import React, { createContext, useContext } from 'react'
 import cx from 'classnames'
 
 import MuiCozyTheme from '../MuiCozyTheme'
-import themesStyles from '../../stylus/settings/palette.styl'
 
 export const CozyThemeContext = createContext()
-
-const allStyles = {
-  'CozyTheme--normal': themesStyles['CozyTheme--normal'],
-  'CozyTheme--inverted': themesStyles['CozyTheme--inverted']
-}
 
 const CozyTheme = ({ variant, children, className }) => (
   <CozyThemeContext.Provider value={variant}>
     <MuiCozyTheme variant={variant}>
-      <div className={cx(className, allStyles[`CozyTheme--${variant}`])}>
+      <div
+        className={cx(className, {
+          [`CozyTheme--${variant}`]: Boolean(variant)
+        })}
+      >
         {children}
       </div>
     </MuiCozyTheme>

--- a/react/Dialog/index.jsx
+++ b/react/Dialog/index.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { RemoveScroll } from 'react-remove-scroll'
 import { default as MUIDialog } from '@material-ui/core/Dialog'
 
-import themesStyles from '../../stylus/settings/palette.styl'
 import useBreakpoints from '../hooks/useBreakpoints'
 import { useCozyTheme } from '../CozyTheme'
 import { useDialogEffects } from './DialogEffects'
@@ -29,10 +28,7 @@ const Dialog = props => {
 
   return (
     <Wrapper>
-      <MUIDialog
-        className={themesStyles[`CozyTheme--${cozyTheme}`]}
-        {...props}
-      />
+      <MUIDialog className={`CozyTheme--${cozyTheme}`} {...props} />
     </Wrapper>
   )
 }

--- a/react/HistoryRow/styles.styl
+++ b/react/HistoryRow/styles.styl
@@ -1,4 +1,4 @@
-@require 'utilities/spaces.styl'
+@require 'settings/spaces.styl'
 // If using this value in .HistoryRowCircle, its box-sizing
 //should be set to border-box so that the border width is accounted in the height
 CIRCLE_HEIGHT=1.125rem

--- a/react/Infos/styles.styl
+++ b/react/Infos/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'settings/breakpoints'
 @require 'tools/mixins'
 @require 'settings/spaces'

--- a/react/InfosCarrousel/styles.styl
+++ b/react/InfosCarrousel/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'settings/breakpoints'
 @require 'settings/spaces'
 

--- a/react/InlineCard/styles.styl
+++ b/react/InlineCard/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'tools/mixins'
 
 .c-inline-card

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -1,6 +1,5 @@
 @require '../../stylus/tools/mixins'
 @require '../../stylus/components/button'
-@require '../../stylus/utilities/display'
 @require '../../stylus/components/modals'
 
 .c-modal-container

--- a/react/Modal/styles.styl
+++ b/react/Modal/styles.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/tools/mixins'
-@require '../../stylus/settings/palette'
 @require '../../stylus/components/button'
 @require '../../stylus/utilities/display'
 @require '../../stylus/components/modals'

--- a/react/Nav/styles.styl
+++ b/react/Nav/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'tools/mixins'
 @require 'settings/breakpoints'
 @require 'components/nav'

--- a/react/SelectBox/styles.styl
+++ b/react/SelectBox/styles.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/components/forms'
-@require '../../stylus/settings/palette'
 @require '../../stylus/settings/breakpoints'
 @require '../../stylus/tools/mixins'
 

--- a/react/SelectionBar/styles.styl
+++ b/react/SelectionBar/styles.styl
@@ -1,5 +1,4 @@
 @require '../../stylus/tools/mixins'
-@require '../../stylus/settings/palette'
 @require '../../stylus/components/button'
 @require '../../stylus/components/selectionbar'
 

--- a/react/Spinner/styles.styl
+++ b/react/Spinner/styles.styl
@@ -1,4 +1,3 @@
-@require '../../stylus/settings/palette'
 @require '../../stylus/settings/icons'
 @require '../../stylus/tools/mixins'
 

--- a/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
+++ b/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
@@ -6,7 +6,7 @@ exports[`SquareAppIcon component should render an app correctly with the app nam
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-40"
@@ -55,7 +55,7 @@ exports[`SquareAppIcon component should render an app correctly with the given n
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-9"
@@ -104,7 +104,7 @@ exports[`SquareAppIcon component should render an app with the app slug if no na
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-71"
@@ -207,7 +207,7 @@ exports[`SquareAppIcon component should render correctly an app in error state 1
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-164"
@@ -317,7 +317,7 @@ exports[`SquareAppIcon component should render correctly an app in maintenance s
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-102"
@@ -366,7 +366,7 @@ exports[`SquareAppIcon component should render correctly an app in shortcut stat
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-226"
@@ -415,7 +415,7 @@ exports[`SquareAppIcon component should render correctly an app with custom cont
   data-testid="square-app-icon"
 >
   <div
-    class="palette__CozyTheme--normal___3UmMb"
+    class="CozyTheme--normal"
   >
     <span
       class="MuiBadge-root-318"

--- a/react/Stack/styles.styl
+++ b/react/Stack/styles.styl
@@ -1,4 +1,4 @@
-@require 'utilities/spaces.styl'
+@require 'settings/spaces.styl'
 
 for k,v in spacing_values
   modifier = "--" + k

--- a/react/Toggle/styles.styl
+++ b/react/Toggle/styles.styl
@@ -1,4 +1,3 @@
-@require '../../stylus/settings/palette'
 @require '../../stylus/tools/mixins'
 
 .toggle

--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette.styl'
 @require 'settings/icons.styl'
 @require 'settings/breakpoints.styl'
 @require 'settings/z-index.styl'

--- a/react/Viewer/ViewersByFile/styles.styl
+++ b/react/Viewer/ViewersByFile/styles.styl
@@ -1,5 +1,4 @@
 @require 'settings/breakpoints.styl'
-@require 'settings/palette.styl'
 @require 'settings/z-index.styl'
 @require '../vars.styl'
 

--- a/react/Viewer/components/styles.styl
+++ b/react/Viewer/components/styles.styl
@@ -1,7 +1,6 @@
 @require 'settings/z-index.styl'
 @require 'components/selectionbar.styl'
 @require 'settings/breakpoints.styl'
-@require 'settings/palette.styl'
 
 @require '../vars.styl'
 

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -1,5 +1,4 @@
 @require 'settings/breakpoints.styl'
-@require 'settings/palette.styl'
 @require 'settings/z-index.styl'
 @require './vars.styl'
 

--- a/react/utilities.js
+++ b/react/utilities.js
@@ -1,5 +1,0 @@
-/* eslint-disable no-unused-vars */
-
-// Special file for utilities to be included in the transpiled stylesheet
-import palette from '../stylus/utilities/palette.styl' // 130k
-import utilies from '../stylus/cozy-ui/utils.styl'

--- a/stylus/components/card.styl
+++ b/stylus/components/card.styl
@@ -1,5 +1,4 @@
 @require 'settings/breakpoints'
-@require 'settings/palette'
 @require 'tools/mixins'
 
 $card

--- a/stylus/components/chip.styl
+++ b/stylus/components/chip.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'tools/mixins'
 
 $chip-height-tiny = rem(24)

--- a/stylus/components/panels.styl
+++ b/stylus/components/panels.styl
@@ -1,4 +1,4 @@
-@require '../../stylus/utilities/spaces.styl'
+@require 'settings/spaces.styl'
 @require 'settings/breakpoints.styl'
 
 $panel-group

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -1,6 +1,5 @@
 @require '../settings/breakpoints'
 @require '../settings/z-index'
-@require '../utilities/display'
 @require '../tools/mixins'
 
 $selectionbar

--- a/stylus/cozy-ui/utils.styl
+++ b/stylus/cozy-ui/utils.styl
@@ -2,3 +2,4 @@
   CSS utility classes only
 \*------------------------------------*/
 @require '../utilities/*'
+@require '../settings/palette.styl'


### PR DESCRIPTION
Deux css sont utilisées dans la app en provenance de cozy-ui : 

- `cozy-ui/transpiled/react/stylesheet.css`
- `cozy-ui/dist/cozy-ui.utils.min.css`

La première, `stylesheet.css` est une css comportant les class hashé des composants react (legacy ou non, à partir du moment où on utilise du stylus dans le composant). Or il y avait différents problèmes : 

- contenait plusieurs fois les var CozyTheme normal `.styles__CozyTheme``--``normal___xxx` et inverted `.styles__CozyTheme--inverted___xxx` (avec hash)
- contenait plusieurs fois les classes utilitaires (sans hash)
- contenait plusieurs fois les styles sur les tag comme `html`, `:root` etc.

La deuxième `cozy-ui.utils.min.css` contient les classes utilitaires sans hash, ainsi que les class `CozyTheme`

démo pour comparer avec la prod actuel : 
- https://jf-cozy.github.io/cozy-ui/react/
- https://jf-cozy.github.io/cozy-ui/styleguide/

Pas de changement dans les app à faire, pas de BC, pas d'impact visuel (RAS côté argos). Voir BundleMon pour le gain de poids :)