### PR TITLE
 fix(css): Avoid importing z-index.styl in each css of legacy component

### DIFF
--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -29,7 +29,7 @@ $coz-bar-size=3rem
 
 
 .upload-queue--popover
-    z-index           $popover-index
+    z-index           var(--zIndex-popover)
     border            rem(1) solid var(--dividerColor)
     border-radius     rem(4)
     box-shadow        rem(0 1 3 0) rgba(50, 54, 63, .19), rem(0 6 18 0) rgba(50, 54, 63, .19)
@@ -133,13 +133,13 @@ progress.upload-queue-progress
         bottom auto
         right 0
         left 0
-        z-index $app-index + 3
+        z-index calc(var(--zIndex-app) + 3)
         max-height 0
 
         &:before
             position fixed
             top $coz-bar-size - $coz-bar-border-size
-            z-index  $nav-index
+            z-index  var(--zIndex-nav)
             width 100%
             height $coz-bar-border-size
             content ''

--- a/react/UploadQueue/styles.styl
+++ b/react/UploadQueue/styles.styl
@@ -1,9 +1,7 @@
 @require 'settings/icons.styl'
 @require 'settings/breakpoints.styl'
-@require 'settings/z-index.styl'
 @require 'settings/spaces.styl'
 @require 'settings/typography.styl'
-@require 'settings/z-index'
 
 $coz-bar-size=3rem
 

--- a/react/Viewer/ViewersByFile/styles.styl
+++ b/react/Viewer/ViewersByFile/styles.styl
@@ -1,5 +1,4 @@
 @require 'settings/breakpoints.styl'
-@require 'settings/z-index.styl'
 @require '../vars.styl'
 
 .viewer-imageviewer

--- a/react/Viewer/components/styles.styl
+++ b/react/Viewer/components/styles.styl
@@ -7,7 +7,7 @@
     position absolute
     top $toolbarHeight
     bottom 0
-    z-index $modal-toolbar-index
+    z-index var(--zIndex-modal-toolbar)
     width 20%
     cursor pointer
     background-color transparent
@@ -62,7 +62,7 @@
 .viewer-toolbar
     position absolute
     top 0
-    z-index $modal-toolbar-index
+    z-index var(--zIndex-modal-toolbar)
     display flex
     flex-shrink 0
     width calc(100% - 2rem)
@@ -86,7 +86,7 @@
 .viewer-footer
     position fixed
     bottom 0
-    z-index $modal-footer-index
+    z-index var(--zIndex-modal-footer)
     width 100%
     height $footerHeight
     padding-bottom var(--flagship-bottom-height, env(safe-area-inset-bottom))

--- a/react/Viewer/components/styles.styl
+++ b/react/Viewer/components/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/z-index.styl'
 @require 'components/selectionbar.styl'
 @require 'settings/breakpoints.styl'
 

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -1,5 +1,4 @@
 @require 'settings/breakpoints.styl'
-@require 'settings/z-index.styl'
 @require './vars.styl'
 
 .viewer-wrapper

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -7,7 +7,7 @@
     right           0
     top             0
     bottom          0
-    z-index         $overlay-index
+    z-index         var(--zIndex-overlay)
     overflow        hidden
     background      var(--charcoalGrey)
     color           var(--white)

--- a/react/deprecated/BottomDrawer/styles.styl
+++ b/react/deprecated/BottomDrawer/styles.styl
@@ -1,6 +1,5 @@
 @require 'tools/mixins'
 @require 'settings/spaces'
-@require 'settings/z-index'
 @require 'settings/breakpoints'
 @require 'generic/animations'
 

--- a/react/deprecated/BottomDrawer/styles.styl
+++ b/react/deprecated/BottomDrawer/styles.styl
@@ -7,7 +7,7 @@
     @extends $transition-transform-ease-out
 
 .BottomDrawer-content
-    z-index $drawer-index
+    z-index var(--zIndex-drawer)
     position fixed
     bottom 0
     left 0

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -1,4 +1,3 @@
-@require '../settings/z-index'
 @require '../components/button'
 @require '../tools/mixins'
 /*

--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -11,7 +11,7 @@ alert-width = rem(640)
 
 $alert
     position fixed
-    z-index $alert-index
+    z-index var(--zIndex-alert)
     right 0
     bottom calc(3rem + env(safe-area-inset-bottom))
     left 0
@@ -24,13 +24,13 @@ $alert
         transition none
 
     @media all and (min-width alert-width)
-        z-index $alert-index
+        z-index var(--zIndex-alert)
         top rem(16)
         bottom auto
         text-align center
 
 $alert--modal
-    z-index $alert-index
+    z-index var(--zIndex-alert)
     bottom 0
 
 $alert-wrapper

--- a/stylus/components/avatar.styl
+++ b/stylus/components/avatar.styl
@@ -4,7 +4,7 @@ $avatar
     background-color var(--paleGrey)
     color var(--silver)
     position relative
-    z-index $low-index
+    z-index var(--zIndex-low)
 
     svg
         width 50%

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -36,7 +36,7 @@ xxlarge-padding = rem(48)
 
 $modals
     position relative
-    z-index $modal-index
+    z-index var(--zindex-modal)
 
 $modal-wrapper
     position fixed

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -1,4 +1,3 @@
-@require '../settings/z-index'
 @require '../settings/breakpoints'
 @require '../objects/layouts'
 @require '../tools/mixins'

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -1,5 +1,4 @@
 @require '../settings/breakpoints'
-@require '../settings/z-index'
 @require '../settings/typography'
 @require '../tools/mixins'
 

--- a/stylus/components/nav.styl
+++ b/stylus/components/nav.styl
@@ -20,7 +20,7 @@ $nav
 
 $nav-item
     position        relative
-    z-index         $app-index
+    z-index         var(--zIndex-app)
     height          rem(48)
     box-sizing      border-box
     cursor          pointer
@@ -28,7 +28,7 @@ $nav-item
     &:hover::before
         content        ''
         position       absolute
-        z-index        $below-index
+        z-index        var(--zIndex-below)
         border-radius  rem(0 3 3 0)
         top 0
         left 0
@@ -143,7 +143,7 @@ $nav-item-secondary
     &:hover::before
         content        ''
         position       absolute
-        z-index        $below-index
+        z-index        var(--zIndex-below)
         border-radius  rem(3 0 0 3)
         top 0
         right 0

--- a/stylus/components/overlay.styl
+++ b/stylus/components/overlay.styl
@@ -1,5 +1,3 @@
-@require '../settings/z-index'
-
 $overlay
     z-index     $overlay-index
     position    fixed

--- a/stylus/components/overlay.styl
+++ b/stylus/components/overlay.styl
@@ -1,5 +1,5 @@
 $overlay
-    z-index     $overlay-index
+    z-index     var(--zIndex-overlay)
     position    fixed
     top         0
     left        0

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -8,7 +8,7 @@
 \*------------------------------------*/
 
 $popover
-    z-index           $popover-index
+    z-index           var(--zIndex-popover)
     border            rem(1) solid var(--dividerColor)
     border-radius     rem(4)
     box-shadow        rem(0 1 3 0) rgba(50, 54, 63, .19), rem(0 6 18 0) rgba(50, 54, 63, .19)

--- a/stylus/components/popover.styl
+++ b/stylus/components/popover.styl
@@ -1,4 +1,3 @@
-@require '../settings/z-index'
 @require '../tools/mixins'
 
 /*------------------------------------*\

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -3,7 +3,7 @@
 
 $selectionbar
     position          fixed
-    z-index           $selection-index
+    z-index           var(--zIndex-selection)
     top               0
     left              0
     box-sizing        border-box

--- a/stylus/components/selectionbar.styl
+++ b/stylus/components/selectionbar.styl
@@ -1,5 +1,4 @@
 @require '../settings/breakpoints'
-@require '../settings/z-index'
 @require '../tools/mixins'
 
 $selectionbar

--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -94,7 +94,7 @@ $table-cell--primary
 $table-divider
     @extend $section-header
     position sticky
-    z-index $low-index
+    z-index var(--zIndex-low)
     top 0
 
 // Legacy table

--- a/stylus/components/table.styl
+++ b/stylus/components/table.styl
@@ -1,5 +1,4 @@
 @require '../settings/breakpoints'
-@require '../settings/z-index'
 @require '../tools/mixins'
 @require './sections'
 

--- a/stylus/cozy-ui/utils.styl
+++ b/stylus/cozy-ui/utils.styl
@@ -3,3 +3,4 @@
 \*------------------------------------*/
 @require '../utilities/*'
 @require '../settings/palette.styl'
+@require '../settings/z-index.styl'

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -130,5 +130,5 @@ $app-2panes-sticky
             bottom 0
             left 0
             display block
-            z-index $nav-index
+            z-index var(--zIndex-nav)
             width 100%

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -1,6 +1,5 @@
 @require '../tools/mixins'
 @require '../settings/breakpoints'
-@require '../settings/z-index'
 @require '../elements/defaults'
 
 /*------------------------------------*\

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -65,6 +65,8 @@ html
     --zIndex-fileActionMenu $file-action-menu
     --zIndex-drawer $drawer-index
     --zIndex-modal $modal-index
+    --zIndex-modal-footer $modal-footer-index
+    --zIndex-modal-toolbar $modal-toolbar-index
     --zindex-alert $alert-index
 // @stylint on
 


### PR DESCRIPTION
Prefer to import z-index.styl in utils.styl to avoid duplication.

Follows @JF-Cozy work here https://github.com/cozy/cozy-ui/pull/2454