### PR TITLE
docs: Add a fake first component to reduce first time loading

### DIFF
--- a/docs/components/Readme.md
+++ b/docs/components/Readme.md
@@ -1,0 +1,1 @@
+<!-- For styleguidist, a .md file is needed in directories -->

--- a/docs/components/Readme/Readme.md
+++ b/docs/components/Readme/Readme.md
@@ -1,0 +1,5 @@
+Welcome on Cozy-ui documentation.
+
+You can find everything you need to know about cozy-ui there : https://github.com/cozy/cozy-ui#readme
+
+Use left sidebar to pick a component and see how it works.

--- a/docs/components/Readme/index.js
+++ b/docs/components/Readme/index.js
@@ -1,0 +1,1 @@
+// useless mandatory file for styleguidist docu

--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -6,6 +6,10 @@ module.exports = {
   pagePerSection: true,
   sections: [
     {
+      name: 'Cozy-ui documentation',
+      components: () => ['../docs/components/Readme']
+    },
+    {
       name: 'Core',
       components: () => [
         '../react/MuiCozyTheme/Accordion',


### PR DESCRIPTION
the `core`, `extra`, `legacy` groups in the documentation contains now a lot of components, so the first load of these pages is very long. This is a quick fix but we need to investigate further (and maybe migrates to storybook...)

démo : https://jf-cozy.github.io/cozy-ui/react/