### PR TITLE
fix(Viewer): Force style of ActionMenuDesktop

### DIFF
--- a/react/Viewer/Panel/styles.styl
+++ b/react/Viewer/Panel/styles.styl
@@ -1,6 +1,6 @@
 .ActionMenuDesktop-ActionMenu
     a
-        padding 0
+        padding 0 !important // Waiting for the migration of the ActionMenu on the Viewer
     .ActionMenuDesktop-ActionMenu-link-disabled
         > div
             cursor default


### PR DESCRIPTION
Otherwise the style in `action-menu.styl` takes priority.

Waiting for the migration of the ActionMenu on the Viewer