### PR TITLE
fix(Alerts): Use correct CSS variable for z-index property

### DIFF
--- a/stylus/components/alerts.styl
+++ b/stylus/components/alerts.styl
@@ -80,4 +80,3 @@ $alert--success
 $alert--info
     color var(--alertInfoColor)
     background-color var(--alertInfoBackgroundColor)
-

--- a/stylus/settings/z-index.styl
+++ b/stylus/settings/z-index.styl
@@ -67,6 +67,5 @@ html
     --zIndex-modal $modal-index
     --zIndex-modal-footer $modal-footer-index
     --zIndex-modal-toolbar $modal-toolbar-index
-    --zindex-alert $alert-index
+    --zIndex-alert $alert-index
 // @stylint on
-


### PR DESCRIPTION
BREAKING CHANGE: Rename `--zindex-alert` CSS variable to `--zIndex-alert`