### PR TITLE
ActionsItems: Add possibility to spread arg  between onClick and actions

### DIFF
--- a/react/ActionsMenu/ActionsItems.jsx
+++ b/react/ActionsMenu/ActionsItems.jsx
@@ -20,8 +20,8 @@ const ActionsItems = forwardRef(
 
       const { Component: ActionComponent, action, disabled } = actionDefinition
 
-      const handleClick = () => {
-        action && action(doc, { client, t, ...actionOptions })
+      const handleClick = clickProps => {
+        action && action(doc, { client, t, ...actionOptions, ...clickProps })
         overridedClick && overridedClick()
       }
 

--- a/react/ActionsMenu/ActionsItems.jsx
+++ b/react/ActionsMenu/ActionsItems.jsx
@@ -6,7 +6,7 @@ import { useI18n } from '../I18n'
 import { getActionName, getOnlyNeededActions } from './Actions/helpers'
 
 const ActionsItems = forwardRef(
-  ({ doc, actions, actionOptions, onClick, ...props }, ref) => {
+  ({ doc, actions, actionOptions, onClick: overridedClick, ...props }, ref) => {
     const client = useClient()
     const { t } = useI18n()
     const cleanedActions = useMemo(() => getOnlyNeededActions(actions, doc), [
@@ -22,7 +22,7 @@ const ActionsItems = forwardRef(
 
       const handleClick = () => {
         action && action(doc, { client, t, ...actionOptions })
-        onClick && onClick()
+        overridedClick && overridedClick()
       }
 
       return (
@@ -45,6 +45,7 @@ ActionsItems.propTypes = {
   actions: PropTypes.array,
   /** Props spread to action method of Actions component */
   actionOptions: PropTypes.object,
+  /** The overrideClick function from ActionsMenuWrapper */
   onClick: PropTypes.func
 }
 

--- a/react/ActionsMenu/ActionsMenuWrapper.jsx
+++ b/react/ActionsMenu/ActionsMenuWrapper.jsx
@@ -20,7 +20,7 @@ const ActionsMenuWrapper = ({
   useActionMenuEffects()
 
   const overrideClick = props => () => {
-    props.onClick?.()
+    props.onClick?.() // this is ActionsItems onClick prop
     autoClose && onClose?.()
   }
 

--- a/react/ActionsMenu/Readme.md
+++ b/react/ActionsMenu/Readme.md
@@ -11,10 +11,13 @@ Use `makeActions` method and create (or use the predefined actions) to build the
 ```bash
 const action1 = ({ option1, option2 }) => ({
   name: action1,
-  Component: props => <SomeComponent {...props} />
+  action: ({ option3, option4 }) => {}
+  Component: ({ onClick, ...props }) => <SomeComponent {...props} onClick={() => onClick({ option3 })}} />
 })
 
 const actions = makeActions([action1, action2], { option1, option2 })
+
+<ActionsMenu actions={actions} componentsProps={{ actionsItems: { actionOptions: { option4 }} }}
 ```
 
 #### How to create actions


### PR DESCRIPTION
Lors de la construction d'une action, il est maintenant possible de passer un argument à onClick afin de le récupérer dans les actions.