### PR TITLE
Add DemoProvider and throw error in useI18n

### DIFF
--- a/react/ContactPicker/index.spec.jsx
+++ b/react/ContactPicker/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
+import { I18nContext } from '../I18n'
 import DemoProvider from '../ContactsListModal/DemoProvider'
 import { BreakpointsProvider } from '../hooks/useBreakpoints'
 import contacts from '../ContactsList/_mockContacts.json'
@@ -8,9 +9,21 @@ import contacts from '../ContactsList/_mockContacts.json'
 import ContactPicker from '.'
 
 const Wrapper = ({ children }) => {
+  const lang = localStorage.getItem('lang') || 'en'
+
   return (
     <DemoProvider>
-      <BreakpointsProvider>{children}</BreakpointsProvider>
+      <BreakpointsProvider>
+        <I18nContext.Provider
+          value={{
+            t: x => x,
+            f: () => '01 Jan. 2022',
+            lang
+          }}
+        >
+          {children}
+        </I18nContext.Provider>
+      </BreakpointsProvider>
     </DemoProvider>
   )
 }

--- a/react/ContactsListModal/Readme.md
+++ b/react/ContactsListModal/Readme.md
@@ -21,26 +21,37 @@ client.registerPlugin(RealtimePlugin)
 ```
 
 ```jsx
-import ContactsListModal from 'cozy-ui/transpiled/react/ContactsListModal';
-import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints';
-import DemoProvider from './DemoProvider';
+import ContactsListModal from 'cozy-ui/transpiled/react/ContactsListModal'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { I18nContext } from 'cozy-ui/transpiled/react/I18n'
+import DemoProvider from './DemoProvider'
 
-initialState = { opened: isTesting() };
+initialState = { opened: isTesting() }
+
+;
 
 <DemoProvider>
   <BreakpointsProvider>
-    <button type="button" onClick={() => setState({ opened: true })}>
-      Open contacts list
-    </button>
-    {state.opened && (
-      <ContactsListModal
-        placeholder="Search a contact"
-        dismissAction={() => setState({ opened: false })}
-        onItemClick={contact => alert(`Clicked on ${contact._id}`)}
-        addContactLabel="Add a contact"
-        emptyMessage="No contact"
-      />
-    )}
+    <I18nContext.Provider
+      value={{
+        t: x => x,
+        f: () => '01 Jan. 2022',
+        lang: localStorage.getItem('lang') || 'en'
+      }}
+    >
+      <button type="button" onClick={() => setState({ opened: true })}>
+        Open contacts list
+      </button>
+      {state.opened && (
+        <ContactsListModal
+          placeholder="Search a contact"
+          dismissAction={() => setState({ opened: false })}
+          onItemClick={contact => alert(`Clicked on ${contact._id}`)}
+          addContactLabel="Add a contact"
+          emptyMessage="No contact"
+        />
+      )}
+    </I18nContext.Provider>
   </BreakpointsProvider>
 </DemoProvider>
 ```

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -63,7 +63,7 @@ import {
   PermissionDialog
 } from  'cozy-ui/transpiled/react/CozyDialogs'
 
-import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import DemoProvider from 'cozy-ui/transpiled/react/providers/DemoProvider'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
@@ -243,7 +243,7 @@ const setFlagshipVars = () => {
 }
 ;
 
-<BreakpointsProvider>
+<DemoProvider>
   <Button
     onClick={() => setFlagshipVars()}
     variant="secondary"
@@ -386,14 +386,15 @@ const setFlagshipVars = () => {
       </>
     )}
   </Variants>
-</BreakpointsProvider>
+</DemoProvider>
 ```
 
 ### Dialogs with title button
 
 ```jsx
 import cx from 'classnames'
-import useBreakpoints, { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import DemoProvider from 'cozy-ui/transpiled/react/providers/DemoProvider'
 
 import { Dialog } from  'cozy-ui/transpiled/react/CozyDialogs'
 import Button from  'cozy-ui/transpiled/react/Buttons'
@@ -433,11 +434,11 @@ const Modal = () => {
 
 ;
 
-<BreakpointsProvider>
+<DemoProvider>
   <Button label="Open modal" onClick={() => setState({ showModal: true })}/>
 
   {state.showModal && (
     <Modal />
   )}
-</BreakpointsProvider>
+</DemoProvider>
 ```

--- a/react/CozyDialogs/testing.spec.jsx
+++ b/react/CozyDialogs/testing.spec.jsx
@@ -9,7 +9,8 @@ import {
   getBackButton,
   getBackCloseButton
 } from './testing'
-import useBreakpoints, { BreakpointsProvider } from '../hooks/useBreakpoints'
+import useBreakpoints from '../hooks/useBreakpoints'
+import DemoProvider from '../providers/DemoProvider'
 
 jest.mock('../hooks/useBreakpoints', () => ({
   ...jest.requireActual('../hooks/useBreakpoints'),
@@ -22,7 +23,7 @@ describe('testing utils for dialog', () => {
   const setup = ({ isMobile = false, onClose, onBack } = {}) => {
     useBreakpoints.mockReturnValue({ isMobile })
     const root = render(
-      <BreakpointsProvider>
+      <DemoProvider>
         <Dialog
           open
           title="Title"
@@ -30,7 +31,7 @@ describe('testing utils for dialog', () => {
           onClose={onClose}
           onBack={onBack}
         />
-      </BreakpointsProvider>
+      </DemoProvider>
     )
     return { root }
   }

--- a/react/Dialog/Readme.md
+++ b/react/Dialog/Readme.md
@@ -8,9 +8,8 @@ will make sure that even your custom Dialogs will behave as CozyDialogs.
 ```jsx
 import Dialog, { DialogTitle, DialogActions } from 'cozy-ui/transpiled/react/Dialog'
 import { DialogBackButton, DialogCloseButton, useCozyDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import useBreakpoints, {
-  BreakpointsProvider
-} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import DemoProvider from 'cozy-ui/transpiled/react/providers/DemoProvider'
 import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
 
 import Divider from 'cozy-ui/transpiled/react/Divider'
@@ -134,9 +133,9 @@ const ExampleDialog = ({ open, onClose }) => {
   <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
     Toggle modal
   </button>
-  <BreakpointsProvider>
+  <DemoProvider>
     <Alerter />
     <ExampleDialog open={state.modalOpened} onClose={handleClose} />
-  </BreakpointsProvider>
+  </DemoProvider>
 </>
 ```

--- a/react/I18n/createUseI18n.jsx
+++ b/react/I18n/createUseI18n.jsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import Polyglot from 'node-polyglot'
+
+import { initFormat } from './format'
+import { useI18n, DEFAULT_LANG } from '.'
+
+const createUseI18n = locales => () => {
+  const { lang } = useI18n() || { lang: DEFAULT_LANG }
+
+  return useMemo(() => {
+    const polyglot = new Polyglot({
+      locale: DEFAULT_LANG,
+      phrases: locales[DEFAULT_LANG]
+    })
+
+    if (lang && lang !== DEFAULT_LANG) {
+      try {
+        polyglot.locale(lang)
+        polyglot.extend(locales[lang])
+      } catch (e) {
+        console.warn(`The dict phrases for "${lang}" can't be loaded`)
+      }
+    }
+
+    const f = initFormat(lang)
+    const t = polyglot.t.bind(polyglot)
+
+    return { t, f, lang }
+  }, [lang])
+}
+
+export default createUseI18n

--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -4,9 +4,8 @@
 
 'use strict'
 
-import React, { Component, useContext, useMemo, forwardRef } from 'react'
+import React, { Component, useContext } from 'react'
 import PropTypes from 'prop-types'
-import Polyglot from 'node-polyglot'
 
 import { initTranslation } from './translation'
 import { initFormat } from './format'
@@ -76,53 +75,12 @@ I18n.childContextTypes = {
   lang: PropTypes.string
 }
 
-// higher order decorator for components that need `t` and/or `f`
-export const translate = () => WrappedComponent => {
-  const Wrapper = forwardRef((props, ref) => {
-    const i18nContext = useContext(I18nContext)
-
-    return (
-      <WrappedComponent
-        {...props}
-        ref={ref}
-        t={i18nContext && i18nContext.t}
-        f={i18nContext && i18nContext.f}
-        lang={i18nContext && i18nContext.lang}
-      />
-    )
-  })
-
-  Wrapper.displayName = `withI18n(${WrappedComponent.displayName ||
-    WrappedComponent.name})`
-
-  return Wrapper
-}
-
 export const useI18n = () => {
   return useContext(I18nContext)
 }
 
-export const createUseI18n = locales => () => {
-  const { lang } = useI18n() || { lang: DEFAULT_LANG }
-  return useMemo(() => {
-    const polyglot = new Polyglot({
-      locale: DEFAULT_LANG,
-      phrases: locales[DEFAULT_LANG]
-    })
-    if (lang && lang !== DEFAULT_LANG) {
-      try {
-        polyglot.locale(lang)
-        polyglot.extend(locales[lang])
-      } catch (e) {
-        console.warn(`The dict phrases for "${lang}" can't be loaded`)
-      }
-    }
-    const f = initFormat(lang)
-    const t = polyglot.t.bind(polyglot)
-    return { t, f, lang }
-  }, [lang])
-}
-
 export { initTranslation, extend } from './translation'
+export { default as translate } from './translate'
+export { default as createUseI18n } from './createUseI18n'
 
 export default I18n

--- a/react/I18n/index.jsx
+++ b/react/I18n/index.jsx
@@ -14,6 +14,18 @@ export const DEFAULT_LANG = 'en'
 
 export const I18nContext = React.createContext()
 
+export const useI18n = () => {
+  const context = useContext(I18nContext)
+
+  if (!context) {
+    throw new Error(
+      '`I18nContext` is missing. `useI18n()` must be used within a `<I18n>`'
+    )
+  }
+
+  return context
+}
+
 // Provider root component
 export class I18n extends Component {
   constructor(props) {
@@ -73,10 +85,6 @@ I18n.childContextTypes = {
   t: PropTypes.func,
   f: PropTypes.func,
   lang: PropTypes.string
-}
-
-export const useI18n = () => {
-  return useContext(I18nContext)
 }
 
 export { initTranslation, extend } from './translation'

--- a/react/I18n/translate.jsx
+++ b/react/I18n/translate.jsx
@@ -1,0 +1,27 @@
+import React, { useContext, forwardRef } from 'react'
+
+import { I18nContext } from '.'
+
+// higher order decorator for components that need `t` and/or `f`
+const translate = () => WrappedComponent => {
+  const Wrapper = forwardRef((props, ref) => {
+    const i18nContext = useContext(I18nContext)
+
+    return (
+      <WrappedComponent
+        {...props}
+        ref={ref}
+        t={i18nContext && i18nContext.t}
+        f={i18nContext && i18nContext.f}
+        lang={i18nContext && i18nContext.lang}
+      />
+    )
+  })
+
+  Wrapper.displayName = `withI18n(${WrappedComponent.displayName ||
+    WrappedComponent.name})`
+
+  return Wrapper
+}
+
+export default translate

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -6,7 +6,8 @@ import NestedSelectModal from './Modal'
 import ListItem from '../ListItem'
 import ListItemText from '../ListItemText'
 import Checkbox from '../Checkbox'
-import useBreakpoints, { BreakpointsProvider } from '../hooks/useBreakpoints'
+import useBreakpoints from '../hooks/useBreakpoints'
+import DemoProvider from '../providers/DemoProvider'
 import palette from 'cozy-ui/transpiled/react/palette'
 
 const Image = ({ letter }) => (
@@ -170,11 +171,11 @@ const InteractiveExample = () => {
 ;
 
 <>
-  <BreakpointsProvider>
+  <DemoProvider>
     {isTesting()
       ? <StaticExample />
       : <InteractiveExample />
     }
-  </BreakpointsProvider>
+  </DemoProvider>
 </>
 ```

--- a/react/SelectBox/Readme.md
+++ b/react/SelectBox/Readme.md
@@ -293,9 +293,7 @@ the options to be displayed on top of all the layers.
 ```jsx
 import { useState, useEffect } from 'react'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import {
-  BreakpointsProvider
-} from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import DemoProvider from 'cozy-ui/transpiled/react/providers/DemoProvider'
 
 import Button from 'cozy-ui/transpiled/react/deprecated/Button'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -375,10 +373,10 @@ const ExampleDialog = ({ open, onClose }) => {
   <button onClick={() => setState({ modalOpened: !state.modalOpened })}>
     Toggle modal
   </button>
-  <BreakpointsProvider>
+  <DemoProvider>
     { state.modalOpened
       ? <ExampleDialog open={true} onClose={handleClose} />
       : null }
-  </BreakpointsProvider>
+  </DemoProvider>
 </>
 ```

--- a/react/providers/DemoProvider.jsx
+++ b/react/providers/DemoProvider.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import { CozyProvider } from 'cozy-client'
+
+import { BreakpointsProvider } from '../hooks/useBreakpoints'
+import { I18nContext } from '../I18n'
+
+const defaultClient = {
+  plugins: {
+    realtime: {
+      subscribe: () => {},
+      unsubscribe: () => {},
+      unsubscribeAll: () => {}
+    }
+  },
+  getStackClient: () => ({
+    uri: 'https://cozy.io/'
+  }),
+  getInstanceOptions: () => ({
+    subdomain: ''
+  })
+}
+
+const DemoProvider = ({ client, children }) => {
+  const lang = localStorage.getItem('lang') || 'en'
+
+  return (
+    <CozyProvider client={client || defaultClient}>
+      <BreakpointsProvider>
+        <I18nContext.Provider
+          value={{
+            t: x => x,
+            f: () => '01 Jan. 2022',
+            lang
+          }}
+        >
+          {children}
+        </I18nContext.Provider>
+      </BreakpointsProvider>
+    </CozyProvider>
+  )
+}
+
+export default DemoProvider


### PR DESCRIPTION
Ceci est une première PR concernant une sujet de déplacement des providers dans un nouveau dossier react/providers.

J'avais corrigé quelques trucs sur les providers I18n et CozyTheme. Comme c'est trop long de tout reprendre d'un coup, je découpe en morceau. Ici cela concerne I18n.

On en profite pour créer le dossier /react/providers et d'utiliser un premier provider `DemoProvider` qui ne sert pour  l'instant qu'à cozy-ui.

Suivra ensuite les PR concernant le déplacement des providers de cozy-ui pour les app.