### PR TITLE
feat: Badge center

### DIFF
--- a/react/Badge/Readme.md
+++ b/react/Badge/Readme.md
@@ -69,3 +69,32 @@ import LinkIcon from "cozy-ui/transpiled/react/Icons/Link"
   <Avatar text="CD" size="small" />
 </InfosBadge>
 ```
+
+### Center badge
+
+The `center` property is used to create a standalone badge that can be integrated into a ListItem, for example, to notify the user.
+
+```jsx
+import Badge from 'cozy-ui/transpiled/react/Badge'
+
+const centerProps = {
+  center: true,
+  color: 'error',
+  withBorder: false,
+  badgeContent: 10
+};
+
+<div class="u-flex u-flex-items-center">
+  <Badge
+    size="small"
+    {...centerProps} />
+  <Badge
+    className="u-ml-1"
+    size="medium"
+    {...centerProps} />
+  <Badge
+    className="u-ml-1"
+    center
+    {...centerProps} />
+</div>
+```

--- a/react/Badge/Readme.md
+++ b/react/Badge/Readme.md
@@ -13,7 +13,7 @@ import Variants from 'cozy-ui/docs/components/Variants'
 import CircleFilledIcon from "cozy-ui/transpiled/react/Icons/CircleFilled"
 
 const initialVariants = [
-  { overlap: true, error: false, dot: false, withBorder: false, left: false, bottom: false, small: false, large: false }
+  { overlap: true, error: false, dot: false, withBorder: false, withGreyBorder: false, left: false, bottom: false, small: false, large: false }
 ]
 
 ;
@@ -33,6 +33,7 @@ const initialVariants = [
         horizontal: variant.left ? "left" : "right",
       }}
       withBorder={variant.withBorder}
+      withGreyBorder={variant.withGreyBorder}
       overlap={variant.overlap ? "circular" : "rectangular"}
     >
       <Icon

--- a/react/Badge/index.jsx
+++ b/react/Badge/index.jsx
@@ -7,6 +7,7 @@ const Badge = ({
   classes = {},
   size,
   withBorder,
+  withGreyBorder,
   overlap: overlapProp,
   ...props
 }) => {
@@ -28,7 +29,14 @@ const Badge = ({
   return (
     <MuiBadge
       classes={{
-        badge: cx(sizeClasses[size], withBorder ? 'badgeBorder' : null),
+        badge: cx(
+          sizeClasses[size],
+          withBorder
+            ? withGreyBorder
+              ? 'badgeGreyBorder'
+              : 'badgeBorder'
+            : null
+        ),
         ...classes
       }}
       overlap={overlap}
@@ -45,7 +53,10 @@ Badge.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   showZero: PropTypes.bool,
   variant: PropTypes.oneOf(['standard', 'dot']),
-  withBorder: PropTypes.bool
+  /** Display a border around the badge */
+  withBorder: PropTypes.bool,
+  /** Set border color into grey */
+  withGreyBorder: PropTypes.bool
 }
 
 Badge.defaultProps = {
@@ -53,6 +64,7 @@ Badge.defaultProps = {
   size: 'medium',
   showZero: true,
   withBorder: true,
+  withGreyBorder: false,
   overlap: 'circular'
 }
 

--- a/react/Badge/index.jsx
+++ b/react/Badge/index.jsx
@@ -9,12 +9,19 @@ const Badge = ({
   withBorder,
   withGreyBorder,
   overlap: overlapProp,
+  center,
   ...props
 }) => {
   const sizeClasses = {
     small: 'badgeSizeSmall',
     medium: 'badgeSizeMedium',
     large: 'badgeSizeLarge'
+  }
+
+  const centerClasses = {
+    small: 'badgeCenterSmall',
+    medium: 'badgeCenterMedium',
+    large: 'badgeCenterLarge'
   }
 
   // due to deprecated prop circle and rectangle
@@ -29,13 +36,15 @@ const Badge = ({
   return (
     <MuiBadge
       classes={{
+        root: cx(center ? centerClasses[size] : null),
         badge: cx(
           sizeClasses[size],
           withBorder
             ? withGreyBorder
               ? 'badgeGreyBorder'
               : 'badgeBorder'
-            : null
+            : null,
+          center ? 'badgeCenter' : null
         ),
         ...classes
       }}
@@ -56,7 +65,9 @@ Badge.propTypes = {
   /** Display a border around the badge */
   withBorder: PropTypes.bool,
   /** Set border color into grey */
-  withGreyBorder: PropTypes.bool
+  withGreyBorder: PropTypes.bool,
+  /** Center the badge */
+  center: PropTypes.bool
 }
 
 Badge.defaultProps = {
@@ -65,7 +76,8 @@ Badge.defaultProps = {
   showZero: true,
   withBorder: true,
   withGreyBorder: false,
-  overlap: 'circular'
+  overlap: 'circular',
+  center: false
 }
 
 export default Badge

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -630,6 +630,20 @@ export const makeOverrides = theme => ({
     }
   },
   MuiBadge: {
+    root: {
+      '&.badgeCenterLarge': {
+        height: '1rem',
+        minWidth: '1rem'
+      },
+      '&.badgeCenterMedium': {
+        height: '.875rem',
+        minWidth: '.875rem'
+      },
+      '&.badgeCenterSmall': {
+        height: '.75rem',
+        minWidth: '.75rem'
+      }
+    },
     badge: {
       boxSizing: 'content-box',
       padding: 0,
@@ -653,6 +667,12 @@ export const makeOverrides = theme => ({
         height: '.75rem',
         minWidth: '.75rem',
         fontSize: '.5rem'
+      },
+      '&.badgeCenter': {
+        position: 'relative',
+        top: 'auto',
+        right: 'auto',
+        transform: 'none'
       }
     },
     anchorOriginTopRightRectangular: {

--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -636,6 +636,9 @@ export const makeOverrides = theme => ({
       '&.badgeBorder': {
         border: `2px solid ${theme.palette.background.paper}`
       },
+      '&.badgeGreyBorder': {
+        border: `2px solid var(--paleGrey)`
+      },
       '&.badgeSizeLarge': {
         fontSize: '.6875rem',
         height: '1rem',


### PR DESCRIPTION
Improving the badge to create a stand-alone component that can be integrated into a Table, for example. [Live demo](https://cballevre.github.io/cozy-ui/react/#!/Core/Badge)

![Capture d’écran 2023-08-10 à 10 55 15](https://github.com/cozy/cozy-ui/assets/7434420/780fccd1-f072-4171-a1ff-072ea76b97c1)
