### PR TITLE
fix(Viewer): Remove filename on path ending with slash

### DIFF
--- a/react/Viewer/components/ToolbarFilePath.jsx
+++ b/react/Viewer/components/ToolbarFilePath.jsx
@@ -7,7 +7,11 @@ import AppLinker from '../../AppLinker'
 import FilePath from '../../FilePath'
 import useBreakpoints from '../../hooks/useBreakpoints'
 
-import { makeWebLink, normalizeAndSpreadAttributes } from '../helpers'
+import {
+  makeWebLink,
+  normalizeAndSpreadAttributes,
+  removeFilenameFromPath
+} from '../helpers'
 import { buildFileByIdQuery } from '../queries'
 
 const { ensureFilePath } = models.file
@@ -35,7 +39,7 @@ const ToolbarFilePath = ({ file }) => {
   if (fileWithPath) {
     const appSlug = 'drive'
     const nativePath = `/folder/${fileWithPath.dir_id}`
-    const path = fileWithPath.path.replace(fileWithPath.name, '')
+    const path = removeFilenameFromPath(fileWithPath.path)
     const link = makeWebLink({ client, path: nativePath, slug: appSlug })
 
     if (isDesktop && link) {

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -203,3 +203,13 @@ export const makeWebLink = ({ client, slug, path }) => {
     return null
   }
 }
+
+/**
+ * Remove the file name at the end of a path
+ * @param {string} path
+ * @returns {string} new path
+ */
+export const removeFilenameFromPath = path => {
+  const newPath = path.substring(0, path.lastIndexOf('/'))
+  return newPath === '' ? '/' : newPath
+}

--- a/react/Viewer/helpers.spec.js
+++ b/react/Viewer/helpers.spec.js
@@ -7,7 +7,8 @@ import {
   buildEditAttributePath,
   knownDateMetadataNames,
   knownInformationMetadataNames,
-  isEditableAttribute
+  isEditableAttribute,
+  removeFilenameFromPath
 } from './helpers'
 
 const fakeMetadata = {
@@ -153,6 +154,21 @@ describe('helpers', () => {
         const qualification = isEditableAttribute('qualification', makeFile())
         expect(qualification).toBe(false)
       })
+    })
+  })
+  describe('removeFilenameFromPath', () => {
+    it('should handle all types of path', () => {
+      expect(removeFilenameFromPath('/folder/7IsD.gif', '7IsD.gif')).toBe(
+        '/folder'
+      )
+
+      expect(removeFilenameFromPath('/7IsD.gif', '7IsD.gif')).toBe('/')
+
+      expect(removeFilenameFromPath('//7IsD.gif', '7IsD.gif')).toBe('/')
+
+      expect(removeFilenameFromPath('/7IsD.gif/7IsD.gif', '7IsD.gif')).toBe(
+        '/7IsD.gif'
+      )
     })
   })
 })


### PR DESCRIPTION
When the file was at the root and the path ended with a slash, the path displayed to the user was `//`. I've improved the function to avoid this