### PR TITLE
Add rerendering content compliancy on  BottomSheet

### DIFF
--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -29,6 +29,7 @@ import {
   setTopPosition,
   setBottomPosition,
   minimizeAndClose,
+  getCssValue,
   computeBottomSpacer
 } from './helpers'
 import { ANIMATION_DURATION } from './constants'
@@ -208,14 +209,11 @@ const BottomSheet = memo(
     useEffect(() => {
       const headerContent = headerContentRef.current
       const innerContentHeight = innerContentRef.current.offsetHeight
-      const actionButtonsHeight = headerContent
-        ? parseFloat(getComputedStyle(headerContent).getPropertyValue('height'))
-        : 0
-      const actionButtonsBottomMargin = headerContent
-        ? parseFloat(
-            getComputedStyle(headerContent).getPropertyValue('padding-bottom')
-          )
-        : 0
+      const actionButtonsHeight = getCssValue(headerContent, 'height')
+      const actionButtonsBottomMargin = getCssValue(
+        headerContent,
+        'padding-bottom'
+      )
 
       const maxHeight = computeMaxHeight(toolbarProps)
 

--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -15,9 +15,11 @@ import Portal from '@material-ui/core/Portal'
 
 import { getFlagshipMetadata } from 'cozy-device-helper'
 
+import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 import CozyTheme, { useCozyTheme } from '../providers/CozyTheme'
 import Stack from '../Stack'
 import Paper from '../Paper'
+
 import BackdropOrFragment from './BackdropOrFragment'
 import {
   computeMaxHeight,
@@ -30,7 +32,6 @@ import {
   computeBottomSpacer
 } from './helpers'
 import { ANIMATION_DURATION } from './constants'
-import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 
 const createContainerWrapperStyles = () => ({
   container: {
@@ -242,6 +243,8 @@ const BottomSheet = memo(
 
       if (computedMediumHeight >= maxHeight) {
         setIsTopPosition(true)
+      } else {
+        setIsTopPosition(false)
       }
       setPeekHeights([...new Set([minHeight, computedMediumHeight, maxHeight])])
       setInitPos(computedMediumHeight)

--- a/react/BottomSheet/helpers.js
+++ b/react/BottomSheet/helpers.js
@@ -136,3 +136,6 @@ export const computeBottomSpacer = ({
   // without backdrop, we want the bottomsheet to open to the top of the window
   return maxHeight - innerContentHeight
 }
+
+export const getCssValue = (element, value) =>
+  element ? parseFloat(getComputedStyle(element).getPropertyValue(value)) : 0

--- a/react/BottomSheet/styles.styl
+++ b/react/BottomSheet/styles.styl
@@ -1,0 +1,15 @@
+.renderSaferAnim
+  position absolute
+  bottom 0
+  height 0
+  width 100%
+  animation slidein 1s
+
+@keyframes slidein {
+  from {
+    height 100%
+  }
+  to {
+    height 0
+  }
+}

--- a/react/NestedSelect/BottomSheet.jsx
+++ b/react/NestedSelect/BottomSheet.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import cx from 'classnames'
 
 import Icon from '../Icon'
@@ -31,10 +31,16 @@ const HeaderComponent = ({ title, showBack, onClickBack }) => {
 }
 
 const SelfBottomSheet = props => {
+  const [, setInnerContentHeight] = useState(0) // tricks to rerender BottomSheet
+
   return (
     <BottomSheet backdrop onClose={props.onClose}>
       <BottomSheetItem disableGutters>
-        <NestedSelect HeaderComponent={HeaderComponent} {...props} />
+        <NestedSelect
+          HeaderComponent={HeaderComponent}
+          setInnerContentHeight={setInnerContentHeight}
+          {...props}
+        />
       </BottomSheetItem>
     </BottomSheet>
   )

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -18,6 +18,7 @@ export { ItemRow }
 class NestedSelect extends Component {
   constructor(props) {
     super(props)
+    this.innerRef = React.createRef()
     this.state = {
       history: [props.options],
       searchValue: '',
@@ -27,6 +28,12 @@ class NestedSelect extends Component {
 
   componentWillUnmount() {
     this.unmounted = true
+  }
+
+  componentDidUpdate() {
+    const { setInnerContentHeight } = this.props
+
+    setInnerContentHeight?.(this.innerRef?.current?.offsetHeight)
   }
 
   resetHistory() {
@@ -105,7 +112,7 @@ class NestedSelect extends Component {
     }
 
     return (
-      <>
+      <span ref={this.innerRef}>
         {HeaderComponent ? (
           <HeaderComponent
             title={current.title || title}
@@ -171,7 +178,7 @@ class NestedSelect extends Component {
             ))
           )}
         </ContentComponent>
-      </>
+      </span>
     )
   }
 }

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -170,7 +170,7 @@ const InteractiveExample = () => {
               radioPosition={variant.leftRadio ? 'left' : 'right'}
               title="Please select letter"
               transformParentItem={transformParentItem}
-              searchOptions={variant.withSearch ? searchOpts : undefined}
+              searchOptions={variant.withSearch ? searchOptions : undefined}
               ellipsis={variant.withEllipsis}
               noDivider={variant.noDivider}
             />


### PR DESCRIPTION
Corrige dans le NestedSelect le fait de cliquer sur l'option B sans que la taille du BottomSheet ne soit changée

demo : https://jf-cozy.github.io/cozy-ui/react/#!/NestedSelect