### PR TITLE
feat: Use the new onHide/onShowCross provided by cozy-interapp

### DIFF
--- a/react/IntentIframe/IntentIframe.jsx
+++ b/react/IntentIframe/IntentIframe.jsx
@@ -46,7 +46,12 @@ class IntentIframe extends React.Component {
       ...DEFAULT_DATA,
       ...data
     })
-      .start(this.intentViewer, this.onFrameLoaded)
+      .start(
+        this.intentViewer,
+        this.onFrameLoaded,
+        this.props.onHideCross,
+        this.props.onShowCross
+      )
       .then(result => {
         // eslint-disable-next-line promise/always-return
         result ? onTerminate && onTerminate(result) : onCancel()
@@ -95,7 +100,9 @@ IntentIframe.propTypes = {
   iframeProps: PropTypes.shape({
     wrapperProps: PropTypes.object,
     spinnerProps: PropTypes.object
-  })
+  }),
+  onHideCross: PropTypes.func,
+  onShowCross: PropTypes.func
 }
 
 IntentIframe.defaultProps = {

--- a/react/deprecated/IntentModal/IntentModal.jsx
+++ b/react/deprecated/IntentModal/IntentModal.jsx
@@ -24,8 +24,22 @@ class IntentModal extends Component {
     logIntentModalDepecrated(
       'The IntentModal component has been deprecated and should be replaced by IntentIframe wrapped in Dialog'
     )
+    this.state = {
+      closable: true
+    }
   }
 
+  hideCross = () => {
+    this.setState({
+      closable: false
+    })
+  }
+
+  showCross = () => {
+    this.setState({
+      closable: true
+    })
+  }
   // As dismissAction is passed twice to the modal, both for closing and for
   // intent cancellation, we need to ensure that it is only actually
   // called once.
@@ -45,6 +59,7 @@ class IntentModal extends Component {
     return (
       <Modal
         {...modalProps}
+        closable={this.state.closable}
         key="modal"
         className={styles.intentModal}
         closeBtnClassName={styles.intentModal__cross}
@@ -59,6 +74,8 @@ class IntentModal extends Component {
           onError={onError}
           onTerminate={onComplete}
           type={doctype}
+          onHideCross={this.hideCross}
+          onShowCross={this.showCross}
         />
       </Modal>
     )


### PR DESCRIPTION
This way, a service can decide if it want to hide or show the cross modale to be closed.

This is usefull when a service can handles its close by itself (like harvest for instance).