### PR TITLE
fix: Improve IllustrationDialog layout in native

### DIFF
--- a/react/MuiCozyTheme/makeOverrides.js
+++ b/react/MuiCozyTheme/makeOverrides.js
@@ -506,11 +506,13 @@ export const makeOverrides = theme => ({
             '& .dialogContentWrapper': {
               flexGrow: 1,
               '&:not(.withActions)': {
-                paddingBottom: '16px'
+                paddingBottom:
+                  'calc(env(safe-area-inset-bottom) + var(--flagship-bottom-height) + 16px)'
               }
             },
             '& .cozyDialogActions': {
-              paddingBottom: '16px'
+              paddingBottom:
+                'calc(env(safe-area-inset-bottom) + var(--flagship-bottom-height) + 16px)'
             }
           }
         },


### PR DESCRIPTION
Due to some conflicting css rules we had to add !important
modifier to the bottom padding.
Due to layout issues in flex and missing css class if no title,
we now display empty DialogTitle so the Dialog displays as intended.
Removing the padding class since the empty title does the same job,
plus handling top padding in native

![image](https://github.com/cozy/cozy-ui/assets/12577784/e57d3bb1-16b0-4932-9fa9-0f1472905419)
