### PR TITLE
feat(CozyTheme): Add ignoreItself prop (add `u-dc` css class)

### DIFF
--- a/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
+++ b/react/SquareAppIcon/__snapshots__/SquareAppIcon.spec.js.snap
@@ -6,7 +6,7 @@ exports[`SquareAppIcon component should render an app correctly with the app nam
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-40"
@@ -55,7 +55,7 @@ exports[`SquareAppIcon component should render an app correctly with the given n
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-9"
@@ -104,7 +104,7 @@ exports[`SquareAppIcon component should render an app with the app slug if no na
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-71"
@@ -153,7 +153,7 @@ exports[`SquareAppIcon component should render correctly an app in add state 1`]
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-195"
@@ -207,7 +207,7 @@ exports[`SquareAppIcon component should render correctly an app in error state 1
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-164"
@@ -268,7 +268,7 @@ exports[`SquareAppIcon component should render correctly an app in ghost state 1
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-133"
@@ -317,7 +317,7 @@ exports[`SquareAppIcon component should render correctly an app in maintenance s
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-102"
@@ -366,7 +366,7 @@ exports[`SquareAppIcon component should render correctly an app in shortcut stat
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-226"
@@ -415,7 +415,7 @@ exports[`SquareAppIcon component should render correctly an app with custom cont
   data-testid="square-app-icon"
 >
   <div
-    class="CozyTheme--normal"
+    class="CozyTheme--normal u-dc"
   >
     <span
       class="MuiBadge-root-318"

--- a/react/__snapshots__/examples.spec.jsx.snap
+++ b/react/__snapshots__/examples.spec.jsx.snap
@@ -2249,7 +2249,7 @@ exports[`ContactsList should render examples: ContactsList 2`] = `
 
 exports[`ContactsListModal should render examples: ContactsListModal 1`] = `
 "<div data-testid=\\"mountNode\\">
-  <div class=\\"CozyTheme--normal\\"><button type=\\"button\\">Open contacts list</button></div>
+  <div class=\\"CozyTheme--normal u-dc\\"><button type=\\"button\\">Open contacts list</button></div>
 </div>"
 `;
 
@@ -2270,7 +2270,7 @@ exports[`DateMonthPicker should render examples: DateMonthPicker 1`] = `
 
 exports[`Dialog should render examples: Dialog 1`] = `
 "<div data-testid=\\"mountNode\\"><button>Toggle modal</button>
-  <div class=\\"CozyTheme--normal\\"></div>
+  <div class=\\"CozyTheme--normal u-dc\\"></div>
 </div>"
 `;
 
@@ -2852,7 +2852,7 @@ exports[`Labs/CollectionField should render examples: Labs/CollectionField 1`] =
   <div class=\\"MuiPaper-root u-p-1 u-mb-1 MuiPaper-elevation1\\">
     <h5 class=\\"MuiTypography-root u-mb-1 MuiTypography-h5 MuiTypography-colorTextPrimary\\">Variant selector</h5><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-4\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-label=\\"INLINE\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">INLINE</span></label><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-4\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-label=\\"EMPTYDATA\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">EMPTYDATA</span></label><label class=\\"MuiFormControlLabel-root\\"><span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary\\" aria-disabled=\\"false\\"><span class=\\"MuiIconButton-label\\"><input class=\\"PrivateSwitchBase-input-4\\" type=\\"checkbox\\" data-indeterminate=\\"false\\" aria-label=\\"NULLDATA\\" aria-checked=\\"\\" value=\\"\\"><svg class=\\"MuiSvgIcon-root\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\"><path d=\\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\\"></path></svg></span></span><span class=\\"MuiTypography-root MuiFormControlLabel-label MuiTypography-body1\\">NULLDATA</span></label>
   </div>
-  <div class=\\"CozyTheme--normal\\">
+  <div class=\\"CozyTheme--normal u-dc\\">
     <div class=\\"styles__o-field___3n5HM\\"><label class=\\"styles__c-label___o4ozG styles__c-label--block___2ZV_7\\">Contacts</label>
       <div class=\\"styles__Stack--m___1tSpV\\">
         <div class=\\"styles__Stack--s___22WMg\\">
@@ -3423,7 +3423,7 @@ exports[`SelectBox should render examples: SelectBox 13`] = `
 
 exports[`SelectBox should render examples: SelectBox 14`] = `
 "<div data-testid=\\"mountNode\\"><button>Toggle modal</button>
-  <div class=\\"CozyTheme--normal\\"></div>
+  <div class=\\"CozyTheme--normal u-dc\\"></div>
 </div>"
 `;
 

--- a/react/providers/CozyTheme/index.jsx
+++ b/react/providers/CozyTheme/index.jsx
@@ -23,12 +23,13 @@ export const useCozyTheme = () => {
   return context
 }
 
-const CozyTheme = ({ variant, className, children }) => (
+const CozyTheme = ({ variant, className, ignoreItself, children }) => (
   <CozyThemeContext.Provider value={variant}>
     <MuiCozyTheme variant={variant}>
       <div
         className={cx(className, {
-          [`CozyTheme--${variant}`]: Boolean(variant)
+          [`CozyTheme--${variant}`]: Boolean(variant),
+          'u-dc': ignoreItself
         })}
       >
         {children}
@@ -39,12 +40,15 @@ const CozyTheme = ({ variant, className, children }) => (
 
 CozyTheme.propTypes = {
   variant: PropTypes.oneOf(['normal', 'inverted']),
+  /** Causes this element's children to appear as if they were direct children of the element's parent, ignoring the element itself. */
+  ignoreItself: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node
 }
 
 CozyTheme.defaultProps = {
-  variant: 'normal'
+  variant: 'normal',
+  ignoreItself: true
 }
 
 export default CozyTheme

--- a/stylus/utilities/display.styl
+++ b/stylus/utilities/display.styl
@@ -63,6 +63,9 @@ display-inline()
 display-block()
     display block
 
+display-contents()
+    display contents
+
 display-inline-block()
     display inline-block
 
@@ -91,6 +94,7 @@ props = {
     'display-none': 'dn',
     'display-inline': 'di',
     'display-block': 'db',
+    'display-contents': 'dc',
     'display-inline-block': 'dib',
     'display-inline-table': 'dit',
     'display-table': 'dt',


### PR DESCRIPTION
BREAKING CHANGE: `CozyTheme` use now `display: contents` by default so as not to change the style of the page, since it's just a wrapper that supports styles and nothing else. If this causes problems in the structure of your app, you can always revert to the previous state by setting `<CozyTheme ignoreItself={false}>`.