### PR TITLE
fix(Viewer): InformationPanel doesn't use Drawer anymore

### DIFF
--- a/react/Viewer/Panel/PanelContent.jsx
+++ b/react/Viewer/Panel/PanelContent.jsx
@@ -15,7 +15,7 @@ const PanelContent = ({ file, t }) => {
   return (
     <Stack spacing="s" className={cx('u-flex u-flex-column u-h-100')}>
       <Paper
-        className={'u-ph-2 u-flex u-flex-items-center u-h-3'}
+        className="u-flex u-flex-items-center u-h-3 u-ph-2 u-flex-shrink-0"
         elevation={2}
         square
       >

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -173,7 +173,7 @@ initialState = {
 }
 
 const initialVariants = [
-  { navigation: true, toolbar: true, onlyOfficeEnabled: true }
+  { navigation: true, toolbar: true, onlyOfficeEnabled: true, disableModal: false }
 ]
 
 const getURL = (file) => {
@@ -223,6 +223,7 @@ const editPathByModelProps = {
               files={files}
               currentIndex={state.currentIndex}
               currentURL={state.currentURL}
+              disableModal={variant.disableModal}
               showNavigation={variant.navigation}
               editPathByModelProps={editPathByModelProps}
               onCloseRequest={toggleViewer}

--- a/react/Viewer/components/InformationPanel.jsx
+++ b/react/Viewer/components/InformationPanel.jsx
@@ -1,32 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Drawer from '@material-ui/core/Drawer'
-
-import { withStyles } from '../../styles'
 
 export const infoWidth = '22rem'
 
-const customStyles = () => ({
-  drawer: {
-    width: infoWidth,
-    flexShrink: 0
-  },
-  drawerPaper: {
+const styles = {
+  panel: {
     width: infoWidth,
     backgroundColor: 'var(--defaultBackgroundColor)'
   }
-})
+}
 
-const InformationPanel = ({ classes, children }) => {
+const InformationPanel = ({ children }) => {
   return (
-    <Drawer
-      className={classes.drawer}
-      classes={{ paper: classes.drawerPaper }}
-      variant="permanent"
-      anchor="right"
-    >
+    <div style={styles.panel} className="u-h-100 u-ov-scroll">
       {children}
-    </Drawer>
+    </div>
   )
 }
 
@@ -35,4 +23,4 @@ InformationPanel.propTypes = {
   children: PropTypes.element
 }
 
-export default withStyles(customStyles)(InformationPanel)
+export default InformationPanel

--- a/react/Viewer/styles.styl
+++ b/react/Viewer/styles.styl
@@ -2,15 +2,16 @@
 @require './vars.styl'
 
 .viewer-wrapper
-    position        absolute
-    left            0
-    right           0
-    top             0
-    bottom          0
-    z-index         var(--zIndex-overlay)
-    overflow        hidden
-    background      var(--charcoalGrey)
-    color           var(--white)
+    position absolute
+    left 0
+    right 0
+    top 0
+    bottom 0
+    z-index var(--zIndex-overlay)
+    overflow hidden
+    background var(--charcoalGrey)
+    color var(--white)
+    display flex
 
     .flagship-app &
         padding-top var(--flagship-top-height)


### PR DESCRIPTION
and then its position is relative to the container, not to the page.

Cela corrige le comportement de l'info panel lorsque disableModal est true et qu'on souhaite donc contenir le viewer dans un wrapper, et non pas le faire poper fullscreen

demo: https://jf-cozy.github.io/cozy-ui/react/#/Viewer