### PR TITLE
chore: Don't run CI for branches if not master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 dist: jammy
 cache: yarn
+branches:
+  only:
+  - master
 env:
   global:
     - PR_TITLE=$(curl https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST} 2> /dev/null | grep "title" | head -1)


### PR DESCRIPTION
Travis is configured to run on branches and PRs. The problem is that the CI is triggered at force push for all branches even if there is no associated PR, and for those with PRs the CI is therefore triggered twice.