### PR TITLE
fix: The createNodeWithThemeCssVars must return null in test env

### DIFF
--- a/react/utils/color.js
+++ b/react/utils/color.js
@@ -7,6 +7,8 @@ const getNodeWithThemeCssVars = (type, variant) => {
 }
 
 export const createNodeWithThemeCssVars = (type, variant) => {
+  if (process.env.NODE_ENV === 'test') return null
+
   if (!getNodeWithThemeCssVars(type, variant)) {
     const node = document.createElement('div')
     node.className = getThemeNodeClassName(type, variant)

--- a/scripts/screenshots/screenshotReactStyleguide.js
+++ b/scripts/screenshots/screenshotReactStyleguide.js
@@ -49,6 +49,9 @@ const screenshotReactStyleguide = async (page, args, config, theme) => {
   console.log('⌛ Screenshotting components...')
 
   for (const component of components) {
+    // Skip components in Deprecated folder
+    if (component.link.includes('Deprecated')) continue
+
     const componentConfig = config[component.name] || {}
     const componentViewportSpec =
       (componentConfig.viewports && componentConfig.viewports[args.viewport]) ||


### PR DESCRIPTION
Please ensure that variable `process.env.NODE_ENV` is well defined and set to `test` during your tests.