### PR TITLE
Print action can now deal with multiple docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.9",
     "node-polyglot": "^2.2.2",
     "normalize.css": "^8.0.0",
+    "pdf-lib": "1.17.1",
     "piwik-react-router": "0.12.1",
     "react-chartjs-2": "4.1.0",
     "react-markdown": "^4.0.8",

--- a/react/ActionsMenu/Actions/helpers.js
+++ b/react/ActionsMenu/Actions/helpers.js
@@ -1,3 +1,9 @@
+import { PDFDocument } from 'pdf-lib'
+import { fetchBlobFileById } from 'cozy-client/dist/models/file'
+
+// Should guarantee good resolution for different uses (printing, downloading, etc.)
+const MAX_RESIZE_IMAGE_SIZE = 3840
+
 /**
  * Make array of actions for ActionsItems component
  *
@@ -81,4 +87,160 @@ export const makeBase64FromFile = async file => {
       reject(err)
     }
   })
+}
+
+/**
+ * @param {HTMLImageElement} image
+ * @param {number} [maxSizeInPixel] - Maximum size before being resized
+ * @returns {number}
+ */
+const getImageScaleRatio = (image, maxSize) => {
+  const longerSideSizeInPixel = Math.max(image.height, image.width)
+  let scaleRatio = 1
+  if (maxSize < longerSideSizeInPixel) {
+    scaleRatio = maxSize / longerSideSizeInPixel
+  }
+
+  return scaleRatio
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.base64 - Base64 of image
+ * @param {string} opts.type - Type of image
+ * @param {number} opts.maxSize - Maximum size before being resized
+ * @returns {Promise<string>}
+ */
+const resizeImage = async ({
+  base64: fileDataUri,
+  type: fileType,
+  maxSize
+}) => {
+  return new Promise((resolve, reject) => {
+    const newImage = new Image()
+    newImage.src = fileDataUri
+    newImage.onerror = reject
+    newImage.onload = () => {
+      const canvas = document.createElement('canvas')
+      const scaleRatio = getImageScaleRatio(newImage, maxSize)
+      const scaledWidth = scaleRatio * newImage.width
+      const scaledHeight = scaleRatio * newImage.height
+
+      canvas.width = scaledWidth
+      canvas.height = scaledHeight
+      canvas
+        .getContext('2d')
+        .drawImage(newImage, 0, 0, scaledWidth, scaledHeight)
+
+      resolve(canvas.toDataURL(fileType))
+    }
+  })
+}
+
+/**
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+const fileToDataUri = async file => {
+  return new Promise((resolve, reject) => {
+    let reader = new FileReader()
+    reader.onerror = reject
+    reader.onload = e => resolve(e.target.result)
+    reader.readAsDataURL(file)
+  })
+}
+
+/**
+ * @param {PDFDocument} pdfDoc
+ * @param {File} file
+ * @returns {Promise<void>}
+ */
+const addImageToPdf = async (pdfDoc, file) => {
+  const fileDataUri = await fileToDataUri(file)
+  const resizedImage = await resizeImage({
+    base64: fileDataUri,
+    type: file.type,
+    maxSize: MAX_RESIZE_IMAGE_SIZE
+  })
+
+  let img
+  if (file.type === 'image/png') img = await pdfDoc.embedPng(resizedImage)
+  if (file.type === 'image/jpeg') img = await pdfDoc.embedJpg(resizedImage)
+
+  const page = pdfDoc.addPage([img.width, img.height])
+  const { width: pageWidth, height: pageHeight } = page.getSize()
+  page.drawImage(img, {
+    x: pageWidth / 2 - img.width / 2,
+    y: pageHeight / 2 - img.height / 2,
+    width: img.width,
+    height: img.height
+  })
+}
+
+/**
+ * @param {File} file
+ * @returns {Promise<ArrayBuffer>}
+ */
+const fileToArrayBuffer = async file => {
+  if ('arrayBuffer' in file) return await file.arrayBuffer()
+
+  return new Promise((resolve, reject) => {
+    let reader = new FileReader()
+    reader.onerror = reject
+    reader.onload = e => resolve(new Uint8Array(e.target.result))
+    reader.readAsArrayBuffer(file)
+  })
+}
+
+/**
+ * @param {PDFDocument} pdfDoc
+ * @param {File} file
+ * @returns {Promise<void>}
+ */
+const addPdfToPdf = async (pdfDoc, file) => {
+  const pdfToAdd = await fileToArrayBuffer(file)
+  const document = await PDFDocument.load(pdfToAdd)
+  const copiedPages = await pdfDoc.copyPages(
+    document,
+    document.getPageIndices()
+  )
+  copiedPages.forEach(page => pdfDoc.addPage(page))
+}
+
+/**
+ * @param {PDFDocument} pdfDoc - Instance of PDFDocument
+ * @param {File} file - File to add in pdf
+ * @returns {Promise<ArrayBuffer>} - Data of pdf generated
+ */
+export const addFileToPdf = async (pdfDoc, file) => {
+  if (file.type === 'application/pdf') {
+    await addPdfToPdf(pdfDoc, file)
+  } else {
+    await addImageToPdf(pdfDoc, file)
+  }
+  const pdfDocBytes = await pdfDoc.save()
+
+  return pdfDocBytes
+}
+
+/**
+ * Fetches file from docs list and return a blob of pdf
+ * @param {import('cozy-client/types/CozyClient').default} client - Instance of CozyClient
+ * @param {array} docs - Docs from an io.cozy.xxx doctypes
+ * @returns {Promise<object>} Blob of generated Pdf
+ */
+export const makePdfBlob = async (client, docs) => {
+  const pdfDoc = await PDFDocument.create()
+
+  for (const doc of docs) {
+    const blob = await fetchBlobFileById(client, doc._id)
+    await addFileToPdf(pdfDoc, blob)
+  }
+
+  const pdfBytes = await pdfDoc.save()
+
+  const bytes = new Uint8Array(pdfBytes)
+  const blob = new Blob([bytes], { type: 'application/pdf' })
+
+  return blob
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,6 +2248,20 @@
   dependencies:
     "@octokit/openapi-types" "^13.4.0"
 
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@pnpm/config.env-replace@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz#c76fa65847c9554e88d910f264c2ba9a1575e833"
@@ -14590,6 +14604,11 @@ pacote@^13.0.3, pacote@^13.0.5:
     ssri "^8.0.1"
     tar "^6.1.11"
 
+pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
@@ -14823,6 +14842,16 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pdf-lib@1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
+  integrity sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pdfjs-dist@2.12.313:
   version "2.12.313"


### PR DESCRIPTION
Dans MesPapiers on souhaite pouvoir imprimer suite à une sélection de plusieurs fichiers. Pour se faire on fusionne les docs en un seul pdf, puis on se rabat sur la méthode précédente qui gérait déjà ce cas de fichier unique.