### PR TITLE
Extend flagship simulation from CozyDialogs to all cozy-ui

### DIFF
--- a/docs/components/TableOfContentsRenderer.jsx
+++ b/docs/components/TableOfContentsRenderer.jsx
@@ -1,31 +1,121 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import DefaultTableOfContents from 'react-styleguidist/lib/client/rsg-components/TableOfContents/TableOfContentsRenderer'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
+
+import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import Buttons from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PhoneIcon from 'cozy-ui/transpiled/react/Icons/Phone'
+import PaletteIcon from 'cozy-ui/transpiled/react/Icons/Palette'
+import Switch from 'cozy-ui/transpiled/react/Switch'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import {
+  addFlagshipElements,
+  removeFlagshipElements
+} from 'cozy-ui/transpiled/react/hooks/useSetFlagshipUi/helpers'
 
 const TableOfContents = props => {
   const deviceThemeType = useMediaQuery('(prefers-color-scheme: dark)')
     ? 'dark'
     : 'light'
-  const themeType =
-    localStorage.getItem('ui-theme-type') || deviceThemeType || 'light'
 
-  const handleChange = ev => {
-    localStorage.setItem('ui-theme-type', ev.target.value)
-    window.location.reload()
-  }
+  const [flagship, setFlagship] = useState({
+    status: JSON.parse(localStorage.getItem('flagship-app'))?.status || 'off',
+    contained:
+      JSON.parse(localStorage.getItem('flagship-app'))?.contained || 'off',
+    busy: false
+  })
+  const [themeType, SetThemeType] = useState({
+    value: localStorage.getItem('ui-theme-type') || deviceThemeType || 'light',
+    busy: false
+  })
+
+  useEffect(() => {
+    const toggleFlaship =
+      flagship.status === 'off' ? removeFlagshipElements : addFlagshipElements
+
+    toggleFlaship()
+  }, [flagship])
 
   return (
-    <>
-      <select
-        className="u-m-1 u-mb-0"
-        value={themeType}
-        onChange={handleChange}
-      >
-        <option>light</option>
-        <option>dark</option>
-      </select>
+    <CozyTheme>
+      <Paper className="u-pv-1 u-ph-half u-ta-center" elevation={0} square>
+        <Buttons
+          className="u-w-100 u-mb-1"
+          startIcon={<Icon icon={PaletteIcon} />}
+          label={themeType.value}
+          size="small"
+          variant="secondary"
+          busy={themeType.busy}
+          onClick={() => {
+            const newThemeType = themeType.value === 'light' ? 'dark' : 'light'
+            SetThemeType({ value: newThemeType, busy: true })
+            localStorage.setItem('ui-theme-type', newThemeType)
+            window.location.reload()
+          }}
+        />
+        <Buttons
+          className="u-w-100 u-mt-half"
+          startIcon={<Icon icon={PhoneIcon} />}
+          label={flagship.status}
+          size="small"
+          variant="secondary"
+          busy={flagship.busy}
+          onClick={() => {
+            localStorage.setItem(
+              'flagship-app',
+              JSON.stringify({
+                ...flagship,
+                status: flagship.status === 'on' ? 'off' : 'on'
+              })
+            )
+            setFlagship(v => ({
+              ...v,
+              status: v.status === 'on' ? 'off' : 'on',
+              busy: true
+            }))
+            window.location.reload()
+          }}
+        />
+        <Typography
+          variant="caption"
+          display="inline"
+          color={flagship.contained === 'on' ? 'textSecondary' : 'textPrimary'}
+        >
+          Immersive
+        </Typography>
+        <Switch
+          color="default"
+          checked={flagship.contained === 'on'}
+          disabled={flagship.busy}
+          onChange={() => {
+            localStorage.setItem(
+              'flagship-app',
+              JSON.stringify({
+                ...flagship,
+                contained: flagship.contained === 'on' ? 'off' : 'on'
+              })
+            )
+            setFlagship(v => ({
+              ...v,
+              contained: v.contained === 'on' ? 'off' : 'on',
+              busy: true
+            }))
+            window.location.reload()
+          }}
+        />
+        <Typography
+          variant="caption"
+          display="inline"
+          color={flagship.contained === 'on' ? 'textPrimary' : 'textSecondary'}
+        >
+          Contained
+        </Typography>
+      </Paper>
+
       <DefaultTableOfContents {...props} />
-    </>
+    </CozyTheme>
   )
 }
 

--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -13,7 +13,7 @@ import { useMutationObserver, useTimeoutWhen } from 'rooks'
 import Fade from '@material-ui/core/Fade'
 import Portal from '@material-ui/core/Portal'
 
-import { getFlagshipMetadata } from 'cozy-device-helper'
+import { getFlagshipMetadata } from '../hooks/useSetFlagshipUi/helpers'
 
 import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 import CozyTheme, { useCozyTheme } from '../providers/CozyTheme'

--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -392,7 +392,7 @@ BottomSheet.defaultProps = {
   toolbarProps: {},
   backdrop: false,
   offset:
-    (getFlagshipMetadata().immersive && getFlagshipMetadata().navbarHeight) ?? 0
+    (getFlagshipMetadata().immersive && getFlagshipMetadata().navbarHeight) || 0
 }
 
 BottomSheet.propTypes = {

--- a/react/BottomSheet/README.md
+++ b/react/BottomSheet/README.md
@@ -94,7 +94,7 @@ const initialState = {
   isSecondBottomSheetDisplayed: false,
   mediumHeight: isTesting() ? 450 : undefined,
   mediumHeightRatio: undefined,
-  offset: 0
+  offset: undefined
 }
 const showBottomSheet = () => setState({ isBottomSheetDisplayed: true })
 const hideBottomSheet = () => setState({ isBottomSheetDisplayed: false })

--- a/react/BottomSheet/helpers.js
+++ b/react/BottomSheet/helpers.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { getFlagshipMetadata } from 'cozy-device-helper'
 
 import { ANIMATION_DURATION } from './constants'
 import { getSafeAreaValue } from '../helpers/getSafeArea'
+import { getFlagshipMetadata } from '../hooks/useSetFlagshipUi/helpers'
 
 export const computeToolbarHeight = (toolbarProps = {}) => {
   const { ref, height } = toolbarProps

--- a/react/BottomSheet/helpers.spec.js
+++ b/react/BottomSheet/helpers.spec.js
@@ -12,7 +12,7 @@ import {
 jest.mock('../helpers/getSafeArea', () => ({
   getSafeAreaValue: jest.fn().mockReturnValue(15)
 }))
-jest.mock('cozy-device-helper', () => ({
+jest.mock('../hooks/useSetFlagshipUi/helpers', () => ({
   getFlagshipMetadata: jest.fn(() => ({ navbarHeight: 10 }))
 }))
 const windowSpy = jest.spyOn(window, 'window', 'get')

--- a/react/CozyDialogs/Readme.md
+++ b/react/CozyDialogs/Readme.md
@@ -208,50 +208,9 @@ const initialVariants = [{
   withBackground: false
 }]
 
-// The goal of this method is to simulate the
-// immersive mode of the flagship app. So we
-// add the flagship-app class to the body and
-// we set 2 css variables:
-// flagship-top-height
-// flagship-bottom-height
-const setFlagshipVars = () => {
-  const root = document.getElementsByTagName('body')[0]
-  root.style.setProperty('--flagship-top-height',  "40px")
-  root.style.setProperty('--flagship-bottom-height',  "40px")
-  root.classList.add('flagship-app')
-
-  const statusBarDiv = document.createElement("div")
-  statusBarDiv.style.cssText = "position:fixed;top:0;height:40px;z-index:10000000;background-color:red;width:100%"
-  // and give it some content
-  const statusBarDivContent = document.createTextNode("Top Status Bar with clock")
-
-  // add the text node to the newly created div
-  statusBarDiv.appendChild(statusBarDivContent)
-
-
-  const bottomBarDiv = document.createElement("div")
-  bottomBarDiv.style.cssText = "position:fixed;bottom:0;height:40px;z-index:10000000;background-color:red;width:100%"
-  // and give it some content
-  const bottomBarDivContent = document.createTextNode("BottomBar")
-
-  // add the text node to the newly created div
-  bottomBarDiv.appendChild(bottomBarDivContent)
-
-  // add the newly created element and its content into the DOM
-  const currentDiv = document.getElementById("rsg-root")
-  document.body.insertBefore(statusBarDiv, currentDiv)
-  document.body.insertBefore(bottomBarDiv, currentDiv)
-}
-
 ;
 
 <DemoProvider>
-  <Button
-    className="u-mb-1"
-    variant="secondary"
-    label={'Simulate Immersive Flagship Mode'}
-    onClick={() => setFlagshipVars()}
-  />
   <Variants initialVariants={initialVariants}>
     {variant => (
       <>

--- a/react/Dialog/DialogEffects.spec.tsx
+++ b/react/Dialog/DialogEffects.spec.tsx
@@ -238,8 +238,11 @@ it('should provide the inversed UI when Cozybar is not black on white, but white
 })
 
 jest.mock('cozy-device-helper', () => ({
-  isFlagshipApp: (): boolean => true,
-  getFlagshipMetadata: (): Record<string, never> => ({})
+  isFlagshipApp: (): boolean => true
+}))
+jest.mock('../hooks/useSetFlagshipUi/helpers', () => ({
+  getFlagshipMetadata: (): Record<string, never> => ({}),
+  setRsgFlagshipElements: (): null => null
 }))
 
 const onOpenMountExpected = {

--- a/react/Dialog/DialogEffects.ts
+++ b/react/Dialog/DialogEffects.ts
@@ -1,7 +1,7 @@
 import { getLuminance, Theme, useTheme } from '@material-ui/core'
 import { useEffect } from 'react'
 
-import { getFlagshipMetadata, isFlagshipApp } from 'cozy-device-helper'
+import { isFlagshipApp } from 'cozy-device-helper'
 import { useWebviewIntent } from 'cozy-intent'
 
 import {
@@ -9,6 +9,8 @@ import {
   ThemeColor,
   parseArg
 } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
+import { getFlagshipMetadata } from '../hooks/useSetFlagshipUi/helpers'
+import { isRsg } from '../hooks/useSetFlagshipUi/helpers'
 
 interface DialogEffectsOptions {
   cozybar?: Element | null
@@ -192,7 +194,8 @@ export const useDialogSetFlagshipUI = (
   }, [open, webviewIntent]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
-export const useDialogEffects = isFlagshipApp()
-  ? useHook
-  : // eslint-disable-next-line @typescript-eslint/no-empty-function
-    (): void => {}
+export const useDialogEffects =
+  isFlagshipApp() || isRsg
+    ? useHook
+    : // eslint-disable-next-line @typescript-eslint/no-empty-function
+      (): void => {}

--- a/react/deprecated/ActionMenu/ActionMenuEffects.ts
+++ b/react/deprecated/ActionMenu/ActionMenuEffects.ts
@@ -7,6 +7,7 @@ import { Theme, useTheme } from '@material-ui/core'
 import { isFlagshipApp } from 'cozy-device-helper'
 
 import { useSetFlagshipUI } from '../../hooks/useSetFlagshipUi/useSetFlagshipUI'
+import { isRsg } from '../../hooks/useSetFlagshipUi/helpers'
 
 const getBottomBackground = (theme: Theme): string => {
   const sidebar = document.getElementById('sidebar')
@@ -40,7 +41,8 @@ const useHook = (): void => {
   )
 }
 
-export const useActionMenuEffects = isFlagshipApp()
-  ? useHook
-  : // eslint-disable-next-line @typescript-eslint/no-empty-function
-    (): void => {}
+export const useActionMenuEffects =
+  isFlagshipApp() || isRsg
+    ? useHook
+    : // eslint-disable-next-line @typescript-eslint/no-empty-function
+      (): void => {}

--- a/react/deprecated/Modal/ModalEffects.ts
+++ b/react/deprecated/Modal/ModalEffects.ts
@@ -4,9 +4,10 @@
 
 import { Theme, useTheme } from '@material-ui/core'
 
-import { getFlagshipMetadata, isFlagshipApp } from 'cozy-device-helper'
+import { isFlagshipApp } from 'cozy-device-helper'
 
 import { useSetFlagshipUI } from '../../hooks/useSetFlagshipUi/useSetFlagshipUI'
+import { getFlagshipMetadata } from '../../hooks/useSetFlagshipUi/helpers'
 
 const getTopBackground = (theme: Theme, cozyBar: Element | null): string =>
   (cozyBar && getComputedStyle(cozyBar).getPropertyValue('background-color')) ||

--- a/react/hooks/useSetFlagshipUi/helpers.js
+++ b/react/hooks/useSetFlagshipUi/helpers.js
@@ -1,0 +1,149 @@
+// eslint-disable-next-line no-unused-vars
+import { FlagshipUI } from './useSetFlagshipUI'
+import { getFlagshipMetadata as getFlagshipMetadataFromDeviceHelper } from 'cozy-device-helper'
+
+/**
+ * The goal of this method is to simulate the immersive mode of the flagship app.
+ * So we add the flagship-app class to the body and we set css variables:
+ * If the "contained" mode is activated, it simulates an classic app behavior
+ * If the "immersive" mode is activated, it simulates a fullscreen app like Home
+ */
+export const addFlagshipElements = () => {
+  const root = document.getElementsByTagName('body')[0]
+  root.style.setProperty('--flagship-top-height', '40px')
+  root.style.setProperty('--flagship-top-bgcolor', 'white') // used only for cozy-ui docs
+  root.style.setProperty('--flagship-top-overlay', 'transparent') // used only for cozy-ui docs
+  root.style.setProperty('--flagship-top-color', 'black') // used only for cozy-ui docs
+  root.style.setProperty('--flagship-bottom-height', '40px')
+  root.style.setProperty('--flagship-bottom-bgcolor', 'white') // used only for cozy-ui docs
+  root.style.setProperty('--flagship-bottom-overlay', 'transparent') // used only for cozy-ui docs
+  root.style.setProperty('--flagship-bottom-color', 'black') // used only for cozy-ui docs
+  root.classList.add('flagship-app')
+
+  // create status bar
+  const statusBarDiv = document.createElement('div')
+  statusBarDiv.setAttribute('id', 'flagshipStatusBar')
+  statusBarDiv.style.cssText =
+    'position:fixed;top:0;height:var(--flagship-top-height);z-index:10000000;color:var(--flagship-top-color);background-color:var(--flagship-top-bgcolor);width:100%;display:flex;align-items:center;justify-content:center'
+  // create status bar overlay
+  const statusBarOverlay = document.createElement('div')
+  statusBarOverlay.setAttribute('id', 'flagshipStatusBarOverlay')
+  statusBarOverlay.style.cssText =
+    'position:absolute;top:0;left:0;width:100%;height:100%;z-index:-1;background-color:var(--flagship-top-overlay)'
+  statusBarDiv.appendChild(statusBarOverlay)
+  // create status bar text
+  const statusBarText = document.createElement('div')
+  statusBarText.setAttribute('id', 'flagshipStatusBarText')
+  statusBarText.innerText = 'Flagship Top Status Bar with clock'
+  statusBarDiv.appendChild(statusBarText)
+
+  // create nav bar
+  const navBarDiv = document.createElement('div')
+  navBarDiv.setAttribute('id', 'flagshipNavBar')
+  navBarDiv.style.cssText =
+    'position:fixed;bottom:0;height:var(--flagship-bottom-height);z-index:10000000;color:var(--flagship-bottom-color);background-color:var(--flagship-bottom-bgcolor);width:100%;display:flex;align-items:center;justify-content:center'
+  // create nav bar overlay
+  const navBarOverlay = document.createElement('div')
+  navBarOverlay.setAttribute('id', 'flagshipNavBarOverlay')
+  navBarOverlay.style.cssText =
+    'position:absolute;top:0;left:0;width:100%;height:100%;z-index:-1;background-color:var(--flagship-bottom-overlay)'
+  navBarDiv.appendChild(navBarOverlay)
+  // create nav bar text
+  const navBarText = document.createElement('div')
+  navBarText.setAttribute('id', 'flagshipNavBarText')
+  navBarText.innerText = 'Flagship Nav Bar'
+  navBarDiv.appendChild(navBarText)
+
+  // add status and nav bar and its content into the DOM
+  const currentDiv = document.getElementById('rsg-root')
+  document.body.insertBefore(statusBarDiv, currentDiv)
+  document.body.insertBefore(navBarDiv, currentDiv)
+}
+
+/**
+ * Remove fake DOM element that simulates native Status and Nav bar
+ */
+export const removeFlagshipElements = () => {
+  const root = document.getElementsByTagName('body')[0]
+  root.style.removeProperty('--flagship-top-height')
+  root.style.removeProperty('--flagship-top-bgcolor')
+  root.style.removeProperty('--flagship-top-overlay')
+  root.style.removeProperty('--flagship-top-color')
+  root.style.removeProperty('--flagship-bottom-height')
+  root.style.removeProperty('--flagship-bottom-bgcolor')
+  root.style.removeProperty('--flagship-bottom-overlay')
+  root.style.removeProperty('--flagship-bottom-color')
+  root.classList.remove('flagship-app')
+
+  document.getElementById('flagshipStatusBar')?.remove()
+  document.getElementById('flagshipNavBar')?.remove()
+}
+
+/**
+ * Whether we are in cozy-ui documentation (Rsg is for ReactStyleGuide)
+ * @returns {boolean}
+ */
+export const isRsg = !!document.getElementById('rsg-root')
+
+/**
+ * Overrides flagship metadata
+ * See https://github.com/cozy/cozy-libs/blob/master/packages/cozy-device-helper/src/flagship.ts#L13
+ */
+export const getFlagshipMetadata = isRsg
+  ? () => ({
+      immersive:
+        JSON.parse(localStorage.getItem('flagship-app'))?.contained === 'off' ||
+        false,
+      statusBarHeight: 40,
+      navbarHeight: 40
+    })
+  : getFlagshipMetadataFromDeviceHelper
+
+/**
+ * Set the css values for Status and Nav bar inside cozy-ui documentation
+ * see https://github.com/cozy/cozy-libs/blob/master/packages/cozy-intent/src/api/models/applications.ts#L33
+ * @param {undefined | Partial<FlagshipUI>} param0
+ * @returns
+ */
+export const setRsgFlagshipElements = ({
+  topBackground,
+  topOverlay,
+  topTheme,
+  bottomBackground,
+  bottomOverlay,
+  bottomTheme
+} = {}) => {
+  if (!isRsg) return
+
+  const root = document.getElementsByTagName('body')[0]
+
+  if (topBackground) {
+    root.style.setProperty('--flagship-top-bgcolor', topBackground)
+  }
+
+  if (topOverlay) {
+    root.style.setProperty('--flagship-top-overlay', topOverlay)
+  }
+
+  if (topTheme) {
+    root.style.setProperty(
+      '--flagship-top-color',
+      topTheme === 'dark' ? 'black' : 'white'
+    )
+  }
+
+  if (bottomBackground) {
+    root.style.setProperty('--flagship-bottom-bgcolor', bottomBackground)
+  }
+
+  if (bottomOverlay) {
+    root.style.setProperty('--flagship-bottom-overlay', bottomOverlay)
+  }
+
+  if (bottomTheme) {
+    root.style.setProperty(
+      '--flagship-bottom-color',
+      bottomTheme === 'dark' ? 'black' : 'white'
+    )
+  }
+}

--- a/react/hooks/useSetFlagshipUi/useSetFlagshipUI.ts
+++ b/react/hooks/useSetFlagshipUi/useSetFlagshipUI.ts
@@ -8,6 +8,8 @@ import { useWebviewIntent } from 'cozy-intent'
 import { FlagshipUI as IntentInterface } from 'cozy-intent/dist/api/models/applications'
 import { WebviewService } from 'cozy-intent/dist/api/services/WebviewService'
 
+import { setRsgFlagshipElements } from './helpers'
+
 export enum ThemeColor {
   Dark = 'dark',
   Light = 'light'
@@ -23,10 +25,12 @@ export const parseArg = (
   arg?: FlagshipUI,
   caller?: string
 ): void => {
-  if (!webviewIntent) return
-
-  const sanitized = isObject(arg) && pickBy(arg, identity)
+  const sanitized = isObject(arg) ? pickBy(arg, identity) : undefined
   const validUI = !isEmpty(sanitized) && sanitized
+
+  setRsgFlagshipElements(sanitized)
+
+  if (!webviewIntent) return
 
   validUI && webviewIntent.call('setFlagshipUI', validUI, caller)
 }


### PR DESCRIPTION
On ajoute un bouton dans le menu principal qui permet d'activer un mode qui simule le rendu dans l'app flagship. Des fausses barres de status et de navigation apparaissent alors pour simuler le comportement sur mobile. Cela gère le mode immersif / contenu via un switch.

Quelque lien pour se rendre compte de la différence :
https://jf-cozy.github.io/cozy-ui/react/#/BottomSheet (le bottomsheet pop plus haut que la barre de navigation du bas)
https://jf-cozy.github.io/cozy-ui/react/#/CozyDialogs (en mode inverted les barres changent de couleur)