### PR TITLE
feat(Viewer): Add isPublic prop for manage panel blocks displayed

### DIFF
--- a/react/Viewer/Footer/BottomSheetContent.jsx
+++ b/react/Viewer/Footer/BottomSheetContent.jsx
@@ -5,9 +5,9 @@ import { BottomSheetItem } from '../../BottomSheet'
 
 import getPanelBlocks, { getPanelBlocksSpecs } from '../Panel/getPanelBlocks'
 
-const BottomSheetContent = ({ file }) => {
+const BottomSheetContent = ({ file, isPublic }) => {
   const panelBlocks = getPanelBlocks({
-    panelBlocksSpecs: getPanelBlocksSpecs(),
+    panelBlocksSpecs: getPanelBlocksSpecs(isPublic),
     file
   })
 
@@ -24,7 +24,7 @@ const BottomSheetContent = ({ file }) => {
 
 BottomSheetContent.propTypes = {
   file: PropTypes.object.isRequired,
-  contactsFullname: PropTypes.string
+  isPublic: PropTypes.bool
 }
 
 export default BottomSheetContent

--- a/react/Viewer/Footer/BottomSheetContent.jsx
+++ b/react/Viewer/Footer/BottomSheetContent.jsx
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 
 import { BottomSheetItem } from '../../BottomSheet'
 
-import getPanelBlocks, { panelBlocksSpecs } from '../Panel/getPanelBlocks'
+import getPanelBlocks, { getPanelBlocksSpecs } from '../Panel/getPanelBlocks'
 
 const BottomSheetContent = ({ file }) => {
-  const panelBlocks = getPanelBlocks({ panelBlocksSpecs, file })
+  const panelBlocks = getPanelBlocks({
+    panelBlocksSpecs: getPanelBlocksSpecs(),
+    file
+  })
 
   return panelBlocks.map((PanelBlock, index) => (
     <BottomSheetItem

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const FooterContent = ({ file, toolbarRef, children }) => {
+const FooterContent = ({ file, toolbarRef, children, isPublic }) => {
   const styles = useStyles()
 
   const toolbarProps = useMemo(() => ({ ref: toolbarRef }), [toolbarRef])
@@ -54,7 +54,7 @@ const FooterContent = ({ file, toolbarRef, children }) => {
         >
           {FooterActionButtonsWithFile}
         </BottomSheetHeader>
-        <BottomSheetContent file={file} />
+        <BottomSheetContent file={file} isPublic={isPublic} />
       </BottomSheet>
     )
   }
@@ -68,6 +68,7 @@ const FooterContent = ({ file, toolbarRef, children }) => {
 FooterContent.propTypes = {
   file: PropTypes.object.isRequired,
   toolbarRef: PropTypes.object,
+  isPublic: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/react/Viewer/Panel/PanelContent.jsx
+++ b/react/Viewer/Panel/PanelContent.jsx
@@ -9,9 +9,9 @@ import { withViewerLocales } from '../hoc/withViewerLocales'
 
 import getPanelBlocks, { getPanelBlocksSpecs } from './getPanelBlocks'
 
-const PanelContent = ({ file, t }) => {
+const PanelContent = ({ file, isPublic, t }) => {
   const panelBlocks = getPanelBlocks({
-    panelBlocksSpecs: getPanelBlocksSpecs(),
+    panelBlocksSpecs: getPanelBlocksSpecs(isPublic),
     file
   })
 
@@ -43,7 +43,8 @@ const PanelContent = ({ file, t }) => {
 }
 
 PanelContent.propTypes = {
-  file: PropTypes.object.isRequired
+  file: PropTypes.object.isRequired,
+  isPublic: PropTypes.bool
 }
 
 export default withViewerLocales(PanelContent)

--- a/react/Viewer/Panel/PanelContent.jsx
+++ b/react/Viewer/Panel/PanelContent.jsx
@@ -7,10 +7,13 @@ import Paper from '../../Paper'
 import Typography from '../../Typography'
 import { withViewerLocales } from '../hoc/withViewerLocales'
 
-import getPanelBlocks, { panelBlocksSpecs } from './getPanelBlocks'
+import getPanelBlocks, { getPanelBlocksSpecs } from './getPanelBlocks'
 
 const PanelContent = ({ file, t }) => {
-  const panelBlocks = getPanelBlocks({ panelBlocksSpecs, file })
+  const panelBlocks = getPanelBlocks({
+    panelBlocksSpecs: getPanelBlocksSpecs(),
+    file
+  })
 
   return (
     <Stack spacing="s" className={cx('u-flex u-flex-column u-h-100')}>

--- a/react/Viewer/Panel/getPanelBlocks.jsx
+++ b/react/Viewer/Panel/getPanelBlocks.jsx
@@ -6,21 +6,43 @@ import Qualification from './Qualification'
 
 const { isFromKonnector, hasQualifications, hasCertifications } = models.file
 
-export const panelBlocksSpecs = {
+/**
+ * @typedef {Object} PanelBlockSpec
+ * @property {Function} condition - Function that returns true if the block should be displayed
+ * @property {React.Component} component - Component to display
+ */
+
+/**
+ * @typedef {Object.<string, PanelBlockSpec>} PanelBlocksSpecs
+ */
+
+/**
+ * Returns the specs of the blocks to display in the panel
+ * @param {boolean} isPublic - Whether the panel is displayed in public view
+ * @returns {PanelBlocksSpecs}
+ */
+export const getPanelBlocksSpecs = (isPublic = false) => ({
   qualifications: {
     condition: hasQualifications,
     component: Qualification
   },
   konnector: {
-    condition: isFromKonnector,
+    condition: () => isFromKonnector && !isPublic,
     component: KonnectorBlock
   },
   certifications: {
     condition: hasCertifications,
     component: Certifications
   }
-}
+})
 
+/**
+ * Returns the blocks to display in the panel
+ * @param {Object} options
+ * @param {PanelBlocksSpecs} options.panelBlocksSpecs - Specs of the blocks to display in the panel
+ * @param {import('cozy-client/types/types').FileDocument} options.file - File object
+ * @returns {Array.<React.Component>}
+ */
 const getPanelBlocks = ({ panelBlocksSpecs, file }) => {
   const panelBlocks = []
 

--- a/react/Viewer/Panel/getPanelBlocks.spec.jsx
+++ b/react/Viewer/Panel/getPanelBlocks.spec.jsx
@@ -1,4 +1,4 @@
-import getPanelBlocks from './getPanelBlocks'
+import getPanelBlocks, { getPanelBlocksSpecs } from './getPanelBlocks'
 
 jest.mock('cozy-harvest-lib/dist/components/KonnectorBlock', () => jest.fn())
 const block1Component = jest.fn()
@@ -58,5 +58,24 @@ describe('getPanelBlocks', () => {
 
     // with no specs
     expect(getPanelBlocks({ panelBlocksSpecs: {} })).toMatchObject([])
+  })
+})
+
+describe('getPanelBlocksSpecs', () => {
+  it('should return the specs of the blocks to display in the panel', () => {
+    expect(getPanelBlocksSpecs()).toEqual({
+      qualifications: {
+        condition: expect.any(Function),
+        component: expect.anything()
+      },
+      konnector: {
+        condition: expect.any(Function),
+        component: expect.anything()
+      },
+      certifications: {
+        condition: expect.any(Function),
+        component: expect.anything()
+      }
+    })
   })
 })

--- a/react/Viewer/ViewerContainer.jsx
+++ b/react/Viewer/ViewerContainer.jsx
@@ -26,6 +26,7 @@ const ViewerContainer = props => {
     editPathByModelProps,
     children,
     componentsProps,
+    isPublic,
     ...rest
   } = props
   const { currentIndex, files, currentURL } = props
@@ -66,6 +67,7 @@ const ViewerContainer = props => {
             />
           </EncryptedProvider>
           <ViewerInformationsWrapper
+            isPublic={isPublic}
             disableFooter={disableFooter}
             validForPanel={validForPanel}
             currentFile={currentFile}
@@ -107,6 +109,8 @@ ViewerContainer.propTypes = {
   disablePanel: PropTypes.bool,
   /** Show/Hide the panel containing more information about the file only on Phone & Tablet devices */
   disableFooter: PropTypes.bool,
+  /** If the Viewer is in public view */
+  isPublic: PropTypes.bool,
   /* Props passed to components with the same name */
   componentsProps: PropTypes.shape({
     /** Used to open an Only Office file */

--- a/react/Viewer/ViewerInformationsWrapper.jsx
+++ b/react/Viewer/ViewerInformationsWrapper.jsx
@@ -15,6 +15,7 @@ const ViewerInformationsWrapper = ({
   disableFooter,
   validForPanel,
   toolbarRef,
+  isPublic,
   children
 }) => {
   const theme = useTheme()
@@ -34,14 +35,18 @@ const ViewerInformationsWrapper = ({
     <>
       {!disableFooter && (
         <Footer>
-          <FooterContent file={currentFile} toolbarRef={toolbarRef}>
+          <FooterContent
+            file={currentFile}
+            toolbarRef={toolbarRef}
+            isPublic={isPublic}
+          >
             {children}
           </FooterContent>
         </Footer>
       )}
       {validForPanel && (
         <InformationPanel>
-          <PanelContent file={currentFile} />
+          <PanelContent file={currentFile} isPublic={isPublic} />
         </InformationPanel>
       )}
     </>
@@ -53,6 +58,7 @@ ViewerInformationsWrapper.propTypes = {
   disableFooter: PropTypes.bool,
   validForPanel: PropTypes.bool,
   toolbarRef: PropTypes.object,
+  isPublic: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)


### PR DESCRIPTION
Dans une page public(suite à un partage), avec un fichier provenant d'un connecteur, le Viewer affiche toujours le bloc contenant les informations en lien avec ce dernier ([KonnectorBlock](https://github.com/cozy/cozy-libs/blob/0291ee72a7d9c019f926d06c814f272a7d95dff5/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx#L30)).
Mais dans ce contexte, nous ne souhaitons plus afficher ce bloc.

Cette PR fait en sorte de masquer ce bloc dans ce cas, car non pertinent et améliore l'UX.