### PR TITLE
fix: Use navigator.clipboard instead of copy-text-to-clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "bundlemon": "^1.3.2",
     "chart.js": "3.7.1",
     "classnames": "^2.2.5",
-    "copy-text-to-clipboard": "3.2.0",
     "cozy-interapp": "^0.5.4",
     "date-fns": "^1.28.5",
     "filesize": "8.0.7",

--- a/react/ListItem/ExpandedAttributes/helpers.js
+++ b/react/ListItem/ExpandedAttributes/helpers.js
@@ -1,5 +1,4 @@
 import get from 'lodash/get'
-import copy from 'copy-text-to-clipboard'
 
 import { formatDate } from '../../Viewer/helpers'
 
@@ -68,15 +67,15 @@ export const makeDefaultExpandedAttributes = (doc, expandedAttributes) => {
     .filter(x => x)
 }
 
-export const copyToClipboard = ({ value, setAlertProps, t }) => () => {
-  const hasCopied = copy(value)
-  if (hasCopied) {
+export const copyToClipboard = ({ value, setAlertProps, t }) => async () => {
+  try {
+    await navigator.clipboard.writeText(value)
     setAlertProps({
       open: true,
       severity: 'success',
       message: t(`ListItem.snackbar.copyToClipboard.success`)
     })
-  } else {
+  } catch (error) {
     setAlertProps({
       open: true,
       severity: 'error',

--- a/react/ListItem/ExpandedAttributes/helpers.spec.js
+++ b/react/ListItem/ExpandedAttributes/helpers.spec.js
@@ -7,8 +7,6 @@ import {
 import { I18nContext } from '../../jestLib/I18n'
 import en from '../locales/en'
 
-jest.mock('copy-text-to-clipboard', () => ({ copy: jest.fn() }))
-
 const i18nContext = I18nContext({
   locale: en
 })

--- a/react/Viewer/Panel/ActionMenuWrapper.jsx
+++ b/react/Viewer/Panel/ActionMenuWrapper.jsx
@@ -1,6 +1,5 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
-import copy from 'copy-text-to-clipboard'
 
 import { useAppLinkWithStoreFallback, useClient } from 'cozy-client'
 
@@ -40,14 +39,14 @@ const ActionMenuWrapper = forwardRef(({ onClose, file, optionFile }, ref) => {
   )
   const isAppLinkLoaded = fetchStatus === 'loaded'
 
-  const handleCopy = () => {
-    const hasCopied = copy(value)
-    if (hasCopied) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
       showViewerSnackbar(
         'success',
         t(`Viewer.snackbar.copiedToClipboard.success`)
       )
-    } else {
+    } catch (error) {
       showViewerSnackbar('error', t(`Viewer.snackbar.copiedToClipboard.error`))
     }
     onClose()

--- a/react/Viewer/Panel/getPanelBlocks.spec.jsx
+++ b/react/Viewer/Panel/getPanelBlocks.spec.jsx
@@ -4,8 +4,6 @@ jest.mock('cozy-harvest-lib/dist/components/KonnectorBlock', () => jest.fn())
 const block1Component = jest.fn()
 const block2Component = jest.fn()
 
-jest.mock('copy-text-to-clipboard', () => ({ copy: jest.fn() }))
-
 describe('getPanelBlocks', () => {
   it('should return only blocks with truthy condition', () => {
     // with two truthy component

--- a/yarn.lock
+++ b/yarn.lock
@@ -5909,11 +5909,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-text-to-clipboard@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz#0202b2d9bdae30a49a53f898626dcc3b49ad960b"
-  integrity sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==
-
 copy-text-to-clipboard@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"


### PR DESCRIPTION
copy-text-to-clipboard use deprecated command.exec which does not work anymore on some desktop browser.

Copy does not work on Chrome Desktop : https://docs.cozy.io/cozy-ui/react/#!/Core/ListItem
Copy works on Chrome Desktop : https://zatteo.github.io/cozy-ui/react/#!/Core/ListItem 