### PR TITLE
Better MidEllipsis and Filename component

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "piwik-react-router": "0.12.1",
     "react-chartjs-2": "4.1.0",
     "react-markdown": "^4.0.8",
+    "react-middle-ellipsis": "1.2.2",
     "react-pdf": "^5.7.2",
     "react-popper": "^2.2.3",
     "react-remove-scroll": "^2.4.0",

--- a/react/Filename/Readme.md
+++ b/react/Filename/Readme.md
@@ -17,7 +17,7 @@ const initialVariants = [
       icon={variant.icon ? FileIcon : undefined}
       variant={variant.body1Variant ? 'body1' : undefined}
       midEllipsis={variant.midEllipsis}
-      filename="Lacinia condimentum potenti id est tortor dictumst lectus tincidunt hac ultricies, curae mattis nisi neque sodales sagittis dui nulla aliquam turpis eros, finibus ac iaculis dictum et orci elit posuere ex"
+      filename="Lacinia condimentum potenti id est tortor dictumst lectus tincidunt hac ultricies, curae mattis nisi neque sodales sagittis dui nulla aliquam turpis eros, finibus ac iaculis dictum et orci elit posuere ex and this is the end"
       extension={variant.noExtension ? undefined : ".pdf"}
     />
   )}

--- a/react/Filename/index.jsx
+++ b/react/Filename/index.jsx
@@ -1,58 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 
-import { Media, Bd, Img } from '../deprecated/Media'
-import Icon from '../Icon'
+import Icon, { iconPropType } from '../Icon'
 import Typography from '../Typography'
 import MidEllipsis from '../MidEllipsis'
 
-import styles from './styles.styl'
-
 const Filename = ({ icon, filename, extension, midEllipsis, variant }) => {
   return (
-    <Media>
+    <div className="u-flex u-flex-items-center">
       {icon && (
-        <Img>
-          <Icon className={'u-mr-1'} icon={icon} width={30} height={30} />
-        </Img>
+        <div className="u-mr-1">
+          <Icon icon={icon} width={30} height={30} />
+        </div>
       )}
-      {(filename || extension) && (
-        <Bd className={styles['c-filename-wrapper']}>
-          {filename && (
-            <Typography
-              variant={variant}
-              component="span"
-              className={cx(styles['c-filename-name'], {
-                'u-ellipsis': !midEllipsis,
-                'u-ov-hidden': midEllipsis
-              })}
-            >
-              {midEllipsis ? <MidEllipsis text={filename} /> : filename}
-            </Typography>
-          )}
-          {extension && (
-            <Typography
-              variant={variant}
-              component="span"
-              color="textSecondary"
-            >
-              {extension}
-            </Typography>
-          )}
-        </Bd>
+      {filename && (
+        <Typography variant={variant} component="span" noWrap>
+          {midEllipsis ? <MidEllipsis text={filename} /> : filename}
+        </Typography>
       )}
-    </Media>
+      {extension && (
+        <Typography variant={variant} component="span" color="textSecondary">
+          {extension}
+        </Typography>
+      )}
+    </div>
   )
 }
 
 Filename.propTypes = {
   /** Filename icon */
-  icon: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.func
-  ]),
+  icon: iconPropType,
   /** folder or file name */
   filename: PropTypes.string,
   /** If a file name, you can specify the extension */

--- a/react/Filename/styles.styl
+++ b/react/Filename/styles.styl
@@ -1,9 +1,0 @@
-.c-filename-wrapper
-    display flex
-
-    :last-child
-        flex-shrink 0
-
-.c-filename-name
-    display inline
-    width auto

--- a/react/MidEllipsis/Readme.md
+++ b/react/MidEllipsis/Readme.md
@@ -1,39 +1,11 @@
 #### Ellipsis in the middle
 
+Text can be passed in `text` prop or as `child`.
+
 ```jsx
-import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
+import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
+
+;
 
 <MidEllipsis text={content.ada.short} />
-```
-
-#### Ellipsis in directory tree
-
-```jsx
-import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
-
-<MidEllipsis text="/Administratif/Netflix" />
-```
-
-#### Ellipsis with React string children
-
-```jsx
-import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
-
-<MidEllipsis>/Administratif/Netflix</MidEllipsis>
-```
-
-#### Ellipsis in directory tree with complex names
-
-```jsx
-import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
-
-<MidEllipsis text="/Administratif/Ameli//1 88 88 88 888 888" />
-```
-
-#### Ellipsis in directory tree with complex names and unusual characters
-
-```jsx
-import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis';
-
-<MidEllipsis text="/Partages reçus/Cozy 🗄 - Team/Customers & Partners 🛒/Xxxxxx (Xxxxxxxx)/4_Suivi opérationnel/Point de synchro" />
 ```

--- a/react/MidEllipsis/index.jsx
+++ b/react/MidEllipsis/index.jsx
@@ -1,6 +1,8 @@
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
+import MiddleEllipsis from 'react-middle-ellipsis'
+import flag from 'cozy-flags'
 
 /** The left-to-right mark (LRM) is a control character (an invisible formatting character)
  * used in computerized typesetting (including word processing in a program like Microsoft Word)
@@ -14,7 +16,7 @@ import PropTypes from 'prop-types'
  * */
 const LRM = <>&#8206;</>
 
-const MidEllipsis = forwardRef(
+const MidEllipsisLegacy = forwardRef(
   ({ text, className, children, ...props }, ref) => {
     if (text && typeof text !== 'string')
       throw new Error('The "text" prop of MidEllipsis can only be a string')
@@ -41,11 +43,36 @@ const MidEllipsis = forwardRef(
   }
 )
 
-MidEllipsis.displayName = 'MidEllipsis'
+MidEllipsisLegacy.displayName = 'MidEllipsis'
 
-MidEllipsis.propTypes = {
+MidEllipsisLegacy.propTypes = {
   text: PropTypes.string,
   className: PropTypes.string
 }
+
+// --
+// This is new component based on react-middle-ellipsis
+// We will delete all other stuff if perf test are successful with this one
+const styles = { whiteSpace: 'nowrap', overflow: 'hidden' }
+
+const MidEllipsisWithLib = forwardRef(({ text, ...props }, ref) => {
+  return (
+    <span style={styles}>
+      <MiddleEllipsis {...props} ref={ref}>
+        <span>{text}</span>
+      </MiddleEllipsis>
+    </span>
+  )
+})
+//
+// --
+
+const MidEllipsis = forwardRef((props, ref) => {
+  if (flag('ui.midellipsis-lib.enabled')) {
+    return <MidEllipsisWithLib {...props} ref={ref} />
+  }
+
+  return <MidEllipsisLegacy {...props} ref={ref} />
+})
 
 export default MidEllipsis

--- a/yarn.lock
+++ b/yarn.lock
@@ -16400,6 +16400,11 @@ react-markdown@^4.2.2:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
+react-middle-ellipsis@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-middle-ellipsis/-/react-middle-ellipsis-1.2.2.tgz#e1676fe2fbc864ea7e2fc25bedc53db2635bb2a9"
+  integrity sha512-tTsyS/hOjT3C5WjpueAx1/WsYUVnNlUnDRCKSffGT1ns7b0NbSi6FGVVPDLTxn207B0sVjNTbMnk1HFGWd5hzA==
+
 react-pdf@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-5.7.2.tgz#c458dedf7983822668b40dcac1eae052c1f6e056"


### PR DESCRIPTION
Il y avait des problèmes de style avec ces composants qui faisait que le midEllipsis avait des espaces en trop, n'était pas placé correctement, ou était présent alors qu'il ne devait pas l'être. On a mis la feature derrière un flag car comme on fait un calcul sur la taille du parent, cela peut avoir une conséquence en terme de perf. Si le test est concluant, on supprimera le flag.

Après vérification dans Drive, le midEllipsis est assez peu utilisé finalement (dans la barre OnlyOffice et sur les chemins des dossiers dans la vue Récents). Ceci est plus pour MesPapiers.

Deux autres libs ont retenu mon attention https://www.npmjs.com/package/react-text-overflow-middle-ellipsis et https://www.npmjs.com/package/react-middle-truncate mais celle choisie a été mise à jour plus récemment, elle est plus légère et elle est largement plus utilisée.