### PR TITLE
[VO-201] fix: Stop propagation of event

### DIFF
--- a/react/IntentDialogOpener/IntentDialogOpener.jsx
+++ b/react/IntentDialogOpener/IntentDialogOpener.jsx
@@ -28,6 +28,7 @@ const IntentDialogOpener = props => {
 
   const openModal = ev => {
     ev.preventDefault()
+    ev.stopPropagation()
     setModalOpened(true)
   }
   const closeModal = () => setModalOpened(false)

--- a/react/deprecated/IntentModal/IntentModal.jsx
+++ b/react/deprecated/IntentModal/IntentModal.jsx
@@ -46,9 +46,9 @@ class IntentModal extends Component {
   // FIXME: this should be fixed by diferenciating dismissAction (for closing
   // modal) and onCancel (for intent cancellation), but it implies deprecating
   // dismissAction first, ensure legacy, prevent regressions, etc.
-  dismiss = once(() => {
+  dismiss = once(evt => {
     const { dismissAction } = this.props
-    dismissAction && dismissAction()
+    dismissAction && dismissAction(evt)
   })
 
   render() {


### PR DESCRIPTION
This avoids triggering events for elements below the component, for example in Banks there are chips integrated into ListItems