### PR TITLE
feat(Viewer): Changing the behavior of the edit action

### DIFF
--- a/react/Viewer/Panel/ActionMenuDesktop.jsx
+++ b/react/Viewer/Panel/ActionMenuDesktop.jsx
@@ -25,14 +25,7 @@ const ActionMenuDesktop = forwardRef(
           <AppLinker app={{ slug: appSlug }} href={appLink}>
             {({ onClick, href }) => {
               return (
-                <a
-                  href={href}
-                  className={
-                    !appLink &&
-                    styles['ActionMenuDesktop-ActionMenu-link-disabled']
-                  }
-                  onClick={() => handleEdit(onClick)}
-                >
+                <a href={href} onClick={() => handleEdit(onClick)}>
                   <ActionMenuItem left={<Icon icon={Edit} />}>
                     <Typography>
                       {t(`Viewer.panel.qualification.actions.edit`)}

--- a/react/Viewer/Panel/ActionMenuMobile.jsx
+++ b/react/Viewer/Panel/ActionMenuMobile.jsx
@@ -35,7 +35,6 @@ const ActionMenuMobile = ({
                     component="a"
                     href={href}
                     onClick={() => handleEdit(onClick)}
-                    disabled={!appLink}
                   >
                     <ListItemIcon>
                       <Icon icon={Edit} />


### PR DESCRIPTION
We no longer want the action to gray out the URL generation time, because this time is generally short and generates an unpleasant flicker.