### PR TITLE
fix(Viewer): All files have konnector block

### DIFF
--- a/react/Viewer/Panel/getPanelBlocks.jsx
+++ b/react/Viewer/Panel/getPanelBlocks.jsx
@@ -27,7 +27,7 @@ export const getPanelBlocksSpecs = (isPublic = false) => ({
     component: Qualification
   },
   konnector: {
-    condition: () => isFromKonnector && !isPublic,
+    condition: file => isFromKonnector(file) && !isPublic,
     component: KonnectorBlock
   },
   certifications: {


### PR DESCRIPTION
During this PR #2563, we should have passed the current file as an argument.
The test was therefore always true in non-public view