### PR TITLE
Fix Filename midellipsis

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "piwik-react-router": "0.12.1",
     "react-chartjs-2": "4.1.0",
     "react-markdown": "^4.0.8",
-    "react-middle-ellipsis": "1.2.2",
     "react-pdf": "^5.7.2",
     "react-popper": "^2.2.3",
     "react-remove-scroll": "^2.4.0",

--- a/react/Filename/Readme.md
+++ b/react/Filename/Readme.md
@@ -6,20 +6,20 @@ import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
 import Variants from 'cozy-ui/docs/components/Variants'
 
 const initialVariants = [
-  { midEllipsis: false, icon: false, body1Variant: false, noExtension: false }
+  { midEllipsis: false, icon: false, body1Variant: false, extension: true, short: false }
 ]
 
 ;
 
 <Variants initialVariants={initialVariants} screenshotAllVariants>
   {variant => (
-    <Filename
-      icon={variant.icon ? FileIcon : undefined}
-      variant={variant.body1Variant ? 'body1' : undefined}
-      midEllipsis={variant.midEllipsis}
-      filename="Lacinia condimentum potenti id est tortor dictumst lectus tincidunt hac ultricies, curae mattis nisi neque sodales sagittis dui nulla aliquam turpis eros, finibus ac iaculis dictum et orci elit posuere ex and this is the end"
-      extension={variant.noExtension ? undefined : ".pdf"}
-    />
+  <Filename
+    icon={variant.icon ? FileIcon : undefined}
+    variant={variant.body1Variant ? 'body1' : undefined}
+    midEllipsis={variant.midEllipsis}
+    filename={variant.short ? "Lacinia condimentum this is the end" : "Lacinia condimentum potenti id est tortor dictumst lectus tincidunt hac ultricies, curae mattis nisi neque sodales sagittis dui nulla aliquam turpis eros, finibus ac iaculis dictum et orci elit posuere ex and this is the end"}
+    extension={variant.extension ? ".pdf" : undefined}
+  />
   )}
 </Variants>
 ```

--- a/react/MidEllipsis/index.jsx
+++ b/react/MidEllipsis/index.jsx
@@ -1,8 +1,6 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import MiddleEllipsis from 'react-middle-ellipsis'
-import flag from 'cozy-flags'
 
 /** The left-to-right mark (LRM) is a control character (an invisible formatting character)
  * used in computerized typesetting (including word processing in a program like Microsoft Word)
@@ -16,7 +14,7 @@ import flag from 'cozy-flags'
  * */
 const LRM = <>&#8206;</>
 
-const MidEllipsisLegacy = forwardRef(
+const MidEllipsis = forwardRef(
   ({ text, className, children, ...props }, ref) => {
     if (text && typeof text !== 'string')
       throw new Error('The "text" prop of MidEllipsis can only be a string')
@@ -27,8 +25,8 @@ const MidEllipsisLegacy = forwardRef(
     const str = text || children
 
     const partLength = Math.round(str.length / 2)
-    const firstPart = str.substr(0, partLength)
-    const lastPart = str.substr(partLength, str.length)
+    const firstPart = str.substring(0, partLength).trim()
+    const lastPart = str.substring(partLength, str.length).trim()
 
     return (
       <div className={cx('u-midellipsis', className)} ref={ref} {...props}>
@@ -43,36 +41,11 @@ const MidEllipsisLegacy = forwardRef(
   }
 )
 
-MidEllipsisLegacy.displayName = 'MidEllipsis'
+MidEllipsis.displayName = 'MidEllipsis'
 
-MidEllipsisLegacy.propTypes = {
+MidEllipsis.propTypes = {
   text: PropTypes.string,
   className: PropTypes.string
 }
-
-// --
-// This is new component based on react-middle-ellipsis
-// We will delete all other stuff if perf test are successful with this one
-const styles = { whiteSpace: 'nowrap', overflow: 'hidden' }
-
-const MidEllipsisWithLib = forwardRef(({ text, ...props }, ref) => {
-  return (
-    <div style={styles}>
-      <MiddleEllipsis {...props} ref={ref}>
-        <span>{text}</span>
-      </MiddleEllipsis>
-    </div>
-  )
-})
-//
-// --
-
-const MidEllipsis = forwardRef((props, ref) => {
-  if (flag('ui.midellipsis-lib.enabled')) {
-    return <MidEllipsisWithLib {...props} ref={ref} />
-  }
-
-  return <MidEllipsisLegacy {...props} ref={ref} />
-})
 
 export default MidEllipsis

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -42,7 +42,6 @@ $midellipsis
 
     > * // @stylint ignore
         display inline-block
-        max-width 50%
         overflow hidden
         white-space pre
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16400,11 +16400,6 @@ react-markdown@^4.2.2:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-react-middle-ellipsis@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/react-middle-ellipsis/-/react-middle-ellipsis-1.2.2.tgz#e1676fe2fbc864ea7e2fc25bedc53db2635bb2a9"
-  integrity sha512-tTsyS/hOjT3C5WjpueAx1/WsYUVnNlUnDRCKSffGT1ns7b0NbSi6FGVVPDLTxn207B0sVjNTbMnk1HFGWd5hzA==
-
 react-pdf@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-5.7.2.tgz#c458dedf7983822668b40dcac1eae052c1f6e056"


### PR DESCRIPTION
Ca ne fonctionnait pas sur Safari, et donc sur iOS, avec la nouvelle lib. J'ai essayé autant que possible d'utiliser le composant `MidEllipsis` dans Filename, et même d'utiliser d'autre lib mais il y a trop de cas particuliers (avec/sans extension/icone) pour que ça fonctionne simplement.

J'ai initialement trouvé une solution de construire à la main un "truncatedFilename" pour avoir un meilleur rendu dans Filename (c'est à ce code dont fait référence le premier commentaire de @Crash-- ), mais ce n'était pas concluant en terme de perf, ni en terme d'homogénéité selon tous les cas d'usages (différents browser, usage particulier dans Drive avec des class css supplémentaires etc.).

Pour info Filename n'est pas utilisé dans Drive, seul `MidEllipsis` l'est.

On a passé beaucoup de temps à chercher différentes solutions sur ce `MidEllipsis`, à cause du fait qu'on utilise ce composant dans des listes, c'est très vite gourmand en terme de perf si on fait des traitements JS. La solution css actuelle reste la meilleure en ratio rendu/perf pour l'instant.

On corrige au passage le fait que `MidEllipsis` ajoutait un ellipsis même pour un texte plus court que la place dispo sur la ligne, ce qui provoquait dans `Filename` un rendu non approprié en ajoutant un espace entre `filename` et `extension`. Ce fix n'impacte pas le rendu dans Drive ni le rendu précédent, il n'y a pas de regression. Ca corrige bien un cas qui n'était pas couvert, sans changer les cas fonctionnels actuels.