### PR TITLE
fix: The background of ListSubHeader should use the default background

### DIFF
--- a/react/MuiCozyTheme/overrides/makeLightNormalOverrides.js
+++ b/react/MuiCozyTheme/overrides/makeLightNormalOverrides.js
@@ -344,7 +344,7 @@ export const makeLightNormalOverrides = theme => ({
       backgroundColor: theme.palette.background.contrast
     },
     sticky: {
-      backgroundColor: theme.palette.background.contrast
+      backgroundColor: theme.palette.background.default
     }
   },
   MuiListItemText: {


### PR DESCRIPTION
The background contrasts with an opacity which reveals the content behind.