### PR TITLE
fix(Styles): Remove import of stylus file with global class creation in it

### DIFF
--- a/react/Field/styles.styl
+++ b/react/Field/styles.styl
@@ -1,5 +1,6 @@
-@require '../../stylus/components/forms'
-@require 'settings/spaces.styl'
+@require 'components/forms'
+@require 'settings/breakpoints'
+@require 'settings/spaces'
 
 .o-field
     @extend $field

--- a/stylus/components/button.styl
+++ b/stylus/components/button.styl
@@ -1,6 +1,4 @@
 @require '../settings/icons'
-@require '../utilities/display'
-@require '../utilities/text'
 @require '../tools/mixins'
 
 palette=json('../settings/palette.json', { hash: true })
@@ -431,7 +429,7 @@ $actionbtn--compact
         justify-content center
 
     [data-action='label']
-        @extend $hide
+        hide()
 
     [data-action='icon']
         border-left none
@@ -476,7 +474,7 @@ $actionbtn--new
         border-style solid
 
 $actionbtn-label
-    @extend $ellipsis
+    ellipsis()
     padding-right rem(8)
 
 $actionbtn-icon

--- a/stylus/components/forms.styl
+++ b/stylus/components/forms.styl
@@ -5,8 +5,8 @@
     This file contains all needs for forms, inputs, labels...
 \*------------------------------------*/
 
-@require '../components/button'
 @require '../tools/mixins'
+@require '../settings/breakpoints'
 
 checkbox-size = rem(16)
 

--- a/stylus/generic/animations.styl
+++ b/stylus/generic/animations.styl
@@ -15,11 +15,11 @@
         transform rotate(0deg)
     to
         transform rotate(359deg)
-        
+
 @keyframes shake
     10%, 90%
         transform translate3d(-1px, 0, 0)
-   
+
     20%, 80%
         transform translate3d(2px, 0, 0)
 

--- a/stylus/tools/mixins.styl
+++ b/stylus/tools/mixins.styl
@@ -96,12 +96,27 @@ visually-hide()
     white-space nowrap
 
 /*
+    ellipsis()
+
+    ellipsis() mixin add an ellipsis on text.
+    This mixin doesn't take parameters.
+
+    Weight: 4
+
+    Styleguide Tools.mixins.ellipsis
+*/
+ellipsis()
+    white-space nowrap
+    overflow hidden
+    text-overflow ellipsis
+
+/*
     reset()
 
     reset() mixin removes every padding, margin and border of an element.
     This mixin doesn't take parameters.
 
-    Weight: 4
+    Weight: 5
 
     Styleguide Tools.mixins.reset
 */

--- a/stylus/utilities/text.styl
+++ b/stylus/utilities/text.styl
@@ -18,9 +18,7 @@ $breakword
     word-break break-word
 
 $ellipsis
-    white-space nowrap
-    overflow hidden
-    text-overflow ellipsis
+    ellipsis()
 
 spacellipsis()
     overflow hidden


### PR DESCRIPTION
Comme les fichiers stylus dans le dossier `utilities` comporte des mixins/var ET les créations des classes css globales (les classes `.u-`), le fait d'importer ces fichiers dans d'autres fichiers stylus duplique les créations des classes utilitaires.

Pour `hide` et `ellipsis` au lieu d'importer la variable depuis le fichier respectif qui contient donc la variable ET la création de la classe utilitaire, on en fait des mixins qui sont alors elles utilisées en remplacement, afin de NE PAS importer le fichier de création des classes utilitaires.

Ceci corrige donc la duplication des classes utilitaires dans le cas où on importe directement c'est fichier stylus dans l'app, ces classes utilitaires se retrouvaient alors dans le css buildé de l'app, entrant donc en conflit (en cas de différence de version) avec celles de cozy-ui.