### PR TITLE
Replace `contentAuthor` by `employerName`

### DIFF
--- a/react/ListItem/ExpandedAttributes/helpers.js
+++ b/react/ListItem/ExpandedAttributes/helpers.js
@@ -36,7 +36,6 @@ export const defaultExpandedAttributes = {
     'metadata.ibanNumber',
     'metadata.bicNumber',
     'metadata.netSocialAmount',
-    'metadata.contentAuthor',
     'metadata.passportNumber',
     'metadata.noticePeriod',
     'metadata.obtentionDate',

--- a/react/ListItem/locales/en.json
+++ b/react/ListItem/locales/en.json
@@ -30,7 +30,6 @@
         "bicNumber": "BIC number",
         "passportNumber": "Passport number",
         "netSocialAmount": "Net social amount",
-        "contentAuthor": "Name of employer",
         "number": {
           "pay_sheet": "Gross remuneration",
           "fine": "Amount of the fine",

--- a/react/ListItem/locales/fr.json
+++ b/react/ListItem/locales/fr.json
@@ -30,7 +30,6 @@
         "bicNumber": "Numéro BIC",
         "passportNumber": "Numéro du passeport",
         "netSocialAmount": "Montant net social",
-        "contentAuthor": "Nom de l'employeur",
         "number": {
           "pay_sheet": "Rémunération brute",
           "fine": "Montant de l'amende",

--- a/react/Viewer/helpers.js
+++ b/react/Viewer/helpers.js
@@ -28,7 +28,7 @@ export const knownInformationMetadataNames = [
   'refTaxIncome',
   'contractType',
   'netSocialAmount',
-  'contentAuthor',
+  'employerName',
   'noticePeriod'
 ]
 export const knownOtherMetadataNames = ['contact', 'page', 'qualification']

--- a/react/Viewer/locales/en.json
+++ b/react/Viewer/locales/en.json
@@ -93,7 +93,7 @@
             "contractType": "Contract type",
             "noticePeriod": "Expiration alert",
             "netSocialAmount": "Net social amount",
-            "contentAuthor": "Name of employer",
+            "employerName": "Name of employer",
             "bicNumber": "BIC number"
           },
           "day": "day |||| days"

--- a/react/Viewer/locales/fr.json
+++ b/react/Viewer/locales/fr.json
@@ -93,7 +93,7 @@
             "contractType": "Type de contrat",
             "noticePeriod": "Alerte d’expiration",
             "netSocialAmount": "Montant net social",
-            "contentAuthor": "Nom de l'employeur",
+            "employerName": "Nom de l'employeur",
             "bicNumber": "Numéro BIC"
           },
           "day": "jour |||| jours"


### PR DESCRIPTION
On souhaite pouvoir afficher le nom de l'employeur dans les infos du Viewer.  Préalablement on avait mise sur `contentAuthor` pour stocker cette info, mais finalement il s'avère qu'on y stocke plutôt la source de récupération du doc lorsqu'on le récupère va un connecteur, ce qui ne convient pas au besoin. On a donc créé une nouvelle metadata `employerName` pour ça.

Côté expanded attributes on ne souhaite plus afficher cette info dans cet élément.