### PR TITLE
fix: Use /medium for PDF thumbnails

### DIFF
--- a/react/FileImageLoader/index.jsx
+++ b/react/FileImageLoader/index.jsx
@@ -171,14 +171,7 @@ export class FileImageLoader extends Component {
 FileImageLoader.propTypes = {
   file: PropTypes.object.isRequired,
   render: PropTypes.func.isRequired,
-  linkType: PropTypes.oneOf([
-    'tiny',
-    'small',
-    'medium',
-    'large',
-    'preview',
-    'icon'
-  ]),
+  linkType: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'icon']),
   onError: PropTypes.func,
   renderFallback: PropTypes.func
 }

--- a/react/Viewer/ViewersByFile/PdfMobileViewer.jsx
+++ b/react/Viewer/ViewersByFile/PdfMobileViewer.jsx
@@ -84,7 +84,7 @@ export const PdfMobileViewer = ({ file, url, t, gestures }) => {
         <FileImageLoader
           file={file}
           url={url}
-          linkType="preview"
+          linkType="medium"
           onError={onImageError}
           key={file.id}
           render={src => (

--- a/react/Viewer/ViewersByFile/PdfMobileViewer.spec.jsx
+++ b/react/Viewer/ViewersByFile/PdfMobileViewer.spec.jsx
@@ -33,7 +33,7 @@ const file = {
   name: 'Demo.pdf',
   mime: 'application/pdf',
   links: {
-    preview: 'https://viewerdemo.cozycloud.cc/IMG_0062.PNG'
+    medium: 'https://viewerdemo.cozycloud.cc/IMG_0062.PNG'
   }
 }
 
@@ -59,7 +59,7 @@ describe('PdfMobileViewer', () => {
     expect(getByRole('progressbar'))
   })
 
-  describe('errors if file as no preview or failed to download', () => {
+  describe('errors if file as no medium or failed to download', () => {
     let fileWithoutLinks = file
 
     beforeAll(() => {

--- a/react/Viewer/docs/DemoProvider.jsx
+++ b/react/Viewer/docs/DemoProvider.jsx
@@ -38,8 +38,7 @@ const mockClient = {
         resolve({
           data: {
             links: {
-              large: 'https://viewerdemo.cozycloud.cc/IMG_0062.PNG',
-              preview: 'https://viewerdemo.cozycloud.cc/IMG_0062.PNG'
+              large: 'https://viewerdemo.cozycloud.cc/IMG_0062.PNG'
             }
           }
         })


### PR DESCRIPTION
The old route will be removed, we should use the new one.

See https://github.com/cozy/cozy-stack/pull/4344/files 