### PR TITLE
Viewer: modify toolbar/footer buttons

### DIFF
--- a/react/Viewer/Footer/DownloadButton.jsx
+++ b/react/Viewer/Footer/DownloadButton.jsx
@@ -3,16 +3,21 @@ import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
 
+import { useI18n } from '../../providers/I18n'
 import Icon from '../../Icon'
+import IconButton from '../../IconButton'
 import DownloadIcon from '../../Icons/Download'
 import Button from '../../Buttons'
 import Alerter from '../../deprecated/Alerter'
-import { withViewerLocales } from '../hoc/withViewerLocales'
 
-const DownloadButton = ({ file, t }) => {
+const DownloadButton = ({ file, variant }) => {
   const client = useClient()
+  const { t } = useI18n()
 
-  const handleClick = async file => {
+  const icon = <Icon icon={DownloadIcon} />
+  const label = t('Viewer.download')
+
+  const handleClick = async () => {
     try {
       await client.collection('io.cozy.files').download(file)
     } catch (error) {
@@ -20,19 +25,43 @@ const DownloadButton = ({ file, t }) => {
     }
   }
 
+  if (variant === 'iconButton') {
+    return (
+      <IconButton className="u-white" aria-label={label} onClick={handleClick}>
+        {icon}
+      </IconButton>
+    )
+  }
+
+  if (variant === 'buttonIcon') {
+    return (
+      <Button
+        variant="secondary"
+        label={icon}
+        aria-label={label}
+        onClick={handleClick}
+      />
+    )
+  }
+
   return (
     <Button
       fullWidth
       variant="secondary"
-      startIcon={<Icon icon={DownloadIcon} />}
-      label={t('Viewer.download')}
-      onClick={() => handleClick(file)}
+      startIcon={icon}
+      label={label}
+      onClick={handleClick}
     />
   )
 }
 
 DownloadButton.propTypes = {
-  file: PropTypes.object
+  file: PropTypes.object,
+  variant: PropTypes.oneOf(['default', 'iconButton', 'buttonIcon'])
 }
 
-export default withViewerLocales(DownloadButton)
+DownloadButton.defaultProptypes = {
+  variant: 'default'
+}
+
+export default DownloadButton

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -1,10 +1,11 @@
-import React, { useMemo, Children, cloneElement, isValidElement } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import BottomSheet, { BottomSheetHeader } from '../../BottomSheet'
 import { makeStyles } from '../../styles'
 import { isValidForPanel } from '../helpers'
+import { extractChildrenCompByName } from './helpers'
 import BottomSheetContent from './BottomSheetContent'
 
 const useStyles = makeStyles(theme => ({
@@ -28,19 +29,11 @@ const FooterContent = ({ file, toolbarRef, children, isPublic }) => {
 
   const toolbarProps = useMemo(() => ({ ref: toolbarRef }), [toolbarRef])
 
-  const FooterActionButtons =
-    Children.toArray(children).find(child => {
-      return (
-        child.type.name === 'FooterActionButtons' ||
-        child.type.displayName === 'FooterActionButtons'
-      )
-    }) || null
-
-  const FooterActionButtonsWithFile = isValidElement(FooterActionButtons)
-    ? cloneElement(FooterActionButtons, {
-        file
-      })
-    : null
+  const FooterActionButtonsWithFile = extractChildrenCompByName({
+    children,
+    file,
+    name: 'FooterActionButtons'
+  })
 
   if (isValidForPanel({ file })) {
     return (
@@ -60,7 +53,7 @@ const FooterContent = ({ file, toolbarRef, children, isPublic }) => {
   }
 
   // If `FooterActionButtons` hasn't children
-  if (!FooterActionButtons) return null
+  if (!FooterActionButtonsWithFile) return null
 
   return <div className={styles.footer}>{FooterActionButtonsWithFile}</div>
 }

--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -5,8 +5,21 @@ import cx from 'classnames'
 import BottomSheet, { BottomSheetHeader } from '../../BottomSheet'
 import { makeStyles } from '../../styles'
 import { isValidForPanel } from '../helpers'
+import PrintButton from '../components/PrintButton'
 import { extractChildrenCompByName } from './helpers'
 import BottomSheetContent from './BottomSheetContent'
+
+const FooterButtons = ({
+  file,
+  FooterActionButtonsWithFile = { FooterActionButtonsWithFile }
+}) => {
+  return (
+    <>
+      {FooterActionButtonsWithFile}
+      <PrintButton file={file} variant="button" />
+    </>
+  )
+}
 
 const useStyles = makeStyles(theme => ({
   footer: {
@@ -45,7 +58,10 @@ const FooterContent = ({ file, toolbarRef, children, isPublic }) => {
         <BottomSheetHeader
           className={cx('u-ph-1 u-pb-1', styles.bottomSheetHeader)}
         >
-          {FooterActionButtonsWithFile}
+          <FooterButtons
+            file={file}
+            FooterActionButtonsWithFile={FooterActionButtonsWithFile}
+          />
         </BottomSheetHeader>
         <BottomSheetContent file={file} isPublic={isPublic} />
       </BottomSheet>
@@ -55,7 +71,14 @@ const FooterContent = ({ file, toolbarRef, children, isPublic }) => {
   // If `FooterActionButtons` hasn't children
   if (!FooterActionButtonsWithFile) return null
 
-  return <div className={styles.footer}>{FooterActionButtonsWithFile}</div>
+  return (
+    <div className={styles.footer}>
+      <FooterButtons
+        file={file}
+        FooterActionButtonsWithFile={FooterActionButtonsWithFile}
+      />
+    </div>
+  )
 }
 
 FooterContent.propTypes = {

--- a/react/Viewer/Footer/ForwardButton.jsx
+++ b/react/Viewer/Footer/ForwardButton.jsx
@@ -6,19 +6,22 @@ import { isIOS, isMobileApp } from 'cozy-device-helper'
 
 import { useI18n } from '../../providers/I18n'
 import Icon from '../../Icon'
+import IconButton from '../../IconButton'
 import ReplyIcon from '../../Icons/Reply'
 import ShareIosIcon from '../../Icons/ShareIos'
 import Button from '../../Buttons'
 import Alerter from '../../deprecated/Alerter'
-import { withViewerLocales } from '../hoc/withViewerLocales'
 import { exportFilesNative } from './helpers'
 import { getSharingLink } from 'cozy-client/dist/models/sharing'
 
 const ForwardIcon = isIOS() ? ShareIosIcon : ReplyIcon
 
-const ForwardButton = ({ file, onClick }) => {
+const ForwardButton = ({ file, variant, onClick }) => {
   const { t } = useI18n()
   const client = useClient()
+
+  const icon = <Icon icon={ForwardIcon} />
+  const label = t('Viewer.actions.forward')
 
   const onFileOpen = async file => {
     if (isMobileApp()) {
@@ -47,13 +50,32 @@ const ForwardButton = ({ file, onClick }) => {
     else onFileOpen(file)
   }
 
+  if (variant === 'iconButton') {
+    return (
+      <IconButton className="u-white" aria-label={label} onClick={handleClick}>
+        {icon}
+      </IconButton>
+    )
+  }
+
+  if (variant === 'buttonIcon') {
+    return (
+      <Button
+        variant="secondary"
+        label={icon}
+        aria-label={label}
+        onClick={handleClick}
+      />
+    )
+  }
+
   return (
     <Button
       fullWidth
       variant="secondary"
-      startIcon={<Icon icon={ForwardIcon} />}
+      startIcon={icon}
       data-testid="openFileButton"
-      label={t('Viewer.actions.forward')}
+      label={label}
       onClick={handleClick}
     />
   )
@@ -61,8 +83,13 @@ const ForwardButton = ({ file, onClick }) => {
 
 ForwardButton.propTypes = {
   file: PropTypes.object.isRequired,
+  variant: PropTypes.oneOf(['default', 'iconButton', 'buttonIcon']),
   onClick: PropTypes.func
 }
 
+ForwardButton.defaultProptypes = {
+  variant: 'default'
+}
+
 export { exportFilesNative }
-export default withViewerLocales(ForwardButton)
+export default ForwardButton

--- a/react/Viewer/Footer/ForwardOrDownloadButton.jsx
+++ b/react/Viewer/Footer/ForwardOrDownloadButton.jsx
@@ -7,14 +7,14 @@ import ForwardButton from './ForwardButton'
 import DownloadButton from './DownloadButton'
 import { shouldBeForwardButton } from './helpers'
 
-const ForwardOrDownloadButton = ({ file }) => {
+const ForwardOrDownloadButton = ({ file, ...props }) => {
   const client = useClient()
 
   const FileActionButton = shouldBeForwardButton(client)
     ? ForwardButton
     : DownloadButton
 
-  return <FileActionButton file={file} />
+  return <FileActionButton file={file} {...props} />
 }
 
 ForwardOrDownloadButton.propTypes = {

--- a/react/Viewer/Footer/Sharing.jsx
+++ b/react/Viewer/Footer/Sharing.jsx
@@ -5,9 +5,27 @@ import { useClient } from 'cozy-client'
 import { ShareModal, ShareButton } from 'cozy-sharing'
 import { SharingProvider } from 'cozy-sharing/dist/SharingProvider'
 
-const Sharing = ({ file }) => {
+import IconButton from '../../IconButton'
+import Icon from '../../Icon'
+import ShareIcon from '../../Icons/Share'
+
+const Sharing = ({ file, variant }) => {
   const client = useClient()
   const [showShareModal, setShowShareModal] = useState(false)
+
+  const SharingButton =
+    variant === 'iconButton' ? (
+      <IconButton className="u-white" onClick={() => setShowShareModal(true)}>
+        <Icon icon={ShareIcon} />
+      </IconButton>
+    ) : (
+      <ShareButton
+        extension="full"
+        useShortLabel
+        docId={file.id}
+        onClick={() => setShowShareModal(true)}
+      />
+    )
 
   return (
     <>
@@ -24,19 +42,19 @@ const Sharing = ({ file }) => {
             onClose={() => setShowShareModal(false)}
           />
         )}
-        <ShareButton
-          extension="full"
-          useShortLabel
-          docId={file.id}
-          onClick={() => setShowShareModal(true)}
-        />
+        {SharingButton}
       </SharingProvider>
     </>
   )
 }
 
 Sharing.propTypes = {
-  file: PropTypes.object
+  file: PropTypes.object,
+  variant: PropTypes.oneOf(['default', 'iconButton'])
+}
+
+Sharing.defaultProptypes = {
+  variant: 'default'
 }
 
 export default Sharing

--- a/react/Viewer/Footer/helpers.js
+++ b/react/Viewer/Footer/helpers.js
@@ -89,3 +89,18 @@ export const mapToAllChildren = (children, cb) => {
     return cb(child)
   })
 }
+
+export const extractChildrenCompByName = ({ children, file, name }) => {
+  const ChildrenComp =
+    Children.toArray(children).find(child => {
+      return child.type.name === name || child.type.displayName === name
+    }) || null
+
+  const ChildrenCompWithFile = isValidElement(ChildrenComp)
+    ? cloneElement(ChildrenComp, {
+        file
+      })
+    : null
+
+  return ChildrenCompWithFile
+}

--- a/react/Viewer/NoViewer/DownloadButton.jsx
+++ b/react/Viewer/NoViewer/DownloadButton.jsx
@@ -1,30 +1,29 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import flow from 'lodash/flow'
 
 import { withClient } from 'cozy-client'
 
+import { useI18n } from '../../providers/I18n'
 import { FileDoctype } from '../../proptypes'
 import Button from '../../deprecated/Button'
 
-import { withViewerLocales } from '../hoc/withViewerLocales'
 import { downloadFile } from '../helpers'
 
-const DownloadButton = ({ t, client, file, url }) => (
-  <Button
-    onClick={() => downloadFile({ client, file, url })}
-    label={t('Viewer.download')}
-  />
-)
+const DownloadButton = ({ client, file, url }) => {
+  const { t } = useI18n()
+
+  return (
+    <Button
+      onClick={() => downloadFile({ client, file, url })}
+      label={t('Viewer.download')}
+    />
+  )
+}
 
 DownloadButton.propTypes = {
-  t: PropTypes.func.isRequired,
   client: PropTypes.object.isRequired,
   file: FileDoctype,
   url: PropTypes.string
 }
 
-export default flow(
-  withClient,
-  withViewerLocales
-)(DownloadButton)
+export default withClient(DownloadButton)

--- a/react/Viewer/Panel/QualificationListItemInformation.spec.jsx
+++ b/react/Viewer/Panel/QualificationListItemInformation.spec.jsx
@@ -1,26 +1,27 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import DemoProvider from '../docs/DemoProvider'
 
 import QualificationListItemInformation, {
   makeInformationValue
 } from './QualificationListItemInformation'
 import MidEllipsis from '../../MidEllipsis'
 
+jest.mock('../../providers/I18n', () => ({
+  useI18n: jest.fn(() => ({ t: x => x }))
+}))
+
 const setup = ({
   formatedMetadataQualification = {},
   toggleActionsMenu = jest.fn()
 } = {}) => {
   return render(
-    <DemoProvider>
-      <QualificationListItemInformation
-        formatedMetadataQualification={formatedMetadataQualification}
-        toggleActionsMenu={toggleActionsMenu}
-        file={{
-          metadata: { qualification: { label: 'label_of_qualification' } }
-        }}
-      />
-    </DemoProvider>
+    <QualificationListItemInformation
+      formatedMetadataQualification={formatedMetadataQualification}
+      toggleActionsMenu={toggleActionsMenu}
+      file={{
+        metadata: { qualification: { label: 'label_of_qualification' } }
+      }}
+    />
   )
 }
 

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -46,7 +46,7 @@ import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import Variants from 'cozy-ui/docs/components/Variants'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
-import Viewer from 'cozy-ui/transpiled/react/Viewer'
+import Viewer, { ToolbarButtons, FooterActionButtons, ForwardOrDownloadButton } from 'cozy-ui/transpiled/react/Viewer'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import Paper from 'cozy-ui/transpiled/react/Paper'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -60,9 +60,8 @@ import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download'
 import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 import { isValidForPanel } from 'cozy-ui/transpiled/react/Viewer/helpers'
 import getPanelBlocks, { panelBlocksSpecs } from 'cozy-ui/transpiled/react/Viewer/Panel/getPanelBlocks'
-import FooterActionButtons from 'cozy-ui/transpiled/react/Viewer/Footer/FooterActionButtons'
-import ForwardOrDownloadButton from 'cozy-ui/transpiled/react/Viewer/Footer/ForwardOrDownloadButton'
 import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
 
 // We provide a collection of (fake) io.cozy.files to be rendered
 const files = [
@@ -263,6 +262,22 @@ const editPathByModelProps = {
                 }
               }}
             >
+              <ToolbarButtons>
+                <IconButton
+                  className="u-white"
+                  aria-label="Share"
+                  onClick={() => alert("Click Share toolbar button")}
+                >
+                  <Icon icon={ShareIcon} />
+                </IconButton>
+                <IconButton
+                  className="u-white"
+                  aria-label="Carbon Copy"
+                  onClick={() => alert("Click CarbonCopy toolbar button")}
+                >
+                  <Icon icon={CarbonCopyIcon} />
+                </IconButton>
+              </ToolbarButtons>
               <FooterActionButtons>
                 <ShareButtonFake />
                 <ForwardOrDownloadButton />

--- a/react/Viewer/Viewer.jsx
+++ b/react/Viewer/Viewer.jsx
@@ -70,6 +70,7 @@ class Viewer extends Component {
       showNavigation,
       renderFallbackExtraContent,
       validForPanel,
+      children,
       componentsProps
     } = this.props
 
@@ -90,6 +91,7 @@ class Viewer extends Component {
           showNavigation={showNavigation}
           showInfoPanel={validForPanel}
         >
+          {children}
           <ViewerByFile
             file={currentFile}
             onClose={this.onClose}

--- a/react/Viewer/ViewerContainer.jsx
+++ b/react/Viewer/ViewerContainer.jsx
@@ -63,7 +63,9 @@ const ViewerContainer = props => {
               hasNext={hasNext}
               validForPanel={validForPanel}
               toolbarRef={toolbarRef}
-            />
+            >
+              {children}
+            </Viewer>
           </EncryptedProvider>
           <ViewerInformationsWrapper
             isPublic={isPublic}

--- a/react/Viewer/ViewerContainer.jsx
+++ b/react/Viewer/ViewerContainer.jsx
@@ -4,9 +4,10 @@ import cx from 'classnames'
 
 import useBreakpoints from '../providers/Breakpoints'
 import { FileDoctype } from '../proptypes'
-
-import Modal from '../Modal'
+import { useExtendI18n } from '../providers/I18n'
 import { useCozyTheme } from '../providers/CozyTheme'
+import Modal from '../Modal'
+
 import { toolbarPropsPropType } from './proptypes'
 import { isValidForPanel } from './helpers'
 import Viewer from './Viewer'
@@ -14,7 +15,7 @@ import ViewerInformationsWrapper from './ViewerInformationsWrapper'
 import EncryptedProvider from './providers/EncryptedProvider'
 import AlertProvider from '../providers/Alert'
 import { ActionMenuProvider } from './providers/ActionMenuProvider'
-
+import { locales } from './locales'
 import styles from './styles.styl'
 
 const ViewerContainer = props => {
@@ -31,6 +32,7 @@ const ViewerContainer = props => {
   const { currentIndex, files, currentURL } = props
   const toolbarRef = createRef()
   const { isDesktop } = useBreakpoints()
+  useExtendI18n(locales)
   const currentFile = files[currentIndex]
   const fileCount = files.length
   const hasPrevious = currentIndex > 0

--- a/react/Viewer/ViewerContainer.jsx
+++ b/react/Viewer/ViewerContainer.jsx
@@ -2,6 +2,8 @@ import React, { createRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
+import { WebviewIntentProvider } from 'cozy-intent'
+
 import useBreakpoints from '../providers/Breakpoints'
 import { FileDoctype } from '../proptypes'
 import { useExtendI18n } from '../providers/I18n'
@@ -50,37 +52,39 @@ const ViewerContainer = props => {
   }
 
   return (
-    <AlertProvider>
-      <ActionMenuProvider editPathByModelProps={editPathByModelProps}>
-        <div
-          id="viewer-wrapper"
-          className={cx(styles['viewer-wrapper'], className)}
-        >
-          <EncryptedProvider url={currentURL}>
-            <Viewer
-              {...rest}
-              componentsProps={componentsPropsWithDefault}
-              currentFile={currentFile}
-              hasPrevious={hasPrevious}
-              hasNext={hasNext}
+    <WebviewIntentProvider>
+      <AlertProvider>
+        <ActionMenuProvider editPathByModelProps={editPathByModelProps}>
+          <div
+            id="viewer-wrapper"
+            className={cx(styles['viewer-wrapper'], className)}
+          >
+            <EncryptedProvider url={currentURL}>
+              <Viewer
+                {...rest}
+                componentsProps={componentsPropsWithDefault}
+                currentFile={currentFile}
+                hasPrevious={hasPrevious}
+                hasNext={hasNext}
+                validForPanel={validForPanel}
+                toolbarRef={toolbarRef}
+              >
+                {children}
+              </Viewer>
+            </EncryptedProvider>
+            <ViewerInformationsWrapper
+              isPublic={isPublic}
+              disableFooter={disableFooter}
               validForPanel={validForPanel}
+              currentFile={currentFile}
               toolbarRef={toolbarRef}
             >
               {children}
-            </Viewer>
-          </EncryptedProvider>
-          <ViewerInformationsWrapper
-            isPublic={isPublic}
-            disableFooter={disableFooter}
-            validForPanel={validForPanel}
-            currentFile={currentFile}
-            toolbarRef={toolbarRef}
-          >
-            {children}
-          </ViewerInformationsWrapper>
-        </div>
-      </ActionMenuProvider>
-    </AlertProvider>
+            </ViewerInformationsWrapper>
+          </div>
+        </ActionMenuProvider>
+      </AlertProvider>
+    </WebviewIntentProvider>
   )
 }
 

--- a/react/Viewer/ViewersByFile/PdfMobileViewer.spec.jsx
+++ b/react/Viewer/ViewersByFile/PdfMobileViewer.spec.jsx
@@ -69,7 +69,7 @@ describe('PdfMobileViewer', () => {
 
       await waitFor(() => {
         expect(queryByRole('progressbar')).toBeFalsy()
-        expect(getByText('Download'))
+        expect(getByText('Viewer.download'))
         expect(getByText(file.name))
       })
     })

--- a/react/Viewer/components/PrintButton.jsx
+++ b/react/Viewer/components/PrintButton.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+import { useWebviewIntent } from 'cozy-intent'
+
+import Button from '../../Buttons'
+import IconButton from '../../IconButton'
+import Icon from '../../Icon'
+import { print } from '../../ActionsMenu/Actions/print'
+
+const PrintButton = ({ file, variant }) => {
+  const [isPrintAvailable, setIsPrintAvailable] = useState(false)
+  const client = useClient()
+  const webviewIntent = useWebviewIntent()
+  const {
+    icon: printIcon,
+    label: printLabel,
+    action: printAction,
+    displayCondition: printDisplayCondition
+  } = print()
+
+  const isPDFDoc = file.mime === 'application/pdf'
+  const showPrintButton = printDisplayCondition && isPDFDoc && isPrintAvailable
+
+  const handleClick = async () =>
+    await printAction([file], { client, webviewIntent })
+
+  useEffect(() => {
+    const init = async () => {
+      const isAvailable =
+        (await webviewIntent?.call('isAvailable', 'print')) ?? true
+
+      setIsPrintAvailable(isAvailable)
+    }
+
+    init()
+  }, [webviewIntent])
+
+  if (!showPrintButton) return null
+
+  if (variant === 'button') {
+    return (
+      <Button
+        variant="secondary"
+        aria-label={printLabel}
+        label={<Icon icon={printIcon} />}
+        onClick={handleClick}
+      />
+    )
+  }
+
+  return (
+    <IconButton
+      className="u-white"
+      aria-label={printLabel}
+      onClick={handleClick}
+    >
+      <Icon icon={printIcon} />
+    </IconButton>
+  )
+}
+
+PrintButton.propTypes = {
+  file: PropTypes.object.isRequired,
+  variant: PropTypes.oneOf(['default', 'button'])
+}
+
+PrintButton.defaultProps = {
+  variant: 'default'
+}
+
+export default PrintButton

--- a/react/Viewer/components/Toolbar.jsx
+++ b/react/Viewer/components/Toolbar.jsx
@@ -7,7 +7,6 @@ import { useClient } from 'cozy-client'
 
 import withBreakpoints from '../../helpers/withBreakpoints'
 import { makeStyles } from '../../styles'
-import Button from '../../deprecated/Button'
 import IconButton from '../../IconButton'
 import Icon from '../../Icon'
 import Typography from '../../Typography'
@@ -78,13 +77,13 @@ const Toolbar = ({
 
       <div className="u-ml-auto u-ph-1">
         {isDesktop && (
-          <Button
+          <IconButton
             className="u-white"
-            icon={DownloadIcon}
-            label={t('Viewer.download')}
-            subtle
+            aria-label={t('Viewer.download')}
             onClick={() => downloadFile({ client, file, url })}
-          />
+          >
+            <Icon icon={DownloadIcon} />
+          </IconButton>
         )}
       </div>
     </div>

--- a/react/Viewer/components/Toolbar.jsx
+++ b/react/Viewer/components/Toolbar.jsx
@@ -17,6 +17,7 @@ import { withViewerLocales } from '../hoc/withViewerLocales'
 import { downloadFile } from '../helpers'
 import { useEncrypted } from '../providers/EncryptedProvider'
 import { ToolbarFilePath } from './ToolbarFilePath'
+import { extractChildrenCompByName } from '../Footer/helpers'
 
 import styles from './styles.styl'
 import MidEllipsis from '../../MidEllipsis'
@@ -38,12 +39,19 @@ const Toolbar = ({
   t,
   toolbarRef,
   breakpoints: { isDesktop },
+  children,
   showFilePath
 }) => {
   const client = useClient()
   const classes = useClasses()
 
   const { url } = useEncrypted()
+
+  const ToolbarButtons = extractChildrenCompByName({
+    children,
+    file,
+    name: 'ToolbarButtons'
+  })
 
   return (
     <div
@@ -76,13 +84,16 @@ const Toolbar = ({
 
       <div className="u-flex">
         {isDesktop && (
-          <IconButton
-            className="u-white"
-            aria-label={t('Viewer.download')}
-            onClick={() => downloadFile({ client, file, url })}
-          >
-            <Icon icon={DownloadIcon} />
-          </IconButton>
+          <>
+            {ToolbarButtons}
+            <IconButton
+              className="u-white"
+              aria-label={t('Viewer.download')}
+              onClick={() => downloadFile({ client, file, url })}
+            >
+              <Icon icon={DownloadIcon} />
+            </IconButton>
+          </>
         )}
       </div>
     </div>

--- a/react/Viewer/components/Toolbar.jsx
+++ b/react/Viewer/components/Toolbar.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import flow from 'lodash/flow'
 
 import { useClient } from 'cozy-client'
 
@@ -12,15 +11,15 @@ import Icon from '../../Icon'
 import Typography from '../../Typography'
 import PreviousIcon from '../../Icons/Previous'
 import DownloadIcon from '../../Icons/Download'
+import { useI18n } from '../../providers/I18n'
+import MidEllipsis from '../../MidEllipsis'
 
-import { withViewerLocales } from '../hoc/withViewerLocales'
 import { downloadFile } from '../helpers'
 import { useEncrypted } from '../providers/EncryptedProvider'
 import { ToolbarFilePath } from './ToolbarFilePath'
 import { extractChildrenCompByName } from '../Footer/helpers'
 
 import styles from './styles.styl'
-import MidEllipsis from '../../MidEllipsis'
 
 const useClasses = makeStyles(theme => ({
   iconButton: {
@@ -36,7 +35,6 @@ const Toolbar = ({
   onMouseLeave,
   file,
   onClose,
-  t,
   toolbarRef,
   breakpoints: { isDesktop },
   children,
@@ -44,6 +42,7 @@ const Toolbar = ({
 }) => {
   const client = useClient()
   const classes = useClasses()
+  const { t } = useI18n()
 
   const { url } = useEncrypted()
 
@@ -109,7 +108,4 @@ Toolbar.propTypes = {
   showFilePath: PropTypes.bool
 }
 
-export default flow(
-  withBreakpoints(),
-  withViewerLocales
-)(Toolbar)
+export default withBreakpoints()(Toolbar)

--- a/react/Viewer/components/Toolbar.jsx
+++ b/react/Viewer/components/Toolbar.jsx
@@ -57,9 +57,8 @@ const Toolbar = ({
     >
       {onClose && (
         <IconButton
-          size="medium"
-          onClick={onClose}
           className={cx(classes.iconButton, { 'u-white': isDesktop })}
+          onClick={onClose}
         >
           <Icon icon={PreviousIcon} />
         </IconButton>
@@ -75,7 +74,7 @@ const Toolbar = ({
         {showFilePath ? <ToolbarFilePath file={file} /> : null}
       </div>
 
-      <div className="u-ml-auto u-ph-1">
+      <div className="u-flex">
         {isDesktop && (
           <IconButton
             className="u-white"

--- a/react/Viewer/components/Toolbar.jsx
+++ b/react/Viewer/components/Toolbar.jsx
@@ -16,8 +16,9 @@ import MidEllipsis from '../../MidEllipsis'
 
 import { downloadFile } from '../helpers'
 import { useEncrypted } from '../providers/EncryptedProvider'
-import { ToolbarFilePath } from './ToolbarFilePath'
 import { extractChildrenCompByName } from '../Footer/helpers'
+import { ToolbarFilePath } from './ToolbarFilePath'
+import PrintButton from './PrintButton'
 
 import styles from './styles.styl'
 
@@ -85,6 +86,7 @@ const Toolbar = ({
         {isDesktop && (
           <>
             {ToolbarButtons}
+            <PrintButton file={file} />
             <IconButton
               className="u-white"
               aria-label={t('Viewer.download')}

--- a/react/Viewer/components/ToolbarButtons.jsx
+++ b/react/Viewer/components/ToolbarButtons.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import FooterActionButtons from '../Footer/FooterActionButtons'
+
+const ToolbarButtons = props => {
+  return <FooterActionButtons {...props} />
+}
+
+ToolbarButtons.displayName = 'ToolbarButtons'
+
+export default ToolbarButtons

--- a/react/Viewer/components/ViewerByFile.jsx
+++ b/react/Viewer/components/ViewerByFile.jsx
@@ -52,44 +52,46 @@ export const getViewerComponentName = ({
   }
 }
 
-const ViewerByFile = ({
-  file,
-  onClose,
-  renderFallbackExtraContent,
-  gestures,
-  gesturesRef,
-  onSwipe,
-  breakpoints: { isDesktop },
-  componentsProps
-}) => {
-  const isOnlyOfficeEnabled = componentsProps?.OnlyOfficeViewer?.isEnabled
-  const onlyOfficeOpener = componentsProps?.OnlyOfficeViewer?.opener
+const ViewerByFile = withBreakpoints()(
+  ({
+    file,
+    onClose,
+    renderFallbackExtraContent,
+    gestures,
+    gesturesRef,
+    onSwipe,
+    breakpoints: { isDesktop },
+    componentsProps
+  }) => {
+    const isOnlyOfficeEnabled = componentsProps?.OnlyOfficeViewer?.isEnabled
+    const onlyOfficeOpener = componentsProps?.OnlyOfficeViewer?.opener
 
-  const { url } = useEncrypted()
+    const { url } = useEncrypted()
 
-  const ComponentName = useMemo(
-    () =>
-      getViewerComponentName({
-        file,
-        isDesktop,
-        isOnlyOfficeEnabled
-      }),
-    [file, isDesktop, isOnlyOfficeEnabled]
-  )
+    const ComponentName = useMemo(
+      () =>
+        getViewerComponentName({
+          file,
+          isDesktop,
+          isOnlyOfficeEnabled
+        }),
+      [file, isDesktop, isOnlyOfficeEnabled]
+    )
 
-  return (
-    <ComponentName
-      file={file}
-      url={url}
-      onClose={onClose}
-      renderFallbackExtraContent={renderFallbackExtraContent}
-      gestures={gestures}
-      gesturesRef={gesturesRef}
-      onSwipe={onSwipe}
-      onlyOfficeOpener={onlyOfficeOpener}
-    />
-  )
-}
+    return (
+      <ComponentName
+        file={file}
+        url={url}
+        onClose={onClose}
+        renderFallbackExtraContent={renderFallbackExtraContent}
+        gestures={gestures}
+        gesturesRef={gesturesRef}
+        onSwipe={onSwipe}
+        onlyOfficeOpener={onlyOfficeOpener}
+      />
+    )
+  }
+)
 
 ViewerByFile.propTypes = {
   file: FileDoctype.isRequired,
@@ -102,4 +104,6 @@ ViewerByFile.propTypes = {
   componentsProps: PropTypes.object
 }
 
-export default withBreakpoints()(ViewerByFile)
+ViewerByFile.displayName = 'ViewerByFile'
+
+export default ViewerByFile

--- a/react/Viewer/components/ViewerControls.jsx
+++ b/react/Viewer/components/ViewerControls.jsx
@@ -92,10 +92,18 @@ class ViewerControls extends Component {
 
   renderChildren(children) {
     if (!children) return null
-    return React.cloneElement(children, {
-      gestures: this.state.gestures,
-      gesturesRef: this.wrapped,
-      onSwipe: this.onSwipe
+
+    return React.Children.map(children, child => {
+      if (
+        child.type.name === 'ViewerByFile' ||
+        child.type.displayName === 'ViewerByFile'
+      ) {
+        return React.cloneElement(child, {
+          gestures: this.state.gestures,
+          gesturesRef: this.wrapped,
+          onSwipe: this.onSwipe
+        })
+      }
     })
   }
 
@@ -137,11 +145,13 @@ class ViewerControls extends Component {
           <Toolbar
             toolbarRef={toolbarRef}
             file={file}
-            onClose={showClose && onClose}
+            showFilePath={showFilePath}
             onMouseEnter={this.showControls}
             onMouseLeave={this.hideControls}
-            showFilePath={showFilePath}
-          />
+            onClose={showClose && onClose}
+          >
+            {children}
+          </Toolbar>
         )}
         {showNavigation && isDesktop && hasPrevious && (
           <Navigation

--- a/react/Viewer/components/styles.styl
+++ b/react/Viewer/components/styles.styl
@@ -65,8 +65,8 @@
     z-index var(--zIndex-modal-toolbar)
     display flex
     flex-shrink 0
-    width calc(100% - 2rem)
-    padding 0 1rem
+    width calc(100% - 1rem)
+    padding 0 0.5rem
     height $toolbarHeight
     transition .4s opacity ease-out
     background linear-gradient(to bottom, var(--charcoalGrey), rgba(50, 54, 63, 0))

--- a/react/Viewer/docs/DemoProvider.jsx
+++ b/react/Viewer/docs/DemoProvider.jsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { CozyProvider } from 'cozy-client'
 import { BreakpointsProvider } from '../../providers/Breakpoints'
 
-import { I18nContext } from '../../providers/I18n'
+import I18n from '../../providers/I18n'
+import { locales } from '../locales/index'
 
 const demoTextFileResponse = {
   text: () => new Promise(resolve => resolve('Hello World !'))
@@ -72,12 +73,14 @@ const mockClient = {
 
 class Wrapper extends React.Component {
   render() {
+    const lang = localStorage.getItem('lang') || 'en'
+
     return (
       <CozyProvider client={mockClient}>
         <BreakpointsProvider>
-          <I18nContext.Provider value={{ t: x => x, lang: 'en' }}>
+          <I18n dictRequire={lang => locales[lang]} lang={lang}>
             {this.props.children}
-          </I18nContext.Provider>
+          </I18n>
         </BreakpointsProvider>
       </CozyProvider>
     )

--- a/react/Viewer/hoc/withViewerLocales.jsx
+++ b/react/Viewer/hoc/withViewerLocales.jsx
@@ -1,11 +1,5 @@
 import withLocales from '../../providers/I18n/withLocales'
 
-import en from '../locales/en.json'
-import fr from '../locales/fr.json'
-
-export const locales = {
-  en,
-  fr
-}
+import { locales } from '../locales'
 
 export const withViewerLocales = withLocales(locales)

--- a/react/Viewer/index.jsx
+++ b/react/Viewer/index.jsx
@@ -6,5 +6,11 @@ export * as toolbarPropsPropType from './proptypes'
 export {
   default as ViewerWithCustomPanelAndFooter
 } from './ViewerWithCustomPanelAndFooter'
+export { default as ToolbarButtons } from './components/ToolbarButtons'
+export { default as FooterActionButtons } from './Footer/FooterActionButtons'
+export { default as ForwardButton } from './Footer/ForwardButton'
+export {
+  default as ForwardOrDownloadButton
+} from './Footer/ForwardOrDownloadButton'
 
 export default ViewerContainer

--- a/react/Viewer/locales/index.js
+++ b/react/Viewer/locales/index.js
@@ -1,0 +1,4 @@
+import en from './en.json'
+import fr from './fr.json'
+
+export const locales = { en, fr }

--- a/react/providers/I18n/index.jsx
+++ b/react/providers/I18n/index.jsx
@@ -46,6 +46,7 @@ export class I18n extends Component {
     return {
       t: this.t,
       f: this.format,
+      polyglot: (props || this.props).polyglot || this.translator,
       lang: (props || this.props).lang
     }
   }
@@ -84,6 +85,7 @@ I18n.defaultProps = {
 I18n.childContextTypes = {
   t: PropTypes.func,
   f: PropTypes.func,
+  polyglot: PropTypes.object,
   lang: PropTypes.string
 }
 

--- a/react/providers/I18n/index.jsx
+++ b/react/providers/I18n/index.jsx
@@ -89,7 +89,7 @@ I18n.childContextTypes = {
   lang: PropTypes.string
 }
 
-export { initTranslation, extend } from './translation'
+export { initTranslation, extend, useExtendI18n } from './translation'
 export { default as translate } from './translate'
 export { default as createUseI18n } from './createUseI18n'
 

--- a/react/providers/I18n/translation.jsx
+++ b/react/providers/I18n/translation.jsx
@@ -1,5 +1,6 @@
 import Polyglot from 'node-polyglot'
-import { DEFAULT_LANG } from '.'
+
+import { DEFAULT_LANG, useI18n } from '.'
 
 export let _polyglot
 
@@ -38,4 +39,35 @@ export const initTranslation = (
   return _polyglot
 }
 
-export const extend = dict => _polyglot && _polyglot.extend(dict)
+export const extend = (dict, polyglot) => (polyglot || _polyglot)?.extend(dict)
+
+// Use to determine if we need to merge locales again, and to avoid useless calls
+let useExtendI18nLang = ''
+
+/**
+ * Hook to merge app locales with cozy-ui locales
+ * @param {object} locales - Locales sorted by lang `{ fr: {...}, en: {...} }`
+ * @returns {void}
+ */
+export const useExtendI18n = locales => {
+  const { lang, polyglot } = useI18n()
+
+  if (!locales || !lang || !polyglot) return
+
+  // To simplify code we use Polyglot.extend to merge
+  // locales from object and from polyglot.phrases
+  // rather than native JS or lodash. this is why we have two extend.
+  if (useExtendI18nLang !== lang) {
+    const _polyglot = new Polyglot({
+      phrases: locales[lang],
+      locale: lang
+    })
+
+    // merge locales from app and cozy-ui, without replacing existing one in app
+    extend(polyglot.phrases, _polyglot)
+    // use merged locales in app
+    extend(_polyglot.phrases, polyglot)
+    // set the sitch to avoid useless merge
+    useExtendI18nLang = lang
+  }
+}


### PR DESCRIPTION
Le besoin initial est d'ajouter un bouton d'impression dans la toolbar du Viewer (en desktop), de modifier le bouton "télécharger" et de pouvoir ajouter depuis l'app des boutons dans la toolbar. On change également le style des boutons dans le footer (le pendant mobile de la toolbar desktop).

Au passage on modifie l'approche concernant les locales. Initialement on importait via un HOC la prop `t` avec un polyglot qui ne contenait que les locales de cozy-ui dans certains composants afin d'avoir la trad de cozy-ui. Sauf que ça ne fonctionne pas si ce composant est appelé également dans l'app en direct. On modifie donc l'approche ici en utilisant un hook plus haut niveau, appelé dans ViewerContainer qui est le composant le plus haut niveau appelable dans l'app pour instancier le Viewer. Ce hook permet de fusionner les locales de l'app avec celle de cozy-ui (concernant le Viewer) sans pour autant remplacer celles de l'app s'il y a doublons entre l'app et cozy-ui. De fait il suffit ensuite simplement de récupérer `t` via `useI18n` comme on le fait habituellement. Le revers de cette approche en revanche est qu'il n'est plus possible d'avoir les trads sur un composant de manière "standalone" sans instanciation préalable de `I18n` mais c'est un choix volontaire : une app a forcément `I18n` d'instancié, et le Viewer est forcément dans une app.

demo : https://jf-cozy.github.io/cozy-ui/react/#/Viewer