### PR TITLE
chore: Describe default type attribute in Buttons documentation

### DIFF
--- a/react/Buttons/Readme.md
+++ b/react/Buttons/Readme.md
@@ -1,3 +1,11 @@
+Buttons are a wrapper arround [MuiButton](https://mui.com/material-ui/react-button/) integrated with Cozy's design system
+
+The `Button` component will produce an HTML `<button>`. The React component accepts classic HTML attributes (i.e. `type`) through React props.
+
+By default the HTML `<button>` is rendered with `type="button"` attribute, so its click effect must be controlled by React (i.e. by using `onClick` event).
+
+If the button is located inside of a form, you can set the props `type="submit"` to the React component, so clicking on it would trigger the form's `onSubmit` event.
+
 ### Default
 
 ```jsx

--- a/react/Buttons/Readme.md
+++ b/react/Buttons/Readme.md
@@ -1,5 +1,3 @@
-The `ref` is forwarded to the root element
-
 ### Default
 
 ```jsx


### PR DESCRIPTION
MUI documentation does not describe default button's `type`, nor explain that is it possible to set classic HTML attributes, so it is easy to forget applying the correct button type when inside of a form

This is what happened on a previous PR when migrating from old `react/deprecated/Button` to new `react/Buttons` as those components have opposite default behaviors

Related PR: cozy/cozy-settings#674