### PR TITLE
fix(Viewer): Events must be limited on the image

### DIFF
--- a/react/Viewer/ViewersByFile/PdfMobileViewer.jsx
+++ b/react/Viewer/ViewersByFile/PdfMobileViewer.jsx
@@ -51,7 +51,10 @@ export const PdfMobileViewer = ({ file, url, t, gestures }) => {
     if (gestures) {
       gestures.get('pinch').set({ enable: true })
       gestures.on('pinchend tap', evt => {
-        if (evt.type === 'pinchend' || evt.tapCount === 1) {
+        if (
+          (evt.type === 'pinchend' || evt.tapCount === 1) &&
+          evt.target === imgRef.current
+        ) {
           handleOnClick(file)
         }
       })


### PR DESCRIPTION
On mobile, the events must not be on the entire page, otherwise the back arrow also triggers the download for example.