### PR TITLE
Viewer: Use ActionsItems in PrintButton

### DIFF
--- a/react/ActionsMenu/Actions/helpers.js
+++ b/react/ActionsMenu/Actions/helpers.js
@@ -5,18 +5,18 @@ import { fetchBlobFileById } from 'cozy-client/dist/models/file'
 const MAX_RESIZE_IMAGE_SIZE = 3840
 
 /**
- * Make array of actions for ActionsItems component
+ * Make array of actions and hydrate actions with options
  *
- * @param {Function[]} actions - Array of actions to create ActionsMenuItem components with associated actions and conditions
+ * @param {Function[]} actions - Array of actions with associated actions and conditions
  * @param {object} actionOptions - Options that need to be passed on actions
  * @returns {object[]} Array of actions
  */
 export const makeActions = (actions = [], options = {}) => {
-  return actions.filter(Boolean).map(action => {
-    const actionMenu = action(options)
-    const name = actionMenu.name || action.name
+  return actions.filter(Boolean).map(actionFn => {
+    const action = actionFn(options)
+    const name = action.name || actionFn.name
 
-    return { [name]: actionMenu }
+    return { [name]: action }
   })
 }
 
@@ -58,7 +58,7 @@ export const getOnlyNeededActions = (actions, docs) => {
         return actionObject
       })
       .filter(Boolean)
-      // We don't want to have an hr as the latest actions available
+      // We don't want to have an hr/divider as the latest actions available
       .filter((cleanedAction, idx, cleanedActions) => {
         return !(
           (getActionName(cleanedAction) === 'hr' ||

--- a/react/ActionsMenu/ActionsItems.jsx
+++ b/react/ActionsMenu/ActionsItems.jsx
@@ -74,4 +74,12 @@ ActionsItems.propTypes = {
   onClick: PropTypes.func
 }
 
+export const actionsItemsComponentPropTypes = {
+  docs: PropTypes.array,
+  action: PropTypes.object,
+  autoFocus: PropTypes.bool,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func
+}
+
 export default ActionsItems

--- a/react/ActionsMenu/Readme.md
+++ b/react/ActionsMenu/Readme.md
@@ -4,23 +4,7 @@ You can pass a reference to a custom DOM element through the `ref` prop to attac
 
 A header `ActionsMenuMobileHeader` can be used to provide context on the menu actions. Since on desktop, we display a popper and not a `BottomSheet`, context for the user is not lost, so the header would be redundant. This is why it is not rendered unless we are on mobile.
 
-### With an automatic creation of actions
-
-Use `makeActions` method and create (or use the predefined actions) to build the actions to pass to `ActionsMenu` high level component. The method `makeActions` takes `actions` array as first argument, and `options` as second argument. `options` are then passed to the `actions` component as `props`.
-
-```bash
-const action1 = ({ option1, option2 }) => ({
-  name: action1,
-  action: (doc, { option3, option4 }) => {}
-  Component: ({ onClick, ...props }) => <SomeComponent {...props} onClick={() => onClick({ option3 })}} />
-})
-
-const actions = makeActions([action1, action2], { option1, option2 })
-
-<ActionsMenu actions={actions} componentsProps={{ actionsItems: { actionOptions: { option4 }} }}
-```
-
-#### How to create actions
+### How to create and use actions
 
 An action is a simple function that returns an object with specific keys:
 
@@ -33,7 +17,7 @@ An action is a simple function that returns an object with specific keys:
 * **Component** : `<func>` – The returned component that manages the display
 
 ```bash
-const expl = makeActionOptions => ({
+const actionExpl = options => ({
   name: 'expl',
   action: () => {},
   disabled: false,
@@ -41,6 +25,32 @@ const expl = makeActionOptions => ({
     return <SomeComponent {...props} />
   }
 })
+```
+
+The method `makeActions` takes `actions` array as first argument, and `options` as second argument. `options` are then passed to the `actions` component as `props`.
+
+```bash
+const action1 = ({ option1, option2, option5 }) => ({
+  name: action1,
+  action: (doc, { option3, option4 }) => {}
+  Component: ({ onClick, ...props }) => <SomeComponent {...props} onClick={() => onClick({ option3 })}} />
+})
+
+const actions = makeActions([action1, action2], { option1, option2 })
+```
+
+Then you can use `ActionsItems` to render the actions, and pass options (as simple props) and component (in `component` prop) to be used for rendering.
+
+```bash
+<ActionsItems actions={actions} docs={[file]} component={ActionComponent} option5="" />
+```
+
+### ActionsMenu with an automatic creation of actions
+
+Use `makeActions` method and create (or use the predefined actions) to build the actions to pass to `ActionsMenu`. You can pass options to actions with `componentsProps.actionsItems.actionOptions` prop.
+
+```bash
+<ActionsMenu actions={actions} componentsProps={{ actionsItems: { actionOptions: { option4 }} }} />
 ```
 
 ```jsx
@@ -125,7 +135,9 @@ const actions = makeActions([ modify, viewInContacts, divider, call, smsTo, emai
 </DemoProvider>
 ```
 
-### With a manual creation of the actions
+### ActionsMenu with a manual creation of the actions
+
+We don't use `makeActions` here, all actions are created "by hand". This is not the recommanded choice.
 
 ```jsx
 import DemoProvider from 'cozy-ui/docs/components/DemoProvider'

--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -68,6 +68,7 @@ const files = [
   {
     _id: 'audio',
     class: 'audio',
+    type: 'file',
     name: 'Sample.mp3',
     mime: 'audio/mp3',
     dir_id: 'parent_folder'
@@ -75,6 +76,7 @@ const files = [
   {
     _id: 'slide',
     class: 'slide',
+    type: 'file',
     name: 'Slide.pptx',
     mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     dir_id: 'parent_folder'
@@ -82,6 +84,7 @@ const files = [
   {
     _id: 'pdf',
     class: 'pdf',
+    type: 'file',
     name: 'My vehicle registration.pdf',
     mime: 'application/pdf',
     metadata: {
@@ -107,6 +110,7 @@ const files = [
   {
     _id: 'text',
     class: 'text',
+    type: 'file',
     name: 'LoremipsumdolorsitametconsecteturadipiscingelitSednonrisusSuspendisselectustortordignissimsitametadipiscingnecultriciesseddolorCraselementumultricesdiamMaecenasligulamassavariusasempercongueeuismodnonmiProinporttitororcinecnonummymolestieenimesteleifendminonfermentumdiamnislsitameteratDuissemperDuisarcumassascelerisquevitaeconsequatinpretiumaenimPellentesquecongueUtinrisusvolutpatliberopharetratemporCrasvestibulumbibendumauguePraesentegestasleoinpedePraesentblanditodioeuenimPellentesquesedduiutaugueblanditsodalesVestibulumanteipsumprimisinfaucibusorciluctusetultricesposuerecubiliaCuraeAliquamnibhMaurisacmaurissedpedepellentesquefermentumMaecenasadipiscingantenondiamsodaleshendrerit.txt',
     mime: 'text/plain',
     metadata: {
@@ -120,6 +124,7 @@ const files = [
     {
     _id: 'text',
     class: 'text',
+    type: 'file',
     name: 'encrypted-example.txt',
     mime: 'text/plain',
     encrypted: true
@@ -128,6 +133,7 @@ const files = [
   {
     _id: 'image',
     class: 'image',
+    type: 'file',
     name: 'Demo.jpg',
     mime: 'image/jpg',
     metadata: {
@@ -143,12 +149,14 @@ const files = [
   {
     _id: 'none',
     class: 'unknown',
+    type: 'file',
     name: 'Unsupported file type',
     mime: '???/???'
   },
   {
     _id: 'none',
     class: 'unknown',
+    type: 'file',
     name: 'Unsupported file type',
     mime: '???/???',
     metadata: {


### PR DESCRIPTION
Le but de cette PR est de montrer qu'il est possible d'utiliser des actions indépendamment du rendu déjà intégrée à l'action dans l'attribut "Component".

Grâce à `makeActions` pour la création puis `ActionsItems` pour le rendu, on peut alors utiliser une action définit comme telle (ici l'action Print) et override le rendu attendu dans l'attribut Component.

L'idée serait d'avoir une approche harmonisée pour ce sujet, donc toujours passer par `makeActions` puis soit un composant clé en main comme ActionsMenu, soit ActionsItems.