### PR TITLE
fix(Viewer): Remove WebviewIntentProvider

### DIFF
--- a/react/Viewer/Readme.md
+++ b/react/Viewer/Readme.md
@@ -4,12 +4,11 @@ Once rendered, the `Viewer` will take up all the available space in it's contain
 
 The `Viewer` can display an **information panel** to show additional information about the current file (e.g. whether a file is certified).
 
-### ⚠️ Important
+### ⚠️ Requirement
 
+* You must have [WebviewIntent Provider](https://github.com/cozy/cozy-libs/blob/b1ad6f5933b463878f641d9fbb63eddd4c45b0d0/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx#L89) & [CozySharing Provider](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-sharing)
 * In order to download and display the files, it will need a `cozy-client` instance in the React context.
 * To have the panels, the app need to have [cozy-harvest-lib](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-harvest-lib) installed
-* To have a working footer, the app need to have a [CozySharing Provider](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-sharing).
-* If the footer will be used on MobileApp, the app should have this Cordova plugin [4db7f8f#diff-8c7901258747b81ed60cc2d9cbb254344fae11f8a602e56c1ae42d9eef11d318R50](https://github.com/cozy/cozy-ui/commit/4db7f8fba866bffe04d81d42c716a8dea5c50157#diff-8c7901258747b81ed60cc2d9cbb254344fae11f8a602e56c1ae42d9eef11d318R50)
 
 ### Props
 

--- a/react/Viewer/ViewerContainer.jsx
+++ b/react/Viewer/ViewerContainer.jsx
@@ -2,8 +2,6 @@ import React, { createRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import { WebviewIntentProvider } from 'cozy-intent'
-
 import useBreakpoints from '../providers/Breakpoints'
 import { FileDoctype } from '../proptypes'
 import { useExtendI18n } from '../providers/I18n'
@@ -52,39 +50,37 @@ const ViewerContainer = props => {
   }
 
   return (
-    <WebviewIntentProvider>
-      <AlertProvider>
-        <ActionMenuProvider editPathByModelProps={editPathByModelProps}>
-          <div
-            id="viewer-wrapper"
-            className={cx(styles['viewer-wrapper'], className)}
-          >
-            <EncryptedProvider url={currentURL}>
-              <Viewer
-                {...rest}
-                componentsProps={componentsPropsWithDefault}
-                currentFile={currentFile}
-                hasPrevious={hasPrevious}
-                hasNext={hasNext}
-                validForPanel={validForPanel}
-                toolbarRef={toolbarRef}
-              >
-                {children}
-              </Viewer>
-            </EncryptedProvider>
-            <ViewerInformationsWrapper
-              isPublic={isPublic}
-              disableFooter={disableFooter}
-              validForPanel={validForPanel}
+    <AlertProvider>
+      <ActionMenuProvider editPathByModelProps={editPathByModelProps}>
+        <div
+          id="viewer-wrapper"
+          className={cx(styles['viewer-wrapper'], className)}
+        >
+          <EncryptedProvider url={currentURL}>
+            <Viewer
+              {...rest}
+              componentsProps={componentsPropsWithDefault}
               currentFile={currentFile}
+              hasPrevious={hasPrevious}
+              hasNext={hasNext}
+              validForPanel={validForPanel}
               toolbarRef={toolbarRef}
             >
               {children}
-            </ViewerInformationsWrapper>
-          </div>
-        </ActionMenuProvider>
-      </AlertProvider>
-    </WebviewIntentProvider>
+            </Viewer>
+          </EncryptedProvider>
+          <ViewerInformationsWrapper
+            isPublic={isPublic}
+            disableFooter={disableFooter}
+            validForPanel={validForPanel}
+            currentFile={currentFile}
+            toolbarRef={toolbarRef}
+          >
+            {children}
+          </ViewerInformationsWrapper>
+        </div>
+      </ActionMenuProvider>
+    </AlertProvider>
   )
 }
 


### PR DESCRIPTION
In commit 97f28ff, WebviewIntentProvider has been added to ViewerContainer, in order to call intent's methods in the container children.

This is not needed because we expect the webapp to implemented on the root level.

Also, this would produce a bug because WebviewIntentProvider is not mean to be declared twice in a same webapp.

When doing so, the child WebviewIntentProvider would overwrite the parent one on the flagship app side. So when opening the Viewer, the parent provider would stop working.