### PR TITLE
fix: Argos screenshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 dist: jammy
 cache:
   npm: false
-branches:
-  only:
-  - master
+if: type NOT IN (pull_request)
 env:
   global:
     - PR_TITLE=$(curl https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST} 2> /dev/null | grep "title" | head -1)


### PR DESCRIPTION
Suite à notre changement https://github.com/cozy/cozy-ui/pull/2552 les branches autres que master ne sont plus buildé, et donc Argos n'est plus capable de s'exécuter sur ces branches. Il ne s'exécute alors que sur master lors du build de la PR.

![image](https://github.com/cozy/cozy-ui/assets/67680939/486e060e-9b53-4be0-bda0-55cd06a92293)

Hors la branche master est la branche de référence pour les screenshots. Et depuis une modification côté Argos il n'est plus possible de valider les screenshot sur la branche de référence.

Après investigation côté Argos lui-même https://app.argos-ci.com/argos-ci/argos il s'avère que les screenshots sont bien comparés entre la branche de la PR et la branche de référence.

![image](https://github.com/cozy/cozy-ui/assets/67680939/5c4c6dcf-043a-42fc-a53b-3d97e699d0b0)

Notre configuration est donc mauvaise.

Cette PR revert donc la modification `branches only master`, ainsi les screenshots sont bien comparés entre la branche de la PR et la branche master.

J'ai également changé la config côté Argos pour supprimer le commentaire argos dans les PR : 

![image](https://github.com/cozy/cozy-ui/assets/67680939/7890c999-92a7-4930-bb00-e05ff2adb65e)

car maintenant on retrouve la comportement précédent, à savoir un fail de la CI en cas de screenshot non revues

![image](https://github.com/cozy/cozy-ui/assets/67680939/4115076e-b451-4fc9-89d1-0259050cebe5)

Enfin, concernant le fait que la CI build la branche ET la PR (ce que le commit https://github.com/cozy/cozy-ui/pull/2552 corrigeait afin de libérer de la bande passante sur la CI), la PR modifie la config travis en ne buildant QUE les branches et non plus les PR (doc https://docs.travis-ci.com/user/conditions-v1 )