### PR TITLE
refactor(Avatar): Move nameToColor in a new helpers file

### DIFF
--- a/react/Avatar/helpers.js
+++ b/react/Avatar/helpers.js
@@ -1,0 +1,27 @@
+import palette from '../palette'
+
+export const nameToColor = (name = '') => {
+  const colors = [
+    palette['azure'],
+    palette['melon'],
+    palette['blazeOrange'],
+    palette['pomegranate'],
+    palette['mango'],
+    palette['pumpkinOrange'],
+    palette['darkPeriwinkle'],
+    palette['purpley'],
+    palette['lightishPurple'],
+    palette['weirdGreen'],
+    palette['puertoRico'],
+    palette['emerald'],
+    palette['seafoamGreen'],
+    palette['lavender'],
+    palette['brightSun'],
+    palette['fuchsia']
+  ]
+  const key =
+    Array.from(name.toUpperCase())
+      .map(letter => letter.charCodeAt(0))
+      .reduce((sum, number) => sum + number, 0) % colors.length
+  return colors[key]
+}

--- a/react/Avatar/index.jsx
+++ b/react/Avatar/index.jsx
@@ -3,37 +3,11 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import assign from 'lodash/assign'
 
-import palette from '../palette'
 import styles from './styles.styl'
 import Icon, { iconPropType } from '../Icon'
 import PeopleIcon from '../Icons/People'
 import { createSizeStyle } from '../Circle'
-
-export const nameToColor = (name = '') => {
-  const colors = [
-    palette['azure'],
-    palette['melon'],
-    palette['blazeOrange'],
-    palette['pomegranate'],
-    palette['mango'],
-    palette['pumpkinOrange'],
-    palette['darkPeriwinkle'],
-    palette['purpley'],
-    palette['lightishPurple'],
-    palette['weirdGreen'],
-    palette['puertoRico'],
-    palette['emerald'],
-    palette['seafoamGreen'],
-    palette['lavender'],
-    palette['brightSun'],
-    palette['fuchsia']
-  ]
-  const key =
-    Array.from(name.toUpperCase())
-      .map(letter => letter.charCodeAt(0))
-      .reduce((sum, number) => sum + number, 0) % colors.length
-  return colors[key]
-}
+import { nameToColor } from './helpers'
 
 const createBgColorStyle = ({ text, textId }) =>
   text ? { backgroundColor: `${nameToColor(textId || text)}` } : {}

--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -15,7 +15,7 @@ import iconOut from '../Icons/LinkOut'
 import iconPlus from '../Icons/Plus'
 import iconWarning from '../Icons/WarningCircle'
 import { alpha, makeStyles } from '../styles'
-import { nameToColor } from '../Avatar'
+import { nameToColor } from '../Avatar/helpers'
 import CozyTheme, { useCozyTheme } from '../providers/CozyTheme'
 
 import styles from './styles.styl'


### PR DESCRIPTION
We need to implement an Avatar like component with Angular for the Cozy Pass extension. We can not reuse the Avatar component from cozy-ui because it is a React component. But we can reuse this nameToColor method to stay as close as we can to cozy-ui.