### PR TITLE
fix: Add vertical scroll to sidebar when needed (VO-628)

### DIFF
--- a/stylus/objects/sidebar.styl
+++ b/stylus/objects/sidebar.styl
@@ -12,6 +12,8 @@ $sidebar
     width rem(220)
     border-right rem(1) solid var(--dividerColor)
     background-color var(--defaultBackgroundColor)
+    overflow-y auto
+    overflow-x hidden
 
     +medium-screen()
         justify-content space-between


### PR DESCRIPTION
This will handle cases in desktop where the
sidebar was hiding its own content because it was too tall
and not letting the user scroll inside it.
This should have no effect on the mobile sidebar
since it has a fixed height