### PR TITLE
feat: Exclude shared drives dir from filepicker (VO-647)

### DIFF
--- a/react/FilePicker/queries.js
+++ b/react/FilePicker/queries.js
@@ -4,6 +4,7 @@ const FILES_DOCTYPE = 'io.cozy.files'
 
 const defaultFetchPolicy = fetchPolicies.olderThan(30 * 1000)
 const TRASH_DIR_ID = `${FILES_DOCTYPE}.trash-dir`
+const SHARED_DRIVES_DIR_ID = `${FILES_DOCTYPE}.shared-drives-dir`
 
 export const buildCurrentFolderQuery = folderId => ({
   definition: () => Q(FILES_DOCTYPE).getById(folderId),
@@ -23,7 +24,7 @@ export const buildContentFolderQuery = dirId => ({
       })
       .partialIndex({
         _id: {
-          $ne: TRASH_DIR_ID
+          $nin: [SHARED_DRIVES_DIR_ID, TRASH_DIR_ID]
         }
       })
       .indexFields(['dir_id', 'type', 'name'])


### PR DESCRIPTION
It is not to be displayed in the filepicker, just like the trash dir