### PR TITLE
fix(MenuItem): Remove maxWidth and add it on Menu instead

### DIFF
--- a/react/Menu/Readme.md
+++ b/react/Menu/Readme.md
@@ -77,6 +77,15 @@ const hideMenu = () => setState({ showMenu: false })
       <ListItemText primary="Attachment" />
     </MenuItem>
     <MenuItem onClick={hideMenu}>
+      <ListItemIcon>
+        <Icon icon={PeopleIcon} />
+      </ListItemIcon>
+      <ListItemText
+        primary="Item with a very long title to show how it should be displayed"
+        primaryTypographyProps={{ ellipsis: false }}
+      />
+    </MenuItem>
+    <MenuItem onClick={hideMenu}>
       <ListItemText primary="Item without icon" />
     </MenuItem>
 

--- a/react/MuiCozyTheme/overrides/makeLightNormalOverrides.js
+++ b/react/MuiCozyTheme/overrides/makeLightNormalOverrides.js
@@ -365,9 +365,13 @@ export const makeLightNormalOverrides = theme => ({
       right: 0
     }
   },
+  MuiMenu: {
+    paper: {
+      maxWidth: 320
+    }
+  },
   MuiMenuItem: {
     root: {
-      maxWidth: 320,
       whiteSpace: 'normal',
       overflow: 'auto',
       paddingTop: 4,


### PR DESCRIPTION
Un MenuItem peut être utilisé dans différents contextes, notamment dans un TextField select qui peut avoir une largeur très grande contrairement à un Menu. C'est donc plus pertinent de déplacer le maxWidth du MenuItem au Menu, pour permettre à un TextField select d'avoir la largeur qu'il veut, mais pour autant avoir un Menu qui ne dépasse pas les 320px.