### PR TITLE
fix(MidEllipsis): It should not trim strings

### DIFF
--- a/react/MidEllipsis/index.jsx
+++ b/react/MidEllipsis/index.jsx
@@ -25,8 +25,8 @@ const MidEllipsis = forwardRef(
     const str = text || children
 
     const partLength = Math.round(str.length / 2)
-    const firstPart = str.substring(0, partLength).trim()
-    const lastPart = str.substring(partLength, str.length).trim()
+    const firstPart = str.substring(0, partLength)
+    const lastPart = str.substring(partLength, str.length)
 
     return (
       <div className={cx('u-midellipsis', className)} ref={ref} {...props}>


### PR DESCRIPTION
On avait initialement rajouté les trim sur les string pour limiter les espaces inutiles entre les 2 blocs du midellipsis (une string midellipsée est en fait 2 strings avec un `...` au milieu). Sauf qu'en fait la séparation visuelle est gérée en css donc les probabilités pour que la séparation soit parfaitement entre les deux blocs (au niveau de la séparation des string) est quasi nulle.
De plus pour une string qui n'a pas besoin d'être midellispée, la séparation en 2 blocs est quand même faite. Or s'il y a un espace entre 2 mots, il faut le conserver. Avoir un trim supprime cet espace et concatène donc les 2 strings. C'est cet effet qu'on corrige ici. 