### PR TITLE
fix(NestedSelect): Search bar on desktop mode

### DIFF
--- a/react/Layout/Layout.md
+++ b/react/Layout/Layout.md
@@ -22,7 +22,6 @@ It can be used to wrap any list of React elements, automatically providing funct
 * **Customizable Limit**: Users can specify how many items should be shown in the limited view.
 * **Ease of Use**: Seamlessly integrates with existing list components from cozy-ui or standard JSX elements.
 
-
 ```jsx
 import { useState } from 'react'
 import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout';

--- a/react/NestedSelect/NestedSelect.jsx
+++ b/react/NestedSelect/NestedSelect.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
+import cx from 'classnames'
 
 import List from '../List'
 import Input from '../Input'
 import Typography from '../Typography'
 import ItemRow from './ItemRow'
 import { makeHistory } from './helpers'
+import styles from './styles.styl'
 
 export { ItemRow }
 
@@ -79,12 +81,13 @@ const NestedSelect = ({
 
   const hasSearchResult = state.searchValue?.length > 0
   const isSelectedWithLevel = item => isSelected(item, level)
+  const currentTitle = current.title || title
 
   return (
     <span ref={innerRef}>
       {HeaderComponent ? (
         <HeaderComponent
-          title={current.title || title}
+          title={currentTitle}
           showBack={state.history.length > 1}
           onClickBack={handleBack}
         />
@@ -108,7 +111,12 @@ const NestedSelect = ({
           />
         ) : null}
         {searchOptions && level === 0 && (
-          <div className="u-mh-1 u-mb-half">
+          <div
+            className={cx('u-ml-1 u-mb-half', {
+              'u-mr-1': currentTitle,
+              [styles['search-container--without-title']]: !currentTitle
+            })}
+          >
             <Input
               placeholder={searchOptions.placeholderSearch}
               onChange={onChange}

--- a/react/NestedSelect/NestedSelect.md
+++ b/react/NestedSelect/NestedSelect.md
@@ -1,6 +1,6 @@
 You can use `react/NestedSelect/NestedSelectResponsive` wich provides automaticaly a modal on desktop and bottomsheet on mobile, or directly `react/NestedSelect/Modal` and `react/NestedSelect/BottomSheet`.
 
-You can open the NestedSelect where a specific item is located, for this your items must have a ***id*** attribute and add the ***focusedId*** attribute to the root of the options.
+You can open the NestedSelect where a specific item is located, for this your items must have a **_id_** attribute and add the **_focusedId_** attribute to the root of the options.
 See below for example
 
 ```jsx

--- a/react/NestedSelect/styles.styl
+++ b/react/NestedSelect/styles.styl
@@ -11,3 +11,7 @@
     margin-bottom -1rem
     position relative
     top -0.5rem
+
+.search-container--without-title
+    margin-right 5rem
+    margin-top 0.5rem


### PR DESCRIPTION
The search bar in Desktop mode does not overlap the closing cross of the modal

In agreement with @joel-costa 

Demo: https://merkur39.github.io/cozy-ui/react/#!/Extra/NestedSelect