### PR TITLE
feat(Viewer): On public view, bottomSheet must be lowered

### DIFF
--- a/react/Viewer/Footer/FooterContent.jsx
+++ b/react/Viewer/Footer/FooterContent.jsx
@@ -53,7 +53,7 @@ const FooterContent = ({ file, toolbarRef, children, isPublic }) => {
       <BottomSheet
         toolbarProps={toolbarProps}
         portalProps={{ disablePortal: true }}
-        settings={{ mediumHeightRatio: 0.5 }}
+        settings={{ mediumHeightRatio: isPublic ? 0 : 0.5 }}
       >
         <BottomSheetHeader
           className={cx('u-ph-1 u-pb-1', styles.bottomSheetHeader)}


### PR DESCRIPTION
Example on public view :

Before:
![image](https://github.com/cozy/cozy-ui/assets/14182143/b2bff6b4-aacc-40b2-95f4-0a464f1b448d)


Now:
![image](https://github.com/cozy/cozy-ui/assets/14182143/599681d1-920f-43de-8c34-b1954fa8e28e)
