### PR TITLE
docs(ListItem): Use date string instead function

### DIFF
--- a/react/ListItem/Readme.md
+++ b/react/ListItem/Readme.md
@@ -153,9 +153,10 @@ const files = [
     metadata: {
       number: 12345,
       refTaxIncome: '153',
-      datetime: new Date(Date.now()).toISOString(),
-      referencedDate: new Date(Date.now()).toISOString(),
-      expirationDate: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+      datetime: '2024-01-11T12:00:00.000Z',
+      datetimeLabel: 'expirationDate',
+      referencedDate: '2024-01-01T12:00:00.000Z',
+      expirationDate: '2024-01-11T12:00:00.000Z',
       noticePeriod: '30',
       qualification: {
         label: 'driver_license'


### PR DESCRIPTION
Calling the date function generates unnecessary changes in Argos.