### PR TITLE
[VO-758] feat(AppsSection): Change only ISP wording

### DIFF
--- a/react/AppSections/__snapshots__/index.spec.jsx.snap
+++ b/react/AppSections/__snapshots__/index.spec.jsx.snap
@@ -217,6 +217,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
             Object {
               "categories": Array [
                 "isp",
+                "telecom",
               ],
               "developer": Object {
                 "name": "Cozy",
@@ -246,6 +247,45 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
         subtitle={
           <SectionSubSubtitle>
             Mobile and Internet
+          </SectionSubSubtitle>
+        }
+      />
+      <AppsSection
+        appsList={
+          Array [
+            Object {
+              "categories": Array [
+                "isp",
+                "telecom",
+              ],
+              "developer": Object {
+                "name": "Cozy",
+              },
+              "icon": "<svg></svg>",
+              "isInRegistry": true,
+              "name": "Bouilligue",
+              "slug": "konnector-bouilligue",
+              "type": "konnector",
+              "uninstallable": true,
+              "versions": Object {
+                "beta": Array [
+                  "0.1.0",
+                ],
+                "dev": Array [
+                  "0.1.0",
+                ],
+                "stable": Array [
+                  "0.1.0",
+                ],
+              },
+            },
+          ]
+        }
+        displaySpecificMaintenanceStyle={false}
+        onAppClick={[MockFunction]}
+        subtitle={
+          <SectionSubSubtitle>
+            Telecom
           </SectionSubSubtitle>
         }
       />
@@ -518,6 +558,7 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
             Object {
               "categories": Array [
                 "isp",
+                "telecom",
               ],
               "developer": Object {
                 "name": "Cozy",
@@ -547,6 +588,45 @@ exports[`AppsSection component should not render dropdown filter on mobile if na
         subtitle={
           <SectionSubSubtitle>
             Mobile and Internet
+          </SectionSubSubtitle>
+        }
+      />
+      <AppsSection
+        appsList={
+          Array [
+            Object {
+              "categories": Array [
+                "isp",
+                "telecom",
+              ],
+              "developer": Object {
+                "name": "Cozy",
+              },
+              "icon": "<svg></svg>",
+              "isInRegistry": true,
+              "name": "Bouilligue",
+              "slug": "konnector-bouilligue",
+              "type": "konnector",
+              "uninstallable": true,
+              "versions": Object {
+                "beta": Array [
+                  "0.1.0",
+                ],
+                "dev": Array [
+                  "0.1.0",
+                ],
+                "stable": Array [
+                  "0.1.0",
+                ],
+              },
+            },
+          ]
+        }
+        displaySpecificMaintenanceStyle={false}
+        onAppClick={[MockFunction]}
+        subtitle={
+          <SectionSubSubtitle>
+            Telecom
           </SectionSubSubtitle>
         }
       />
@@ -822,6 +902,7 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
             Object {
               "categories": Array [
                 "isp",
+                "telecom",
               ],
               "developer": Object {
                 "name": "Cozy",
@@ -851,6 +932,45 @@ exports[`AppsSection component should not render dropdown filter on tablet if na
         subtitle={
           <SectionSubSubtitle>
             Mobile and Internet
+          </SectionSubSubtitle>
+        }
+      />
+      <AppsSection
+        appsList={
+          Array [
+            Object {
+              "categories": Array [
+                "isp",
+                "telecom",
+              ],
+              "developer": Object {
+                "name": "Cozy",
+              },
+              "icon": "<svg></svg>",
+              "isInRegistry": true,
+              "name": "Bouilligue",
+              "slug": "konnector-bouilligue",
+              "type": "konnector",
+              "uninstallable": true,
+              "versions": Object {
+                "beta": Array [
+                  "0.1.0",
+                ],
+                "dev": Array [
+                  "0.1.0",
+                ],
+                "stable": Array [
+                  "0.1.0",
+                ],
+              },
+            },
+          ]
+        }
+        displaySpecificMaintenanceStyle={false}
+        onAppClick={[MockFunction]}
+        subtitle={
+          <SectionSubSubtitle>
+            Telecom
           </SectionSubSubtitle>
         }
       />
@@ -965,6 +1085,12 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
           "secondary": true,
           "type": "konnector",
           "value": "isp",
+        },
+        Object {
+          "label": "Telecom",
+          "secondary": true,
+          "type": "konnector",
+          "value": "telecom",
         },
         Object {
           "label": "Transportation",
@@ -1185,6 +1311,7 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
             Object {
               "categories": Array [
                 "isp",
+                "telecom",
               ],
               "developer": Object {
                 "name": "Cozy",
@@ -1214,6 +1341,45 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
         subtitle={
           <SectionSubSubtitle>
             Mobile and Internet
+          </SectionSubSubtitle>
+        }
+      />
+      <AppsSection
+        appsList={
+          Array [
+            Object {
+              "categories": Array [
+                "isp",
+                "telecom",
+              ],
+              "developer": Object {
+                "name": "Cozy",
+              },
+              "icon": "<svg></svg>",
+              "isInRegistry": true,
+              "name": "Bouilligue",
+              "slug": "konnector-bouilligue",
+              "type": "konnector",
+              "uninstallable": true,
+              "versions": Object {
+                "beta": Array [
+                  "0.1.0",
+                ],
+                "dev": Array [
+                  "0.1.0",
+                ],
+                "stable": Array [
+                  "0.1.0",
+                ],
+              },
+            },
+          ]
+        }
+        displaySpecificMaintenanceStyle={false}
+        onAppClick={[MockFunction]}
+        subtitle={
+          <SectionSubSubtitle>
+            Telecom
           </SectionSubSubtitle>
         }
       />
@@ -1320,6 +1486,12 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
           "secondary": true,
           "type": "konnector",
           "value": "isp",
+        },
+        Object {
+          "label": "Telecom",
+          "secondary": true,
+          "type": "konnector",
+          "value": "telecom",
         },
         Object {
           "label": "Transportation",
@@ -1543,6 +1715,7 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
             Object {
               "categories": Array [
                 "isp",
+                "telecom",
               ],
               "developer": Object {
                 "name": "Cozy",
@@ -1572,6 +1745,45 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
         subtitle={
           <SectionSubSubtitle>
             Mobile and Internet
+          </SectionSubSubtitle>
+        }
+      />
+      <AppsSection
+        appsList={
+          Array [
+            Object {
+              "categories": Array [
+                "isp",
+                "telecom",
+              ],
+              "developer": Object {
+                "name": "Cozy",
+              },
+              "icon": "<svg></svg>",
+              "isInRegistry": true,
+              "name": "Bouilligue",
+              "slug": "konnector-bouilligue",
+              "type": "konnector",
+              "uninstallable": true,
+              "versions": Object {
+                "beta": Array [
+                  "0.1.0",
+                ],
+                "dev": Array [
+                  "0.1.0",
+                ],
+                "stable": Array [
+                  "0.1.0",
+                ],
+              },
+            },
+          ]
+        }
+        displaySpecificMaintenanceStyle={false}
+        onAppClick={[MockFunction]}
+        subtitle={
+          <SectionSubSubtitle>
+            Telecom
           </SectionSubSubtitle>
         }
       />

--- a/react/AppSections/__snapshots__/search.spec.js.snap
+++ b/react/AppSections/__snapshots__/search.spec.js.snap
@@ -623,6 +623,7 @@ Array [
   Object {
     "categories": Array [
       "isp",
+      "telecom",
     ],
     "developer": Object {
       "name": "Cozy",
@@ -848,6 +849,7 @@ Array [
   Object {
     "categories": Array [
       "isp",
+      "telecom",
     ],
     "developer": Object {
       "name": "Cozy",

--- a/react/AppSections/_mockApps.js
+++ b/react/AppSections/_mockApps.js
@@ -76,7 +76,7 @@ export const apps = [
     icon: '<svg></svg>',
     developer: { name: 'Cozy' },
     type: 'konnector',
-    categories: ['isp'],
+    categories: ['isp', 'telecom'],
     versions: {
       stable: ['0.1.0'],
       beta: ['0.1.0'],

--- a/react/AppSections/categories.spec.js
+++ b/react/AppSections/categories.spec.js
@@ -23,6 +23,7 @@ describe('groupApps', () => {
       isp: ['konnector-bouilligue'],
       others: ['devonly'],
       partners: ['tasky'],
+      telecom: ['konnector-bouilligue'],
       transport: ['konnector-trinlane']
     })
   })
@@ -44,6 +45,7 @@ describe('sorter', () => {
       'cozy',
       'isp',
       'all',
+      'telecom',
       'others',
       'banking'
     ])
@@ -52,16 +54,24 @@ describe('sorter', () => {
       'cozy',
       'banking',
       'isp',
+      'telecom',
       'others'
     ])
   })
 
   it('should test with all and others at the border', () => {
-    const catList2 = prepareCategories(['all', 'banking', 'cozy', 'others'])
+    const catList2 = prepareCategories([
+      'all',
+      'telecom',
+      'banking',
+      'cozy',
+      'others'
+    ])
     expect(catList2.sort(catUtils.sorter).map(x => x.value)).toEqual([
       'all',
       'cozy',
       'banking',
+      'telecom',
       'others'
     ])
   })
@@ -104,6 +114,12 @@ describe('generateOptionsFromApps', () => {
         secondary: true,
         type: 'konnector',
         value: 'isp'
+      },
+      {
+        label: 'Telecom',
+        secondary: true,
+        type: 'konnector',
+        value: 'telecom'
       },
       {
         label: 'Transportation',
@@ -150,6 +166,12 @@ describe('generateOptionsFromApps', () => {
         secondary: true,
         type: 'konnector',
         value: 'isp'
+      },
+      {
+        label: 'Telecom',
+        secondary: true,
+        type: 'konnector',
+        value: 'telecom'
       },
       {
         label: 'Transportation',

--- a/react/AppSections/locales/en.json
+++ b/react/AppSections/locales/en.json
@@ -21,6 +21,7 @@
     "public_service": "Public services",
     "shopping": "Shopping",
     "social": "Social",
+    "telecom": "Telecom",
     "transport": "Transportation",
     "pro": "Work"
   },

--- a/react/AppSections/locales/fr.json
+++ b/react/AppSections/locales/fr.json
@@ -21,6 +21,7 @@
     "public_service": "Services publics",
     "shopping": "Shopping",
     "social": "Social",
+    "telecom": "Mobile",
     "transport": "Voyage et transport",
     "pro": "Travail"
   },

--- a/react/mocks/apps.js
+++ b/react/mocks/apps.js
@@ -75,7 +75,7 @@ export const apps = [
     icon: '<svg></svg>',
     developer: { name: 'Cozy' },
     type: 'konnector',
-    categories: ['isp'],
+    categories: ['isp', 'telecom'],
     versions: {
       stable: ['0.1.0'],
       beta: ['0.1.0'],


### PR DESCRIPTION
The telecom category is still used because konnector installed needs to run to updated there manifest.

This reverts a part of commit d5d45988929961fd076039cdf4bc60b12817bac5.