### PR TITLE
feat: Improve contacts list performances

### DIFF
--- a/react/ContactsListModal/queries.js
+++ b/react/ContactsListModal/queries.js
@@ -4,7 +4,7 @@ import { CONTACTS_DOCTYPE } from 'cozy-client/dist/models/contact'
 const defaultFetchPolicy = fetchPolicies.olderThan(30 * 1000)
 
 export const buildContactsQuery = () => ({
-  definition: () => Q(CONTACTS_DOCTYPE),
+  definition: () => Q(CONTACTS_DOCTYPE).limitBy(1000),
   options: {
     as: `${CONTACTS_DOCTYPE}`,
     fetchPolicy: defaultFetchPolicy


### PR DESCRIPTION
When dealing with thousands of contacts, the default 100 pagination will make dozens of requests, thus making it quite slow.