### PR TITLE
feat(CozyTheme): Use `io.cozy.settings` to determine default type

### DIFF
--- a/react/providers/CozyTheme/CozyThemeWithQuery.jsx
+++ b/react/providers/CozyTheme/CozyThemeWithQuery.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
+
+import { buildSettingsInstanceQuery } from './queries'
+import { DumbCozyTheme } from './index'
+
+const CozyThemeWithQuery = props => {
+  const instanceQuery = buildSettingsInstanceQuery()
+  const { data: instance, ...instanceQueryLeft } = useQuery(
+    instanceQuery.definition,
+    instanceQuery.options
+  )
+
+  if (
+    isQueryLoading(instanceQueryLeft) &&
+    !hasQueryBeenLoaded(instanceQueryLeft)
+  ) {
+    return null
+  }
+
+  return <DumbCozyTheme {...props} settingsThemeType={instance?.colorScheme} />
+}
+
+export default CozyThemeWithQuery

--- a/react/providers/CozyTheme/Readme.md
+++ b/react/providers/CozyTheme/Readme.md
@@ -24,6 +24,7 @@ const themesSupportingContext = [
 ]
 
 ;
+
 <DemoProvider>
   <CozyTheme variant='inverted' className='u-stack-m'>
     <Paper className='u-p-1'>

--- a/react/providers/CozyTheme/index.jsx
+++ b/react/providers/CozyTheme/index.jsx
@@ -1,12 +1,14 @@
 import React, { createContext, useContext, useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import flag from 'cozy-flags'
 
+import flag from 'cozy-flags'
 import log from 'cozy-logger'
 
+import { isRsg } from '../../hooks/useSetFlagshipUi/helpers'
 import useMediaQuery from '../../hooks/useMediaQuery'
 import MuiCozyTheme from '../../MuiCozyTheme'
+import CozyThemeWithQuery from './CozyThemeWithQuery'
 
 export const CozyThemeContext = createContext()
 
@@ -25,7 +27,13 @@ export const useCozyTheme = () => {
   return context
 }
 
-const CozyTheme = ({ variant, className, ignoreItself, children }) => {
+const DumbCozyTheme = ({
+  variant,
+  className,
+  ignoreItself,
+  settingsThemeType,
+  children
+}) => {
   const uiThemeType = localStorage.getItem('ui-theme-type') // use only for cozy-ui documentation and argos screenshots
   const uiThemeVariant = localStorage.getItem('ui-theme-variant') // use only for cozy-ui documentation and argos screenshots
 
@@ -36,17 +44,26 @@ const CozyTheme = ({ variant, className, ignoreItself, children }) => {
       : 'light'
     : 'light'
 
-  const selfThemeType = uiThemeType || deviceThemeType
+  const selfThemeType =
+    uiThemeType ||
+    (['light', 'dark'].includes(settingsThemeType)
+      ? settingsThemeType
+      : deviceThemeType)
   const selfThemeVariant = uiThemeVariant || variant
 
-  // add css var to body to be able to use them on it
-  useLayoutEffect(
-    () =>
-      document
-        .querySelector('body')
-        .classList.add(`CozyTheme--${selfThemeType}-normal`), // add omits if already present
-    [selfThemeType]
-  )
+  useLayoutEffect(() => {
+    const negativeThemeType = selfThemeType === 'light' ? 'dark' : 'light'
+
+    // remove "negative" value because can be changed without refresh
+    document
+      .querySelector('body')
+      .classList.remove(`CozyTheme--${negativeThemeType}-normal`)
+
+    // add css var to body to be able to use them on it
+    document
+      .querySelector('body')
+      .classList.add(`CozyTheme--${selfThemeType}-normal`) // `add` omits if already present
+  }, [selfThemeType])
 
   return (
     <CozyThemeContext.Provider
@@ -67,18 +84,34 @@ const CozyTheme = ({ variant, className, ignoreItself, children }) => {
     </CozyThemeContext.Provider>
   )
 }
+DumbCozyTheme.propTypes = CozyThemeProptypes
+DumbCozyTheme.defaultProps = CozyThemeDefaultProps
 
-CozyTheme.propTypes = {
+const CozyTheme = props => {
+  const Comp =
+    process.env.NODE_ENV === 'test' || isRsg
+      ? DumbCozyTheme
+      : CozyThemeWithQuery
+
+  return <Comp {...props} />
+}
+
+const CozyThemeProptypes = {
   variant: PropTypes.oneOf(['normal', 'inverted']),
   /** Causes this element's children to appear as if they were direct children of the element's parent, ignoring the element itself. */
   ignoreItself: PropTypes.bool,
   className: PropTypes.string,
+  settingsThemeType: PropTypes.string,
   children: PropTypes.node
 }
 
-CozyTheme.defaultProps = {
+const CozyThemeDefaultProps = {
   variant: 'normal',
   ignoreItself: true
 }
+CozyTheme.propTypes = CozyThemeProptypes
+CozyTheme.defaultProps = CozyThemeDefaultProps
 
+// export this way to help doc generates correct component and props
 export default CozyTheme
+export { DumbCozyTheme }

--- a/react/providers/CozyTheme/queries.js
+++ b/react/providers/CozyTheme/queries.js
@@ -1,0 +1,14 @@
+import { Q, fetchPolicies } from 'cozy-client'
+
+const SETTINGS_DOCTYPE = 'io.cozy.settings'
+
+const defaultFetchPolicy = fetchPolicies.olderThan(5 * 60 * 1000)
+
+export const buildSettingsInstanceQuery = () => ({
+  definition: Q(SETTINGS_DOCTYPE).getById('io.cozy.settings.instance'),
+  options: {
+    as: `${SETTINGS_DOCTYPE}/io.cozy.settings.instance`,
+    fetchPolicy: defaultFetchPolicy,
+    singleDocData: true
+  }
+})


### PR DESCRIPTION
BREAKING CHANGE: To use `<CozyTheme>` properly, you must have permission in your app to get `io.cozy.settings` documents. The experience would be even better with realtime on this doctypes.