### PR TITLE
Dark mode for flagship app

### DIFF
--- a/react/BottomSheet/BottomSheet.jsx
+++ b/react/BottomSheet/BottomSheet.jsx
@@ -301,9 +301,14 @@ const BottomSheet = memo(
       forceRender // to recompute data when content has changed
     ])
 
+    const { isLight } = useCozyTheme()
+
     useSetFlagshipUI(
-      { bottomTheme: 'dark' },
-      { bottomTheme: getFlagshipMetadata().immersive ? 'light' : 'dark' },
+      { bottomTheme: isLight ? 'dark' : 'light' },
+      {
+        bottomTheme:
+          getFlagshipMetadata().immersive || !isLight ? 'light' : 'dark'
+      },
       'cozy-ui/BottomSheet'
     )
 

--- a/react/Dialog/DialogEffects.spec.tsx
+++ b/react/Dialog/DialogEffects.spec.tsx
@@ -161,7 +161,8 @@ it('should provide a strong reset when unmounting a Dialog in presence of a Side
   expect(
     makeOnUnmount({
       sidebar,
-      theme
+      theme,
+      isLight: true
     })
   ).toEqual({
     bottomBackground: theme.palette.background[DOMStrings.BackgroundDefault],
@@ -176,7 +177,8 @@ it('should provide a strong reset when unmounting a Dialog in presence of a Side
 it('should provide the default black on white UI when unmounting in simple contexts', () => {
   expect(
     makeOnUnmount({
-      theme
+      theme,
+      isLight: true
     })
   ).toEqual({
     bottomBackground: theme.palette.background[DOMStrings.BackgroundPaper],
@@ -207,7 +209,8 @@ it('should provide the default black on white UI with the Cozybar background on 
   expect(
     makeOnUnmount({
       cozybar,
-      theme
+      theme,
+      isLight: true
     })
   ).toEqual({
     bottomBackground: theme.palette.background[DOMStrings.BackgroundPaper],
@@ -225,7 +228,8 @@ it('should provide the inversed UI when Cozybar is not black on white, but white
   expect(
     makeOnUnmount({
       cozybar,
-      theme
+      theme,
+      isLight: true
     })
   ).toEqual({
     bottomBackground: theme.palette.background[DOMStrings.BackgroundPaper],

--- a/react/Dialog/DialogEffects.ts
+++ b/react/Dialog/DialogEffects.ts
@@ -11,6 +11,7 @@ import {
 } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
 import { getFlagshipMetadata } from '../hooks/useSetFlagshipUi/helpers'
 import { isRsg } from '../hooks/useSetFlagshipUi/helpers'
+import { useCozyTheme } from '../providers/CozyTheme'
 
 interface DialogEffectsOptions {
   cozybar?: Element | null
@@ -19,6 +20,7 @@ interface DialogEffectsOptions {
   sidebar?: HTMLElement | Element | null
   rootModal?: HTMLElement | Element | null
   theme: Theme
+  isLight?: boolean
 }
 
 export enum DOMStrings {
@@ -41,7 +43,8 @@ export const makeOnMount = ({
   fullscreen,
   sidebar,
   rootModal,
-  theme
+  theme,
+  isLight
 }: DialogEffectsOptions): FlagshipUI => {
   const hasBottomBackground = !rootModal
   const hasTopBackground = cozybar && !rootModal
@@ -78,7 +81,8 @@ export const makeOnUnmount = ({
   theme,
   immersive,
   sidebar,
-  cozybar
+  cozybar,
+  isLight
 }: DialogEffectsOptions): FlagshipUI => {
   const hasDarkRoot =
     rootModal &&
@@ -86,12 +90,15 @@ export const makeOnUnmount = ({
       getComputedStyle(rootModal).getPropertyValue(DOMStrings.RootModalColor)
     ) < LUMINANCE_BREAKPOINT
   const hasBottomBackground = !rootModal
-  const hasDarkBottomTheme = hasDarkRoot || !immersive
+  const hasDarkBottomTheme = hasDarkRoot || (!immersive && isLight)
   const hasTopBackground = cozybar && !rootModal
   const hasDarkTopTheme =
     hasDarkRoot ||
     (!immersive &&
-      !(cozybar && cozybar.classList.contains(DOMStrings.CozyBarPrimaryClass)))
+      !(
+        cozybar && cozybar.classList.contains(DOMStrings.CozyBarPrimaryClass)
+      ) &&
+      isLight)
 
   return {
     bottomBackground: hasBottomBackground
@@ -134,6 +141,7 @@ const getRootModal = (): HTMLElement | null => {
 
 const useHook = (open: boolean, fullscreen?: boolean): void => {
   const theme = useTheme()
+  const { isLight } = useCozyTheme()
   const cozybar = document.querySelector(DOMStrings.CozyBarClass)
   const sidebar = document.getElementById(DOMStrings.SidebarID)
   const rootModal = getRootModal()
@@ -141,8 +149,8 @@ const useHook = (open: boolean, fullscreen?: boolean): void => {
 
   useDialogSetFlagshipUI(
     open,
-    makeOnMount({ fullscreen, theme, sidebar, rootModal, cozybar }),
-    makeOnUnmount({ rootModal, theme, immersive, sidebar, cozybar }),
+    makeOnMount({ fullscreen, theme, sidebar, rootModal, cozybar, isLight }),
+    makeOnUnmount({ rootModal, theme, immersive, sidebar, cozybar, isLight }),
     makeCaller(!!fullscreen, !!rootModal, immersive)
   )
 }

--- a/react/Sidebar/index.jsx
+++ b/react/Sidebar/index.jsx
@@ -3,15 +3,17 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import styles from './styles.styl'
 import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
+import { useCozyTheme } from '../providers/CozyTheme'
 import { useTheme } from '@material-ui/core'
 
 const Sidebar = ({ children, className, ...restProps }) => {
   const theme = useTheme()
+  const { isLight } = useCozyTheme()
 
   useSetFlagshipUI(
     {
       bottomBackground: theme.palette.background.default,
-      bottomTheme: 'dark'
+      bottomTheme: isLight ? 'dark' : 'light'
     },
     {
       bottomBackground: theme.palette.background.paper

--- a/react/Viewer/ViewerInformationsWrapper.jsx
+++ b/react/Viewer/ViewerInformationsWrapper.jsx
@@ -9,6 +9,7 @@ import Footer from './components/Footer'
 import PanelContent from './Panel/PanelContent'
 import FooterContent from './Footer/FooterContent'
 import { useSetFlagshipUI } from '../hooks/useSetFlagshipUi/useSetFlagshipUI'
+import { useCozyTheme } from '../providers/CozyTheme'
 
 const ViewerInformationsWrapper = ({
   currentFile,
@@ -19,12 +20,13 @@ const ViewerInformationsWrapper = ({
   children
 }) => {
   const theme = useTheme()
+  const { isLight } = useCozyTheme()
   const sidebar = document.querySelector('[class*="sidebar"]')
 
   useSetFlagshipUI(
     {
       bottomBackground: theme.palette.background.paper,
-      bottomTheme: 'dark'
+      bottomTheme: isLight ? 'dark' : 'light'
     },
     {
       bottomBackground: theme.palette.background[sidebar ? 'default' : 'paper']

--- a/react/deprecated/ActionMenu/ActionMenuEffects.ts
+++ b/react/deprecated/ActionMenu/ActionMenuEffects.ts
@@ -8,6 +8,7 @@ import { isFlagshipApp } from 'cozy-device-helper'
 
 import { useSetFlagshipUI } from '../../hooks/useSetFlagshipUi/useSetFlagshipUI'
 import { isRsg } from '../../hooks/useSetFlagshipUi/helpers'
+import { useCozyTheme } from '../../providers/CozyTheme'
 
 const getBottomBackground = (theme: Theme): string => {
   const sidebar = document.getElementById('sidebar')
@@ -20,11 +21,13 @@ const getBottomBackground = (theme: Theme): string => {
 const useHook = (): void => {
   const theme = useTheme()
 
+  const { isLight } = useCozyTheme()
+
   useSetFlagshipUI(
     {
       bottomBackground: theme.palette.background.paper,
       // @ts-ignore
-      bottomTheme: 'dark',
+      bottomTheme: isLight ? 'dark' : 'light',
       topOverlay: 'rgba(0, 0, 0, 0.5)',
       topBackground: theme.palette.background.paper,
       // @ts-ignore
@@ -32,10 +35,10 @@ const useHook = (): void => {
     },
     {
       bottomBackground: getBottomBackground(theme),
-      bottomTheme: 'dark',
+      bottomTheme: isLight ? 'dark' : 'light',
       topOverlay: 'transparent',
       topBackground: theme.palette.background.paper,
-      topTheme: 'dark'
+      topTheme: isLight ? 'dark' : 'light'
     },
     'cozy-ui/ActionMenu'
   )

--- a/react/deprecated/ActionMenu/ActionMenuEffects.ts
+++ b/react/deprecated/ActionMenu/ActionMenuEffects.ts
@@ -25,7 +25,7 @@ const useHook = (): void => {
       bottomBackground: theme.palette.background.paper,
       // @ts-ignore
       bottomTheme: 'dark',
-      topOverlay: 'var(--overlay)',
+      topOverlay: 'rgba(0, 0, 0, 0.5)',
       topBackground: theme.palette.background.paper,
       // @ts-ignore
       topTheme: 'light'

--- a/react/deprecated/Modal/ModalEffects.ts
+++ b/react/deprecated/Modal/ModalEffects.ts
@@ -8,19 +8,27 @@ import { isFlagshipApp } from 'cozy-device-helper'
 
 import { useSetFlagshipUI } from '../../hooks/useSetFlagshipUi/useSetFlagshipUI'
 import { getFlagshipMetadata } from '../../hooks/useSetFlagshipUi/helpers'
+import { useCozyTheme } from '../../providers/CozyTheme'
 
 const getTopBackground = (theme: Theme, cozyBar: Element | null): string =>
   (cozyBar && getComputedStyle(cozyBar).getPropertyValue('background-color')) ||
   theme.palette.background.paper
 
-const getTopTheme = (cozyBar: Element | null): 'light' | 'dark' =>
+const getTopTheme = (
+  cozyBar: Element | null,
+  isLight: boolean
+): 'light' | 'dark' =>
   getFlagshipMetadata().immersive ||
-  (cozyBar && cozyBar.classList.contains('coz-theme-primary'))
+  (cozyBar && cozyBar.classList.contains('coz-theme-primary')) || // Needed for previous versions of cozy-bar like v7. Can be removed when all apps in v12.
+  !isLight
     ? 'light'
     : 'dark'
 
 const useHook = (): void => {
   const theme = useTheme()
+
+  const { isLight } = useCozyTheme()
+
   const cozyBar = document.querySelector('.coz-bar-wrapper')
   const sidebar = document.getElementById('sidebar')
 
@@ -28,18 +36,19 @@ const useHook = (): void => {
     {
       bottomBackground: theme.palette.background.paper,
       // @ts-ignore
-      bottomTheme: 'dark',
+      bottomTheme: isLight ? 'dark' : 'light',
       topBackground: theme.palette.background.paper,
       // @ts-ignore
-      topTheme: 'dark'
+      topTheme: isLight ? 'dark' : 'light'
     },
     {
       bottomBackground: theme.palette.background[sidebar ? 'default' : 'paper'],
-      bottomTheme: getFlagshipMetadata().immersive ? 'light' : 'dark',
+      bottomTheme:
+        getFlagshipMetadata().immersive || !isLight ? 'light' : 'dark',
       bottomOverlay: 'transparent',
       topOverlay: 'transparent',
       topBackground: getTopBackground(theme, cozyBar),
-      topTheme: getTopTheme(cozyBar)
+      topTheme: getTopTheme(cozyBar, isLight)
     },
     'cozy-ui/Modal'
   )

--- a/react/providers/CozyTheme/index.jsx
+++ b/react/providers/CozyTheme/index.jsx
@@ -12,6 +12,9 @@ import CozyThemeWithQuery from './CozyThemeWithQuery'
 
 export const CozyThemeContext = createContext()
 
+/**
+ * @returns {{ type: 'light'|'dark', variant: 'normal'|'inverted', isLight: boolean }}
+ */
 export const useCozyTheme = () => {
   const context = useContext(CozyThemeContext)
 
@@ -21,7 +24,7 @@ export const useCozyTheme = () => {
       '`CozyThemeContext` is missing. `useCozyTheme()` must be used within a `<CozyTheme>`. `light normal` is returned as fallback value.'
     )
 
-    return { type: 'light', variant: 'normal' }
+    return { type: 'light', variant: 'normal', isLight: true }
   }
 
   return context
@@ -67,7 +70,11 @@ const DumbCozyTheme = ({
 
   return (
     <CozyThemeContext.Provider
-      value={{ type: selfThemeType, variant: selfThemeVariant }}
+      value={{
+        type: selfThemeType,
+        variant: selfThemeVariant,
+        isLight: selfThemeType === 'light'
+      }}
     >
       <MuiCozyTheme type={selfThemeType} variant={selfThemeVariant}>
         <div


### PR DESCRIPTION
**Fix a bug related to the overlay of the status bar when opening the BottomSheet (not related to dark mode)**

**Set the good colors for the status bar and bottom baar in dark mode** 

It is the front end, and most of the time cozy-ui, that is responsible of setting the good colors for the status bar and bottom bar.

_For example for the BottomSheet_
- when opening it  
  - add an overlay to the status bar
  - set the status bar icon and text in light
- when closing it 
  - remove the overlay 
  - set the status bar icon and text in dark ==> in dark mode we want light here
  
  In the second commit of this PR we update every call to setFlagshipUI to take this into account.