### PR TITLE
fix: Print in Safari

### DIFF
--- a/react/ActionsMenu/Actions/print.js
+++ b/react/ActionsMenu/Actions/print.js
@@ -48,7 +48,13 @@ export const print = () => {
           docUrl = URL.createObjectURL(blob)
         }
 
-        window.open(docUrl, '_blank')
+        /*
+          We need to write window.open in a setTimeout because
+          Safari does not allow window.open in an async function.
+        */
+        setTimeout(() => {
+          window.open(docUrl, '_blank')
+        })
       } catch (error) {
         logger.error(
           `Error trying to print document ${


### PR DESCRIPTION
We need to write window.open in a setTimeout because Safari does not allow window.open in an async function.

It was an issue only in the print action in the mobile viewer.