### PR TITLE
Fix colors for intents and height layout for mobile

### DIFF
--- a/docs/components/IntentExample.jsx
+++ b/docs/components/IntentExample.jsx
@@ -1,25 +1,31 @@
 import React from 'react'
+
 import IntentWrapper from '../../react/IntentWrapper'
+import CozyTheme from '../../react/providers/CozyTheme'
+import Button from '../../react/Buttons'
+import Typography from '../../react/Typography'
 import { placeholder90 } from '../placeholders/img'
 
 const IntentExample = function({ onComplete, action, doctype, options }) {
   return (
-    <IntentWrapper
-      appIcon={placeholder90}
-      appName="IntentExample"
-      appEditor="EditorExample"
-    >
-      <p>
-        Action: {action}
-        <br />
-        Doctype: {doctype}
-        <br />
-        Options: <pre>{JSON.stringify(options, null, 2)}</pre>
-        <br />
-        <br />
-        <button onClick={onComplete}>Click to complete intent</button>
-      </p>
-    </IntentWrapper>
+    <CozyTheme>
+      <IntentWrapper
+        appIcon={placeholder90}
+        appName="IntentExample"
+        appEditor="EditorExample"
+      >
+        <Typography>Action: {action}</Typography>
+        <Typography>Doctype: {doctype}</Typography>
+        <Typography>
+          Options: <pre>{JSON.stringify(options, null, 2)}</pre>
+        </Typography>
+        <Button
+          className="u-mt-1"
+          label="Click to complete intent"
+          onClick={onComplete}
+        />
+      </IntentWrapper>
+    </CozyTheme>
   )
 }
 

--- a/react/IntentDialogOpener/IntentDialogOpener.md
+++ b/react/IntentDialogOpener/IntentDialogOpener.md
@@ -1,7 +1,7 @@
 ```jsx
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
 import IntentDialogOpener from 'cozy-ui/transpiled/react/IntentDialogOpener'
-import { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
 
 const customStyles = () => ({
   paper: {
@@ -12,7 +12,8 @@ const customStyles = () => ({
 const StyledIntentDialogOpener = withStyles(customStyles)(IntentDialogOpener)
 
 ;
-<BreakpointsProvider>
+
+<DemoProvider>
   <StyledIntentDialogOpener
     onComplete={res => alert('intent has completed ! ' + JSON.stringify(res))}
     onDismiss={() => alert('intent has been dismissed !')}
@@ -27,5 +28,5 @@ const StyledIntentDialogOpener = withStyles(customStyles)(IntentDialogOpener)
   >
     <button>Launch Intent OPEN for doctype io.cozy.files</button>
   </StyledIntentDialogOpener>
-</BreakpointsProvider>
+</DemoProvider>
 ```

--- a/react/IntentHeader/styles.styl
+++ b/react/IntentHeader/styles.styl
@@ -5,7 +5,7 @@
     align-items center
     height rem(32)
     padding rem(8 16)
-    background-color var(--paleGrey)
+    background-color var(--contrastBackgroundColor)
     margin 0
     // Keep its height in a flex configuration
     flex-basis auto
@@ -15,7 +15,7 @@
     display flex
     align-items center
     font-size rem(20)
-    color var(--charcoalGrey)
+    color var(--primaryTextColor)
 
     span
         font-weight normal

--- a/react/IntentIframe/Readme.md
+++ b/react/IntentIframe/Readme.md
@@ -33,28 +33,23 @@ import { withStyles } from 'cozy-ui/transpiled/react/styles'
 import { DialogCloseButton } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
 import IntentIframe from 'cozy-ui/transpiled/react/IntentIframe'
-import useBreakpoints, { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
 
 initialState = { modalOpened: false}
 
-const customStyles = () => ({
-  paper: {
-    height: '100%'
-  }
-})
-
-const StyledDialog = withStyles(customStyles)(Dialog)
 const onClose = () => setState({ modalOpened: false })
 
 const IntentDialog = () => {
   const { isMobile } = useBreakpoints()
   return (
-    <StyledDialog
+    <Dialog
       open={state.modalOpened}
-      onClose={onClose}
+      classes={{ paper: 'u-h-100' }}
       fullScreen={isMobile}
       fullWidth
       maxWidth="md"
+      onClose={onClose}
     >
       <DialogCloseButton onClick={onClose} />
       <IntentIframe
@@ -70,16 +65,16 @@ const IntentDialog = () => {
         // cozy.client.intents.create
         create={utils.fakeIntentCreate}
       />
-    </StyledDialog>
+    </Dialog>
   )
 }
 
 ;
 
-<BreakpointsProvider>
+<DemoProvider>
   <button onClick={()=>setState({ modalOpened: !state.modalOpened })}>
     Toggle an IntentDialog OPEN io.cozy.files
   </button>
   <IntentDialog />
-</BreakpointsProvider>
+</DemoProvider>
 ```

--- a/react/IntentIframe/styles.styl
+++ b/react/IntentIframe/styles.styl
@@ -3,7 +3,6 @@ iframe
     height 100%
     border 0
 
-
 .intentContainer,
 .intentPlaceHolder
     height 100%
@@ -18,5 +17,5 @@ iframe
     width 0
 
 .intentContainer__error
-    color red
+    color var(--errorColor)
     font-size 1.5em

--- a/react/Layout/Layout.md
+++ b/react/Layout/Layout.md
@@ -24,19 +24,20 @@ It can be used to wrap any list of React elements, automatically providing funct
 
 ```jsx
 import { useState } from 'react'
-import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout';
-import Sidebar from 'cozy-ui/transpiled/react/Sidebar';
-import Nav, { NavItem, NavIcon, NavText, genNavLink, NavDesktopLimiter } from 'cozy-ui/transpiled/react/Nav';
+import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
+import Sidebar from 'cozy-ui/transpiled/react/Sidebar'
+import Nav, { NavItem, NavIcon, NavText, genNavLink, NavDesktopLimiter } from 'cozy-ui/transpiled/react/Nav'
 import cx from 'classnames'
 import isEqual from 'lodash/isEqual'
 import WarnIcon from 'cozy-ui/transpiled/react/Icons/Warn'
 import CheckIcon from 'cozy-ui/transpiled/react/Icons/Check'
 import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download'
 import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 /**
  * In a normal app, ExampleRouterNavLink is from react-router
- * 
+ *
  * import { NavLink } from 'react-router'
  * const NavLink = genNavLink(NavLink)
  */
@@ -54,10 +55,23 @@ const styles = {
     position: 'relative',
     transform: 'translateZ(0)'
   }
-};
+}
+
+const useStyles = makeStyles({
+  layout: {
+    position: 'relative',
+    transform: 'translateZ(0)',
+    '& > main': {
+      minHeight: 'unset'
+    }
+  }
+})
+
+;
 
 const Example = () => {
   const [active, setActive] = useState(['Section 1', 'Subsection 1'])
+  const styles = useStyles()
 
   // makeProps is not necessary in a normal app since react-router sets active
   // and onClick by itself
@@ -65,7 +79,8 @@ const Example = () => {
     const routeIsMatching = isEqual(active.slice(0, route.length), route)
     return { onClick: () => setActive(route), active: routeIsMatching }
   }
-  return <Layout style={styles.layout}>
+
+  return <Layout className={styles.layout}>
     <Sidebar>
       <Nav>
         <NavItem>
@@ -116,13 +131,36 @@ const Example = () => {
 `monoColumn` option (without sidebar)
 
 ```jsx
-import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout';
+import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
+import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
-<Layout monoColumn>
-    <Main>
-      <Content className='u-p-1'>
-        { content.ada.short }
-      </Content>
-    </Main>
-</Layout>
+// Not necessary in a normal app
+const useStyles = makeStyles({
+  layout: {
+    '& > main': {
+      minHeight: 'unset'
+    }
+  }
+})
+
+const Example = () => {
+  const styles = useStyles()
+
+  return (
+    <Layout className={styles.layout} monoColumn>
+        <Main>
+          <Content className='u-p-1'>
+            { content.ada.short }
+          </Content>
+        </Main>
+    </Layout>
+  )
+}
+
+;
+
+<DemoProvider>
+  <Example />
+</DemoProvider>
 ```

--- a/react/deprecated/Modal/index.jsx
+++ b/react/deprecated/Modal/index.jsx
@@ -15,6 +15,7 @@ import ModalButtons from './ModalButtons'
 import AnimatedContentHeader from './AnimatedContentHeader'
 import ModalBackButton from './ModalBackButton'
 import { ModalEffects } from './ModalEffects'
+import { useCozyTheme } from '../../providers/CozyTheme'
 
 const ModalDescription = ModalContent
 
@@ -30,7 +31,7 @@ export const BODY_CLASS = 'has-modal'
 /**
  * @deprecated Please use [CozyDialogs](#/CozyDialogs) or [Dialog](#/Dialog).
  */
-class Modal extends Component {
+class ModalWithoutTheme extends Component {
   constructor(props) {
     super(props)
     this.titleID = uniqueId('modal_')
@@ -165,7 +166,7 @@ class Modal extends Component {
   }
 }
 
-Modal.propTypes = {
+ModalWithoutTheme.propTypes = {
   /** Modal title */
   title: PropTypes.node,
   /** Content for simple modals */
@@ -218,7 +219,7 @@ Modal.propTypes = {
   dismissAction: PropTypes.func
 }
 
-Modal.defaultProps = {
+ModalWithoutTheme.defaultProps = {
   primaryType: 'regular',
   secondaryType: 'secondary',
   closable: true,
@@ -246,6 +247,23 @@ ModalContent.propTypes = {
   iconDest: PropTypes.node,
   fixed: PropTypes.bool
 }
+
+const Modal = props => {
+  const { type, variant } = useCozyTheme()
+
+  return (
+    <ModalWithoutTheme
+      {...props}
+      containerClassName={cx(
+        props.containerClassName,
+        `CozyTheme--${type}-${variant}`
+      )}
+    />
+  )
+}
+
+Modal.propTypes = ModalWithoutTheme.propTypes
+Modal.defaultProps = ModalWithoutTheme.defaultProps
 
 const EnhancedModal = migrateProps([
   { src: 'withCross', dest: 'closable' }, // withCross -> closable

--- a/react/providers/CozyTheme/index.jsx
+++ b/react/providers/CozyTheme/index.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useLayoutEffect } from 'react'
+import React, { createContext, useContext } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -50,20 +50,6 @@ const DumbCozyTheme = ({
       ? settingsThemeType
       : deviceThemeType)
   const selfThemeVariant = uiThemeVariant || variant
-
-  useLayoutEffect(() => {
-    const negativeThemeType = selfThemeType === 'light' ? 'dark' : 'light'
-
-    // remove "negative" value because can be changed without refresh
-    document
-      .querySelector('body')
-      .classList.remove(`CozyTheme--${negativeThemeType}-normal`)
-
-    // add css var to body to be able to use them on it
-    document
-      .querySelector('body')
-      .classList.add(`CozyTheme--${selfThemeType}-normal`) // `add` omits if already present
-  }, [selfThemeType])
 
   return (
     <CozyThemeContext.Provider

--- a/stylus/components/modals.styl
+++ b/stylus/components/modals.styl
@@ -64,8 +64,8 @@ $modal
     border-radius rem(8)
     max-height 100%
     max-width 100%
-    background-color var(--white)
-    color var(--charcoalGrey)
+    background-color var(--paperBackgroundColor)
+    color var(--primaryTextColor)
 
 for size in 'xsmall' 'small' 'medium' 'large' 'xlarge' 'xxlarge'
     $modal--{size}
@@ -158,7 +158,7 @@ $modal-header-app
     display flex
     align-items center
     font-size rem(20)
-    color var(--charcoalGrey)
+    color var(--primaryTextColor)
 
 $modal-header-app-editor
     font-weight normal
@@ -288,7 +288,7 @@ $modal--hidden
 $modal-back-button
     top rem(6)
     left rem(6)
-    color var(--coolGrey)
+    color var(--actionColorActive)
 
     +small-screen()
         top 0

--- a/stylus/elements/defaults.styl
+++ b/stylus/elements/defaults.styl
@@ -26,7 +26,6 @@ body
     width           100vw
     height          100%
     margin 0
-    background-color var(--paperBackgroundColor)
 
     // Overrides Normalize.css default style
     button,

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -85,6 +85,7 @@ $app
             padding-left env(safe-area-inset-left)
             padding-right env(safe-area-inset-right)
             padding-bottom env(safe-area-inset-bottom)
+            min-height 'calc(100vh - %s - %s)' % (barHeight navHeight)
 
         main,
         main > [role=contentinfo], // Deprecated

--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -39,13 +39,8 @@ $elastic
     align-items stretch
 
 $elastic-content
-    // Those backgrounds give a visual information that the content is scrollable
-    background  linear-gradient(white 30%, rgba(255, 255, 255, 0)),
-                linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
-                linear-gradient(rgba(214, 216, 218, .25) 0, rgba(214, 216, 218, .25) 25%, rgba(255, 255, 255, 0) 26%, rgba(255, 255, 255, 0) 100%),
-                linear-gradient(rgba(255, 255, 255, 0) 0, rgba(255, 255, 255, 0) 74%, rgba(214, 216, 218, .25) 75%, rgba(214, 216, 218, .25) 100%) 0 100%
     background-repeat no-repeat
-    background-color var(--white)
+    background-color var(--paperBackgroundColor)
     background-size 100% rem(32), 100% rem(32), 100% rem(8), 100% rem(8)
     background-attachment local, local, scroll, scroll
     background-clip padding-box


### PR DESCRIPTION
J'ai testé le correctif sur le layout en mobile avec Drive, MesPapiers, Contacts et Store.

Le correctif sur Modal est dû au fait qu'on s'en sert encore (à tort car deprecated depuis longtemps) pour les Intent

Pour la gestion du type/variant du thème, si on manipule le body ou une balise très haute comme ça, on devrait après réflexion avoir 2 composants, ou alors un prop pour distinguer l'usage du type et l'usage du variant. Car le type ne se définit qu'une fois pour toute (pour l'app et pour l'intent), alors que le variant peut être utilisé à l'intérieur de l'app. Si c'est un seul composant qui fait les deux on devrait avoir une prop `<CozyTheme master={true}>` par exemple qu'on utiliserait uniquement dans les providers de l'app/intent et qui s'occuperait de gérer le type du thème.

demo: https://jf-cozy.github.io/cozy-ui/react/#/IntentIframe