### PR TITLE
[VO-889] fix(PermissionDialog): Show overflow icon on iOS

### DIFF
--- a/react/MuiCozyTheme/overrides/makeLightNormalOverrides.js
+++ b/react/MuiCozyTheme/overrides/makeLightNormalOverrides.js
@@ -456,7 +456,10 @@ export const makeLightNormalOverrides = theme => ({
         }
       },
       '&.overflow': {
-        overflowY: 'visible !important' // Allow the icon to overflow the dialog, otherwise it will be cut off
+        overflowY: 'visible !important', // Allow the icon to overflow the dialog, otherwise it will be cut off,
+        '& .cozyDialogContent': {
+          overflowY: 'visible !important' // This allow the overflow to work also on iOS
+        }
       }
     },
     scrollPaper: {


### PR DESCRIPTION
MUI adds a `-webkit-overflow-scrolling` property to manage scrolling on iOS on the content. This is act as a counter-effect to `overflow-y: visible` of the parent to display the icon beyond the modal.