### PR TITLE
[VO-903] fix(ViewerControls): children can contain undefined values

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,9 @@ module.exports = {
     'react-pdf/dist/esm/entry.webpack': 'react-pdf',
     '^cozy-client$': 'cozy-client/dist/index'
   },
-  transformIgnorePatterns: ['node_modules/(?!(react-styleguidist)/)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-styleguidist|cozy-harvest-lib)/)'
+  ],
   testPathIgnorePatterns: ['/node_modules/', '/transpiled/', '/dist/'],
   transform: {
     '^.+\\.(ts|tsx|js|jsx)?$': 'babel-jest'

--- a/react/Viewer/components/ViewerControls.jsx
+++ b/react/Viewer/components/ViewerControls.jsx
@@ -95,8 +95,8 @@ class ViewerControls extends Component {
 
     return React.Children.map(children, child => {
       if (
-        child.type.name === 'ViewerByFile' ||
-        child.type.displayName === 'ViewerByFile'
+        child?.type?.name === 'ViewerByFile' ||
+        child?.type?.displayName === 'ViewerByFile'
       ) {
         return React.cloneElement(child, {
           gestures: this.state.gestures,

--- a/react/Viewer/components/ViewerControls.spec.jsx
+++ b/react/Viewer/components/ViewerControls.spec.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import ViewerControls from './ViewerControls'
+import ViewerByFile from './ViewerByFile'
+
+jest.mock('../ViewersByFile/AudioViewer', () => () => <div>AudioViewer</div>)
+jest.mock('../providers/EncryptedProvider', () => ({
+  useEncrypted: () => ({ url: 'random' })
+}))
+
+describe('ViewerControls', () => {
+  const file = {
+    _id: 'audio',
+    class: 'audio',
+    mime: 'audio/mp3',
+    name: 'sample.mp3'
+  }
+
+  const setup = ({ children } = {}) => {
+    render(
+      <ViewerControls
+        file={file}
+        onClose={() => {}}
+        hasPrevious={false}
+        hasNext={false}
+        onPrevious={() => {}}
+        onNext={() => {}}
+        expanded={false}
+        toolbarProps={{
+          showToolbar: false,
+          showClose: false,
+          showFilePath: false,
+          toolbarRef: undefined
+        }}
+        showNavigation={false}
+      >
+        {children}
+      </ViewerControls>
+    )
+  }
+
+  it('should only render children if they are ViewerByFile', () => {
+    setup({
+      children: [
+        undefined,
+        <div key="notViewer">not ViewerByFile</div>,
+        <ViewerByFile key="viewer" file={file} onClose={() => {}} />
+      ]
+    })
+    expect(screen.queryByText('not ViewerByFile')).not.toBeInTheDocument()
+    expect(screen.getByText('AudioViewer')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
In the Viewer, we define a variable which can be undefined inside the ViewerControls children. When the ViewerControls matches its children to find out which display it checks for the type that crashed the application because it doesn't exist on undefined.