### PR TITLE
feat(Layout): Use var css instead of stylus var to set Main min-height on mobile

### DIFF
--- a/stylus/objects/layouts.styl
+++ b/stylus/objects/layouts.styl
@@ -85,7 +85,7 @@ $app
             padding-left env(safe-area-inset-left)
             padding-right env(safe-area-inset-right)
             padding-bottom env(safe-area-inset-bottom)
-            min-height 'calc(100vh - %s - %s)' % (barHeight navHeight)
+            min-height 'calc(100vh - var(--sidebarHeight) - %s)' % barHeight
 
         main,
         main > [role=contentinfo], // Deprecated


### PR DESCRIPTION
and so to be able to override it with `:root`

utile pour les app qui n'ont pas la nav bar, comme Settings, et donc qui pourrait alors mettre la valeur à `0` pour éviter un espace trop important

relatif au commit https://github.com/cozy/cozy-ui/pull/2661/commits/2bc7e5df1bbb88fbfa5a20f7bf497f9d9d6e9d69 qui fait la modification initiale