### PR TITLE
[SCR-785] typo: Replace commercial '&' by their equivalents

### DIFF
--- a/react/AppSections/locales/en.json
+++ b/react/AppSections/locales/en.json
@@ -2,11 +2,11 @@
   "app_categories": {
     "all": "All categories",
     "banking": "Banking",
-    "clouds": "Clouds & vaults",
+    "clouds": "Clouds and vaults",
     "cozy": "The essentials",
     "education": "Education",
     "energy": "Energy",
-    "finance": "Employment & finance",
+    "finance": "Employment and finance",
     "health": "Health",
     "host_provider": "Host",
     "insurance": "Insurance",

--- a/react/AppSections/locales/fr.json
+++ b/react/AppSections/locales/fr.json
@@ -2,11 +2,11 @@
   "app_categories": {
     "all": "Toutes les catégories",
     "banking": "Banques",
-    "clouds": "Clouds & coffres",
+    "clouds": "Clouds et coffres",
     "cozy": "Les essentielles",
     "education": "Éducation",
     "energy": "Energie",
-    "finance": "Emploi & finance",
+    "finance": "Emploi et finance",
     "health": "Santé",
     "host_provider": "Hébergeur",
     "insurance": "Assurance",


### PR DESCRIPTION
Replace "&" char by their equivalent in each language to uniformize display in store