### PR TITLE
feat: handle shortcuts in appsections VO-777

### DIFF
--- a/react/AppIcon/index.jsx
+++ b/react/AppIcon/index.jsx
@@ -5,8 +5,10 @@ import React, { Component } from 'react'
 import { withClient } from 'cozy-client'
 
 import styles from './styles.styl'
+import { isShortcutFile } from '../AppSections/helpers'
 import Icon, { iconPropType } from '../Icon'
 import CubeIcon from '../Icons/Cube'
+import { ShortcutTile } from '../ShortcutTile'
 import palette from '../palette'
 import { AppDoctype } from '../proptypes'
 
@@ -44,6 +46,9 @@ export class AppIcon extends Component {
 
   fetchIcon() {
     const { app, type, priority, client } = this.props
+
+    // Shortcut files used in cozy-store have their own icon in their doctype metadata
+    if (isShortcutFile(app)) return
 
     return client.getStackClient().getIconURL({
       type,
@@ -92,6 +97,10 @@ export class AppIcon extends Component {
   render() {
     const { alt, className, fallbackIcon } = this.props
     const { icon, status } = this.state
+
+    if (isShortcutFile(this.props.app)) {
+      return <ShortcutTile file={this.props.app} />
+    }
 
     switch (status) {
       case FETCHING:

--- a/react/AppSections/__snapshots__/index.spec.jsx.snap
+++ b/react/AppSections/__snapshots__/index.spec.jsx.snap
@@ -1076,6 +1076,11 @@ exports[`AppsSection component should render dropdown filter on mobile if no nav
           "value": "partners",
         },
         Object {
+          "label": "Shortcuts",
+          "secondary": false,
+          "value": "shortcuts",
+        },
+        Object {
           "label": "Services",
           "secondary": false,
           "value": "konnectors",
@@ -1475,6 +1480,11 @@ exports[`AppsSection component should render dropdown filter on tablet if no nav
           "secondary": false,
           "type": "webapp",
           "value": "partners",
+        },
+        Object {
+          "label": "Shortcuts",
+          "secondary": false,
+          "value": "shortcuts",
         },
         Object {
           "label": "Services",

--- a/react/AppSections/categories.spec.js
+++ b/react/AppSections/categories.spec.js
@@ -104,6 +104,7 @@ describe('generateOptionsFromApps', () => {
         type: 'webapp',
         value: 'others'
       },
+      { label: 'Shortcuts', secondary: false, value: 'shortcuts' },
       {
         label: 'Services',
         secondary: false,
@@ -155,6 +156,11 @@ describe('generateOptionsFromApps', () => {
         secondary: false,
         type: 'webapp',
         value: 'others'
+      },
+      {
+        label: 'Shortcuts',
+        secondary: false,
+        value: 'shortcuts'
       },
       {
         label: 'Services',

--- a/react/AppSections/components/__snapshots__/AppsSection.spec.jsx.snap
+++ b/react/AppSections/components/__snapshots__/AppsSection.spec.jsx.snap
@@ -28,7 +28,7 @@ Array [
     "title": "Cozy Photos",
   },
   Object {
-    "developer": null,
+    "developer": "By undefined",
     "status": "Update available",
     "title": "Tasky",
   },

--- a/react/AppSections/constants.js
+++ b/react/AppSections/constants.js
@@ -1,4 +1,9 @@
 export const APP_TYPE = {
   KONNECTOR: 'konnector',
-  WEBAPP: 'webapp'
+  WEBAPP: 'webapp',
+  FILE: 'file'
+}
+
+export const APP_CLASS = {
+  SHORTCUT: 'shortcut'
 }

--- a/react/AppSections/generateI18nConfig.ts
+++ b/react/AppSections/generateI18nConfig.ts
@@ -1,0 +1,23 @@
+export const generateI18nConfig = (categories?: {
+  [key: string]: string
+}): {
+  en: Record<string, string>
+  fr: Record<string, string>
+} => {
+  if (!categories) return { en: {}, fr: {} }
+
+  const i18nConfig: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(categories)) {
+    // Extract the final part of the path as the display name
+    const displayName =
+      value?.split('/').pop() ?? ''.replace(/([A-Z])/g, ' $1').trim()
+
+    i18nConfig[`app_categories.${key}`] = displayName
+  }
+
+  return {
+    en: i18nConfig,
+    fr: i18nConfig
+  }
+}

--- a/react/AppSections/helpers.js
+++ b/react/AppSections/helpers.js
@@ -1,8 +1,16 @@
 import _get from 'lodash/get'
 
+import { APP_CLASS, APP_TYPE } from './constants'
+
 export const getTranslatedManifestProperty = (app, path, t) => {
   if (!t || !app || !path) return _get(app, path, '')
   return t(`apps.${app.slug}.${path}`, {
     _: _get(app, path, '')
   })
+}
+
+export const isShortcutFile = app => {
+  if (!app) return false
+
+  return app.type === APP_TYPE.FILE && app.class === APP_CLASS.SHORTCUT
 }

--- a/react/AppSections/locales/en.json
+++ b/react/AppSections/locales/en.json
@@ -26,10 +26,12 @@
     "tech": "Tech",
     "telecom": "Telecom",
     "transport": "Transportation",
-    "pro": "Work"
+    "pro": "Work",
+    "shortcuts": "Shortcuts"
   },
   "sections": {
     "applications": "Applications",
-    "konnectors": "Services"
+    "konnectors": "Services",
+    "shortcuts": "Shortcuts"
   }
 }

--- a/react/AppSections/locales/fr.json
+++ b/react/AppSections/locales/fr.json
@@ -26,10 +26,12 @@
     "tech": "Tech",
     "telecom": "Mobile",
     "transport": "Voyage et transport",
-    "pro": "Travail"
+    "pro": "Travail",
+    "shortcuts": "Raccourcis"
   },
   "sections": {
     "applications": "Applications",
-    "konnectors": "Services"
+    "konnectors": "Services",
+    "shortcuts": "Raccourcis"
   }
 }

--- a/react/AppTile/AppTile.spec.jsx
+++ b/react/AppTile/AppTile.spec.jsx
@@ -5,10 +5,11 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 
-import CozyClient, { CozyProvider } from 'cozy-client'
+import CozyClient from 'cozy-client'
 
 import AppTile from '.'
 import en from '../AppSections/locales/en.json'
+import DemoProvider from '../providers/DemoProvider'
 import I18n from '../providers/I18n'
 
 const appMock = {
@@ -41,11 +42,11 @@ const appMock2 = {
 const client = new CozyClient({})
 const Wrapper = props => {
   return (
-    <CozyProvider client={client}>
+    <DemoProvider client={client}>
       <I18n dictRequire={() => en} lang="en">
         <AppTile {...props} />
       </I18n>
-    </CozyProvider>
+    </DemoProvider>
   )
 }
 

--- a/react/AppTile/locales/en.json
+++ b/react/AppTile/locales/en.json
@@ -3,6 +3,7 @@
     "by": "By",
     "installed": "Installed",
     "maintenance": "In maintenance",
-    "update": "Update available"
+    "update": "Update available",
+    "favorite": "Added to home page"
   }
 }

--- a/react/AppTile/locales/fr.json
+++ b/react/AppTile/locales/fr.json
@@ -3,6 +3,7 @@
     "by": "Par",
     "installed": "Installée",
     "maintenance": "En maintenance",
-    "update": "Mise à jour dispo."
+    "update": "Mise à jour dispo.",
+    "favorite": "Ajouté sur la page d'accueil"
   }
 }

--- a/react/ShortcutTile/index.tsx
+++ b/react/ShortcutTile/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import { IOCozyFile } from 'cozy-client/types/types'
+// @ts-expect-error - The following component is not typed
+import { nameToColor } from 'cozy-ui/react/Avatar/helpers'
+// @ts-expect-error - The following component is not typed
+import Typography from 'cozy-ui/react/Typography'
+
+import styles from '../AppTile/styles.styl'
+import { TileIcon } from '../Tile'
+import { makeStyles } from '../styles'
+
+interface ShortcutTileProps {
+  file: Partial<IOCozyFile> & {
+    name: string
+    attributes?: { metadata?: { icon?: string; iconMimeType?: string } }
+  }
+}
+
+const useStyles = makeStyles({
+  letter: {
+    color: 'white',
+    margin: 'auto'
+  },
+  letterWrapper: {
+    backgroundColor: ({ name }: { name: string }) =>
+      (nameToColor as (name: string) => string)(name)
+  }
+})
+
+export const ShortcutTile = ({ file }: ShortcutTileProps): JSX.Element => {
+  const classes = useStyles({ name: file.name })
+  const icon = file.attributes?.metadata?.icon
+  const iconMimeType = file.attributes?.metadata?.iconMimeType
+
+  if (icon) {
+    return (
+      <TileIcon>
+        <img
+          className={styles['AppTile-icon']}
+          src={
+            iconMimeType
+              ? `data:${iconMimeType};base64,${icon}`
+              : `data:image/svg+xml;base64,${window.btoa(icon)}`
+          }
+          width={48}
+          height={48}
+          alt={file.name}
+        />
+      </TileIcon>
+    )
+  }
+
+  return (
+    <TileIcon>
+      <div className={classes.letterWrapper}>
+        <Typography className={classes.letter} variant="h2" align="center">
+          {file.name[0].toUpperCase()}
+        </Typography>
+      </div>
+    </TileIcon>
+  )
+}

--- a/react/types.d.ts
+++ b/react/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.styl' {
+  const classes: Record<string, string>
+  export default classes
+}


### PR DESCRIPTION
Allow shortcuts doctype to be used in AppsSections in cozy-store (previously only konnectors and apps were set up).

![image](https://github.com/user-attachments/assets/68bccdb2-88fc-40f5-a01f-f6a37924953d)


