### PR TITLE
chore: Ignore branches with tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 dist: jammy
 cache:
   npm: false
-if: type NOT IN (pull_request)
+if: type NOT IN (pull_request) # we run CI only on branches, not PR
+branches:
+  except:
+    - /^\d+\.\d+\.\d+$/ # we don't want to run CI on tag after new publication
 env:
   global:
     - PR_TITLE=$(curl https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST} 2> /dev/null | grep "title" | head -1)


### PR DESCRIPTION
`skip ci` seems to be ignored...

Depuis un certain moment (non totalement défini) Travis crée un build après la publication d'un tag, sur le commit associé, malgré la présence du `skip ci` sur ce commit 🤷‍♂️ 

On rajoute donc ici une règle pour ignorer ce cas là.