### PR TITLE
fix: Redirect with PopupOpener on flagship app

### DIFF
--- a/react/PopupOpener/index.jsx
+++ b/react/PopupOpener/index.jsx
@@ -14,11 +14,10 @@ export function openCenteredPopup(url, title, w, h) {
   var left = width / 2 - w / 2 + window.screenX
   var top = height / 2 - h / 2 + window.screenY
   var newWindow = window.open(
-    '',
+    url,
     title,
     `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`
   )
-  newWindow.location.href = url
 
   // Puts focus on the newWindow
   if (window.focus) {


### PR DESCRIPTION
Flagship app does not handle a redirection with const newWindow = window.open('') and then newWindow.location.href. So let's set the url directly in window.open because we do not know why it was separated in two.