### PR TITLE
fix: Import resolution problem inside Storybook of cozy-harvest

### DIFF
--- a/react/ShortcutTile/index.tsx
+++ b/react/ShortcutTile/index.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 
 import { IOCozyFile } from 'cozy-client/types/types'
-// @ts-expect-error - The following component is not typed
-import { nameToColor } from 'cozy-ui/react/Avatar/helpers'
-// @ts-expect-error - The following component is not typed
-import Typography from 'cozy-ui/react/Typography'
 
 import styles from '../AppTile/styles.styl'
+import { nameToColor } from '../Avatar/helpers'
 import { TileIcon } from '../Tile'
+import Typography from '../Typography'
 import { makeStyles } from '../styles'
 
 interface ShortcutTileProps {

--- a/react/Typography/index.jsx
+++ b/react/Typography/index.jsx
@@ -1,6 +1,16 @@
 import MuiTypography from '@material-ui/core/Typography'
 import React, { forwardRef } from 'react'
 
+/**
+ * @typedef TypographyPropTypes
+ * @property {string} [color] - The color of the text.
+ * @property {string} [variant] - The variant of the text.
+ * @property {React.ReactNode} children - The content of the component.
+ */
+
+/**
+ * @type React.ForwardRefRenderFunction<HTMLDivElement, TypographyPropTypes & MuiTypography>
+ */
 const Typography = forwardRef(({ color, variant, children, ...props }, ref) => {
   const madeColor =
     color || (variant === 'caption' ? 'textSecondary' : 'textPrimary')


### PR DESCRIPTION
The Storybook for Harvest could not resolve cozy-ui/react/ as it isn't present in the transpiled version. To resolve this, I updated the import to use relative paths consistently with the rest of the codebase. Additionally, as ShortcutTile is a TypeScript file, I needed typed versions of all components it relies on, so I added JSDoc to Typography to ensure compatibility.