### PR TITLE
fix(initFormat): Ensure do not crash if no date is passed

### DIFF
--- a/react/providers/I18n/format.jsx
+++ b/react/providers/I18n/format.jsx
@@ -53,7 +53,11 @@ export const initFormat =
     const locale = provideDateFnsLocale(userLang, defaultLang)
     const ensureDate = date && typeof date === 'string' ? new Date(date) : date
 
-    return format(ensureDate, formatStr, { locale, ...opts })
+    try {
+      return format(ensureDate, formatStr, { locale, ...opts })
+    } catch (error) {
+      console.error('Error in initFormat', error)
+    }
   }
 
 export const formatLocallyDistanceToNow = date => {


### PR DESCRIPTION
Since version 115.0.0, the new version of `date-fns` throws an error if no date has passed.
In order to maintain the same behavior on our apps, we make sure we don't throw any errors in the apps.