### PR TITLE
chore: Trigger Argos to verify false positive 

### DIFF
--- a/react/ActionsBar/Readme.md
+++ b/react/ActionsBar/Readme.md
@@ -1,4 +1,4 @@
-Use same actions as `<ActionsMenu />`
+Use same actions as `<ActionsMenu />`.
 
 ```jsx
 import DemoProvider from 'cozy-ui/docs/components/DemoProvider'


### PR DESCRIPTION
Il semblerait que quelque chose ait changé côté argos car tous les screenshots sont détectés comme ayant changé, alors qu'aucune modification n'a été apportée. Cette PR fait un changement mineur afin de revalider tous les screenshots et de repartir sur une base saine pour les prochaines PR.