### PR TITLE
feat: Revert "feat: Set pdf-lib as a peerDep"

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "mini-css-extract-plugin": "0.6.0",
     "nodemon": "1.19.4",
     "npm-run-all": "4.1.5",
-    "pdf-lib": "1.17.1",
     "postcss-cli": "6.1.3",
     "postcss-loader": "2.1.6",
     "prettier": "2.6.0",
@@ -173,6 +172,7 @@
     "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.9",
     "node-polyglot": "^2.5.0",
     "normalize.css": "^8.0.0",
+    "pdf-lib": "1.17.1",
     "react-chartjs-2": "4.1.0",
     "react-markdown": "^4.0.8",
     "react-popper": "^2.2.3",
@@ -186,14 +186,8 @@
     "cozy-device-helper": "^2.0.0",
     "cozy-flags": ">=2.10.1",
     "cozy-intent": ">=2.29.1",
-    "pdf-lib": "1.17.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
-  },
-  "peerDependenciesMeta": {
-    "pdf-lib": {
-      "optional": true
-    }
   },
   "eslintConfig": {
     "extends": [

--- a/react/ActionsMenu/Readme.md
+++ b/react/ActionsMenu/Readme.md
@@ -4,25 +4,6 @@ You can pass a reference to a custom DOM element through the `ref` prop to attac
 
 A header `ActionsMenuMobileHeader` can be used to provide context on the menu actions. Since on desktop, we display a popper and not a `BottomSheet`, context for the user is not lost, so the header would be redundant. This is why it is not rendered unless we are on mobile.
 
-## Available actions
-
-cozy-ui exposes a list of ready-to-use action : 
-- makeActions
-- divider
-- modify
-- smsTo
-- call
-- emailTo
-- print (requires to add `pdf-lib` in the app)
-- download
-- addToFavorites
-- removeFromFavorites
-- viewInContacts
-- viewInDrive
-- copyToClipboard
-- editAttribute
-- others
-
 ### How to create and use actions
 
 An action is a simple function that returns an object with specific keys:


### PR DESCRIPTION
This reverts commit 15604af04a8f68b77d9ae4c42612e81f04b4f31c.

Setting pdf-lib as a peerDep makes bundles errors when building even if do not need pdf-lib. I need to understand better how it works to propose a better solution.

BREAKING CHANGE: Remove pdf-lib as a dep in your app if you added it in cozy-ui 120.0.0