### PR TITLE
feat(SquareAppIcon): Dark mode in Twake theme

### DIFF
--- a/react/SquareAppIcon/index.jsx
+++ b/react/SquareAppIcon/index.jsx
@@ -118,7 +118,7 @@ export const SquareAppIcon = ({
   hideShortcutBadge = false,
   ...appIconProps
 }) => {
-  const { variant: themeVariant } = useCozyTheme()
+  const { variant: themeVariant, type } = useCozyTheme()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
   const appName =
@@ -172,8 +172,9 @@ export const SquareAppIcon = ({
           />
           <Badge
             className={cx(
-              styles['SquareAppIcon-wrapper'],
+              styles[`SquareAppIcon-wrapper`],
               styles[`SquareAppIcon-wrapper-${variant}`],
+              styles[`SquareAppIcon-wrapper--${type}`],
               {
                 [classes.squareAppIconGhost]:
                   exceptionVariant.includes(variant),

--- a/react/SquareAppIcon/styles_twake.styl
+++ b/react/SquareAppIcon/styles_twake.styl
@@ -8,7 +8,6 @@ $mobileIconPadding = constants['mobileIconPadding']
 
 .SquareAppIcon-wrapper
     box-sizing border-box
-    background linear-gradient(0deg, rgba(255, 255, 255, 0.09) 0%, rgba(255, 255, 255, 0.09) 100%), rgba(255, 251, 254, 0.80) // we don't want to be theme responsive
     border-radius 100%
     height $iconSize
     width $iconSize
@@ -17,6 +16,12 @@ $mobileIconPadding = constants['mobileIconPadding']
     +small-screen()
         height $mobileIconSize
         width $mobileIconSize
+
+    &--light
+        background linear-gradient(0deg, rgba(255, 255, 255, 0.09) 0%, rgba(255, 255, 255, 0.09) 100%), rgba(255, 251, 254, 0.80)
+
+    &--dark
+        background linear-gradient(0deg, rgba(255, 255, 255, 0.09) 0%, rgba(255, 255, 255, 0.09) 100%), #2C3039
 
 .SquareAppIcon-icon-container
     display flex


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8fcee117-f258-4ec1-8e58-f041bd93b5c2)

See https://zatteo.github.io/cozy-ui/react/#/Extra/SquareAppIcon