### PR TITLE
fix: Wait for flags initialization before making MUI theme

### DIFF
--- a/react/MuiCozyTheme/index.jsx
+++ b/react/MuiCozyTheme/index.jsx
@@ -1,11 +1,29 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+
+import { useClient } from 'cozy-client'
 
 import { getTheme } from './theme'
 import { ThemeProvider } from '../styles'
 
 const MuiCozyTheme = ({ type, variant, children }) => {
-  const theme = getTheme(type, variant)
+  const client = useClient()
+  const [theme, setTheme] = useState(undefined)
+
+  useEffect(() => {
+    const initTheme = async () => {
+      if (client.plugins.flags) {
+        await client.plugins.flags.initializing
+      }
+      const computedTheme = getTheme(type, variant)
+
+      setTheme(computedTheme)
+    }
+
+    if (client) initTheme()
+  }, [client, type, variant])
+
+  if (!theme) return null
 
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>
 }

--- a/react/MuiCozyTheme/theme.jsx
+++ b/react/MuiCozyTheme/theme.jsx
@@ -1,22 +1,27 @@
 import { makeTheme } from './makeTheme'
 
-export const lightNormalTheme = makeTheme('light', 'normal')
-export const lightInvertedTheme = makeTheme('light', 'inverted')
-export const darkNormalTheme = makeTheme('dark', 'normal')
-export const darkInvertedTheme = makeTheme('dark', 'inverted')
+const makeThemes = () => {
+  const lightNormalTheme = makeTheme('light', 'normal')
+  const lightInvertedTheme = makeTheme('light', 'inverted')
+  const darkNormalTheme = makeTheme('dark', 'normal')
+  const darkInvertedTheme = makeTheme('dark', 'inverted')
 
-const themes = {
-  light: {
-    normal: lightNormalTheme,
-    inverted: lightInvertedTheme
-  },
-  dark: {
-    normal: darkNormalTheme,
-    inverted: darkInvertedTheme
+  const themes = {
+    light: {
+      normal: lightNormalTheme,
+      inverted: lightInvertedTheme
+    },
+    dark: {
+      normal: darkNormalTheme,
+      inverted: darkInvertedTheme
+    }
   }
+
+  return themes
 }
 
 export const getTheme = (type, variant) => {
+  const themes = makeThemes()
   const theme = themes[type]?.[variant]
 
   if (!theme) {


### PR DESCRIPTION
Since #2748 the `makeTheme()` methods relies on cozy's flags

Because flags are initialized asynchronously, the `makeTheme()` methods were called too early and so on the first cozy-app render, the app would render with the incorrect theme. Then after a refresh, because the flags is now on the local storage, then the app would render with the correct theme

To reproduce this bug, either:
- clear the app storage, re-login and access the app
- or clear the `flag__ui.theme-twake.enabled` entry in local storage

By awaiting for flags initialization the first cozy-app render would display the correct theme