### PR TITLE
feat: Update isTwakeTheme condition to force it to `true`

### DIFF
--- a/react/helpers/isTwakeTheme.js
+++ b/react/helpers/isTwakeTheme.js
@@ -1,7 +1,5 @@
-import flag from 'cozy-flags'
-
 /**
- * Relies on flag and local storage to determine if the Twake theme is enabled
+ * Forced to `true`, we don't want to use Cozy theme anymore
  * @returns {boolean}
  */
 export const isTwakeTheme = () => {
@@ -9,8 +7,5 @@ export const isTwakeTheme = () => {
     return false
   }
 
-  return (
-    flag('ui.theme-twake.enabled') ||
-    localStorage.getItem('ui-theme-name') === 'Twake'
-  )
+  return true
 }


### PR DESCRIPTION
We decided to remove Cozy theme completely and relies only on Twake theme. So we have to remove `isTwakeTheme` condition everywhere in the Cozy codebase. To be able to do that by taking the time to do it well, we simply return `true` to begin with.