### PR TITLE
feat: Change default font from Lato to Inter

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -191,7 +191,7 @@ module.exports = {
   },
   theme: {
     fontFamily: {
-      base: 'Lato, sans-serif'
+      base: 'sans-serif'
     }
   },
   webpackConfig: webpackMerge(require('./webpack.config.js'), {


### PR DESCRIPTION
The main goal is this PR https://github.com/cozy/cozy-ui/pull/2791 but because of font modification, Argos is triggered everywhere.

Here we just modify the documentation font (not the font used in components), update Argos, and then we will see better on the other PR if we broke something or not.

In the documentation we use now sans-serif to be agnostic and so to avoid triggering Argos if we change font again (it will still be sans-serif in the doc).