### PR TITLE
fix: Allow cozy-device-helper >= 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
   },
   "peerDependencies": {
     "cozy-client": ">=52.1.0",
-    "cozy-device-helper": "^2.0.0",
+    "cozy-device-helper": ">=2.0.0",
     "cozy-flags": ">=2.10.1",
     "cozy-intent": ">=2.29.1",
     "react": "^16.8.6",


### PR DESCRIPTION
Follow our convention about internal peer deps.

Will allow apps to have only version of cozy-device-helper because here we ask a 2.x version whereas other libs ask >= 2.x (so 3.x as of now).

No change needed on apps.