### PR TITLE
feat(ActionsMenu): Add autoclose on context menu event

### DIFF
--- a/react/ActionsMenu/index.jsx
+++ b/react/ActionsMenu/index.jsx
@@ -20,6 +20,7 @@ const ActionsMenu = forwardRef(
       children,
       componentsProps,
       onClose,
+      autoCloseOnContextMenu,
       ...props
     },
     ref
@@ -34,6 +35,12 @@ const ActionsMenu = forwardRef(
         anchorOrigin={anchorOrigin}
         transformOrigin={transformOrigin}
         keepMounted
+        {...(autoCloseOnContextMenu && {
+          onContextMenu: ev => {
+            ev.preventDefault()
+            onClose()
+          }
+        })}
         onClose={onClose}
       >
         {children}
@@ -53,6 +60,7 @@ ActionsMenu.defaultProps = {
     horizontal: 'left'
   },
   autoClose: true,
+  autoCloseOnContextMenu: true,
   componentsProps: {}
 }
 
@@ -70,6 +78,8 @@ ActionsMenu.propTypes = {
   }),
   /** Whether the menu should automatically close itself when an item is clicked */
   autoClose: PropTypes.bool,
+  /** Whether the menu should automatically close itself when right-click is triggered */
+  autoCloseOnContextMenu: PropTypes.bool,
   /* Props passed to components with the same name */
   componentsProps: PropTypes.shape({
     /** Props spread to ActionsItems component */


### PR DESCRIPTION
By default the menu stays open when clicking right mouse button outside of it. It doesn't anymore but if you don't want to close the menu on right-click you have to set `autoCloseOnContextMenu` to `false`.

We need this because now we have right-click menu on apps (Drive) and we don't want to have too many menus open at the same time.