### PR TITLE
feat: Adjust view in drive to adapt shared drive :sparkles:

### DIFF
--- a/react/ActionsMenu/Actions/viewInDrive.js
+++ b/react/ActionsMenu/Actions/viewInDrive.js
@@ -38,12 +38,13 @@ export const viewInDrive = () => {
     Component: makeComponent(label, icon),
     action: (docs, { client }) => {
       const dirId = docs[0].dir_id
+      const driveId = docs[0].driveId
       const webLink = generateWebLink({
         slug: 'drive',
         cozyUrl: client.getStackClient().uri,
         subDomainType: client.getInstanceOptions().subdomain,
         pathname: '/',
-        hash: `folder/${dirId}`
+        hash: driveId ? `shareddrive/${driveId}/${dirId}` : `folder/${dirId}`
       })
 
       window.open(webLink, '_blank')


### PR DESCRIPTION
### Related issue:

[cozy/cozy-drive#3436](https://github.com/cozy/cozy-drive/pull/3436)

### What has been changed?

Update action `viewInDrive` to get `driveId` from `docs` to open files in shared drive.