### PR TITLE
fix: Add `@fastify/deepmerge` as dep to apply patch correctly on apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "@date-io/date-fns": "1",
+    "@fastify/deepmerge": "2.0.2",
     "@material-ui/core": "4.12.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@material-ui/pickers": "3.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,7 +1643,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fastify/deepmerge@^2.0.2":
+"@fastify/deepmerge@2.0.2", "@fastify/deepmerge@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@fastify/deepmerge/-/deepmerge-2.0.2.tgz#5dcbda2acb266e309b8a1ca92fa48b2125e65fc0"
   integrity sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==


### PR DESCRIPTION
related to https://github.com/cozy/cozy-ui/pull/2837

it works without on local app, but fails in CI: 
```
[5/5] Building fresh packages...
error /home/runner/work/cozy-admin/cozy-admin/node_modules/cozy-ui: Command failed.
Exit code: 1
Command: patch-package
Arguments: 
Directory: /home/runner/work/cozy-admin/cozy-admin/node_modules/cozy-ui
Output:
patch-package 8.0.0
Applying patches...
Error: Patch file found for package deepmerge which is not present at node_modules/@fastify/deepmerge
```

So we need the package as dep to apply the patch in the app.