### PR TITLE
fix(packages): Don't apply patch-package if no package to patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test": "jest",
     "screenshots:server": "nodemon ./scripts/pixelmatch-server/server.js -e js,hbs",
     "postbuild": "postcss transpiled/react/stylesheet.css --replace",
-    "postinstall": "patch-package",
+    "postinstall": "if [ -d 'node_modules/@fastify/deepmerge' ]; then patch-package; fi",
     "travis-deploy-once": "travis-deploy-once",
     "start:css:utils": "yarn build:css:utils --watch",
     "start:css": "yarn build:css --watch",
@@ -161,7 +161,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "@date-io/date-fns": "1",
-    "@fastify/deepmerge": "2.0.2",
     "@material-ui/core": "4.12.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@material-ui/pickers": "3.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,7 +1643,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fastify/deepmerge@2.0.2", "@fastify/deepmerge@^2.0.2":
+"@fastify/deepmerge@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@fastify/deepmerge/-/deepmerge-2.0.2.tgz#5dcbda2acb266e309b8a1ca92fa48b2125e65fc0"
   integrity sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==


### PR DESCRIPTION
related to https://github.com/cozy/cozy-ui/pull/2837
revert https://github.com/cozy/cozy-ui/pull/2842

I hope this is the final solution :) The problem is that we need to apply the patch in cozy-ui to build the documentation with webpack 4, but we don't need the patch in an app because we use rsbuild (which doesn't cause any problems).

However, when installing packages in the app, cozy-ui dependencies are installed in the app's `node_modules` and not in `node_modules/cozy-ui/node_modules`. Cozy-ui's postinstall then tries to apply a patch to a library it can't find.