### PR TITLE
fix: Resolve issue item in table could not select :bug:

### DIFF
--- a/react/Table/Virtualized/RowContent.jsx
+++ b/react/Table/Virtualized/RowContent.jsx
@@ -30,7 +30,7 @@ const RowContent = ({
             'aria-labelledby': `enhanced-table-checkbox-${index}`
           }}
           size="small"
-          onClick={event => onSelectClick(event, row, index)}
+          onClick={event => onSelectClick(row, event, index)}
         />
       </TableCell>
       {columns.map(column => (


### PR DESCRIPTION
Change the order of params in `onSelectClick`, put param `row` on first to handle if the function from the caller use param `event` or not.