### PR TITLE
fix: Postinstall hook not working using Yarn 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test": "jest",
     "screenshots:server": "nodemon ./scripts/pixelmatch-server/server.js -e js,hbs",
     "postbuild": "postcss transpiled/react/stylesheet.css --replace",
-    "postinstall": "if [ -d 'node_modules/@fastify/deepmerge' ]; then patch-package; fi",
+    "postinstall": "/bin/bash -c 'if [ -d node_modules/@fastify/deepmerge ]; then patch-package; fi'",
     "travis-deploy-once": "travis-deploy-once",
     "start:css:utils": "yarn build:css:utils --watch",
     "start:css": "yarn build:css --watch",


### PR DESCRIPTION
When installing cozy-ui with Yarn 4, we get the following errors :
command not found: if
command not found: then
command not found: fi

Fixing it following this advice https://stackoverflow.com/questions/70805712/command-not-found-if-when-running-package-json-script-with-yarn-v3-berry