### PR TITLE
feat(Providers): Add ConfirmDialog providers

### DIFF
--- a/docs/styleguide.config.js
+++ b/docs/styleguide.config.js
@@ -117,6 +117,7 @@ module.exports = {
       components: () => [
         '../react/providers/Alert',
         '../react/providers/Breakpoints',
+        '../react/providers/ConfirmDialog',
         '../react/providers/CozyTheme',
         '../react/providers/Selection'
       ]

--- a/react/providers/ConfirmDialog/Readme.md
+++ b/react/providers/ConfirmDialog/Readme.md
@@ -1,0 +1,30 @@
+```jsx
+import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
+import ConfirmDialogProvider, { useConfirmDialog } from 'cozy-ui/transpiled/react/providers/ConfirmDialog'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+
+const Component = () => {
+  const { showConfirmDialog } = useConfirmDialog()
+
+  return (
+    <Button
+      label="Show ConfirmDialog"
+      onClick={() =>
+        showConfirmDialog({
+          title: "Title of the ConfirmDialog",
+          content: "Content of the ConfirmDialog",
+          actions: <Button label="Ok" />
+        })
+      }
+    />
+  )
+}
+
+;
+
+<DemoProvider>
+  <ConfirmDialogProvider>
+    <Component />
+  </ConfirmDialogProvider>
+</DemoProvider>
+```

--- a/react/providers/ConfirmDialog/index.jsx
+++ b/react/providers/ConfirmDialog/index.jsx
@@ -1,0 +1,59 @@
+import React, { createContext, useState, useContext, useMemo } from 'react'
+
+import { ConfirmDialog } from '../../CozyDialogs'
+
+export const ConfirmDialogContext = createContext()
+
+export const useConfirmDialog = () => {
+  const context = useContext(ConfirmDialogContext)
+
+  if (!context) {
+    throw new Error(
+      'useConfirmDialog must be used within a ConfirmDialogProvider'
+    )
+  }
+  return context
+}
+
+const defaultState = {
+  title: '',
+  content: '',
+  actions: null,
+  open: false
+}
+
+const handleClose = (state, setState) => () => {
+  return setState({ ...state, open: false })
+}
+
+const ConfirmDialogProvider = ({ children }) => {
+  const [state, setState] = useState(defaultState)
+  const { open, title, content, actions, ...confirmDialogProps } = state
+
+  const value = useMemo(
+    () => ({
+      showConfirmDialog: args => {
+        setState({ open: true, ...args })
+      }
+    }),
+    []
+  )
+
+  return (
+    <ConfirmDialogContext.Provider value={value}>
+      {children}
+      {open && (
+        <ConfirmDialog
+          open
+          title={title}
+          content={content}
+          actions={actions}
+          onClose={handleClose(state, setState)}
+          {...confirmDialogProps}
+        />
+      )}
+    </ConfirmDialogContext.Provider>
+  )
+}
+
+export default React.memo(ConfirmDialogProvider)


### PR DESCRIPTION
We don't use routes for confirm modal, so we need to create simple components in app to show them. However it's not possible easily to trigger them in pure js code without creating components. It's a bit fastidious also to create many of theme everywhere we want them.

With a provider, I think it will be easier to deal with these cases.

demo: https://jf-cozy.github.io/cozy-ui/react/#/Providers/ConfirmDialogProvider