### PR TITLE
feat(virtualizedTable): update defaultOrder to be an object containing the properties used to sort the table

### DIFF
--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -121,7 +121,7 @@ const ExampleTable = ({ variant, ...props }) => {
       <Typography className="u-mt-1" variant="h4">Sorted table</Typography>
       <div className="u-mt-half" style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%" }}>
         <SelectionProvider>
-          <ExampleTable variant={variant} defaultOrder={columns[0].id} />
+          <ExampleTable variant={variant} defaultOrder={{by: columns[0].id, direction: 'asc'}} />
         </SelectionProvider>
       </div>
     </>

--- a/react/Table/Virtualized/index.jsx
+++ b/react/Table/Virtualized/index.jsx
@@ -28,8 +28,10 @@ const VirtualizedTable = forwardRef(
     },
     ref
   ) => {
-    const [orderDirection, setOrderDirection] = useState('asc')
-    const [orderBy, setOrderBy] = useState(defaultOrder)
+    const [orderDirection, setOrderDirection] = useState(
+      defaultOrder?.direction ?? 'asc'
+    )
+    const [orderBy, setOrderBy] = useState(defaultOrder?.by ?? undefined)
 
     const sortedData = orderBy
       ? stableSort(rows, getComparator(orderDirection, orderBy))
@@ -117,10 +119,27 @@ VirtualizedTable.defaultProps = {
 }
 
 VirtualizedTable.propTypes = {
-  /** Column ID to be used for initiating the sort */
-  defaultOrder: PropTypes.string,
+  /** Rows to display in the table */
+  rows: PropTypes.array,
+  /** Column configuration */
+  columns: PropTypes.array,
   /** Returned object is: PropTypes.shape({ groupLabels: PropTypes.array, groupCounts: PropTypes.array }) */
   groups: PropTypes.func,
+  /** Default sorting configuration */
+  defaultOrder: PropTypes.shape({
+    direction: PropTypes.oneOf(['asc', 'desc']),
+    by: PropTypes.string
+  }),
+  /** Sort files by type to put directory and trash before files */
+  secondarySort: PropTypes.func,
+  /** Array of selected items */
+  selectedItems: PropTypes.array,
+  /** Callback function when a row is selected */
+  onSelect: PropTypes.func,
+  /** Callback function when all rows are selected/deselected */
+  onSelectAll: PropTypes.func,
+  /** Function to determine if a row is selected */
+  isSelectedItem: PropTypes.func,
   /** Callback called after the sort */
   onSortChange: PropTypes.func
 }


### PR DESCRIPTION
Hello ! 
We needed to sort the trash by last_update and by default the virtualizedTable componant set the direction to 'asc'. 
So we're adding a new property to dynamically change this value.
Ticket : https://www.notion.so/linagora/Display-files-in-the-trash-by-deletion-date-1c062718bad1803d8aa6c3f51d515d4c?source=copy_link 