### PR TITLE
ContactForm: Hide some fields with 2 different ways

### DIFF
--- a/react/Contacts/AddModal/ContactForm/FieldInput.jsx
+++ b/react/Contacts/AddModal/ContactForm/FieldInput.jsx
@@ -16,6 +16,7 @@ import { fieldInputAttributesTypes, labelPropTypes } from '../types'
 const FieldInput = ({
   name,
   labelProps,
+  className,
   attributes: { subFields, ...restAttributes },
   contacts,
   error,
@@ -48,6 +49,7 @@ const FieldInput = ({
   return (
     <div
       className={cx(
+        className,
         styles['contact-form-field__wrapper'],
         'u-flex',
         'u-flex-column-s'
@@ -98,6 +100,7 @@ const FieldInput = ({
 
 FieldInput.propTypes = {
   name: PropTypes.string.isRequired,
+  className: PropTypes.string,
   labelProps: labelPropTypes,
   attributes: fieldInputAttributesTypes,
   contacts: PropTypes.shape({

--- a/react/Contacts/AddModal/ContactForm/FieldInputAccordion.jsx
+++ b/react/Contacts/AddModal/ContactForm/FieldInputAccordion.jsx
@@ -1,0 +1,57 @@
+import cx from 'classnames'
+import React, { useState } from 'react'
+
+import FieldInput from './FieldInput'
+import { locales } from './locales'
+import Icon from '../../../Icon'
+import IconButton from '../../../IconButton'
+import DropdownIcon from '../../../Icons/Dropdown'
+import DropupIcon from '../../../Icons/Dropup'
+import { useI18n, useExtendI18n } from '../../../providers/I18n'
+
+const FieldInputAccordion = ({
+  attributes: { name, label, subFields, ...restAttributes },
+  contacts,
+  error,
+  helperText
+}) => {
+  useExtendI18n(locales)
+  const { t } = useI18n()
+  const [showExtended, setShowExtended] = useState(false)
+
+  return (
+    <>
+      <div className="u-flex u-flex-items-baseline">
+        <FieldInput
+          attributes={restAttributes}
+          contacts={contacts}
+          error={error}
+          helperText={helperText}
+          name={name}
+          label={t(`Contacts.AddModal.ContactForm.fields.${name}`)}
+          labelProps={label}
+        />
+        <IconButton
+          className="u-ml-half"
+          size="medium"
+          onClick={() => setShowExtended(v => !v)}
+        >
+          <Icon icon={showExtended ? DropupIcon : DropdownIcon} />
+        </IconButton>
+      </div>
+      {subFields.map(({ name, ...attributes }, index) => {
+        return (
+          <FieldInput
+            key={index}
+            className={cx('u-mt-1', { 'u-dn': !showExtended })}
+            attributes={attributes}
+            name={name}
+            label={t(`Contacts.AddModal.ContactForm.fields.${name}`)}
+          />
+        )
+      })}
+    </>
+  )
+}
+
+export default FieldInputAccordion

--- a/react/Contacts/AddModal/ContactForm/FieldInputArray.jsx
+++ b/react/Contacts/AddModal/ContactForm/FieldInputArray.jsx
@@ -36,7 +36,7 @@ const FieldInputArray = ({
               return (
                 <div
                   key={key}
-                  className={cx('u-flex u-flex-items-center', {
+                  className={cx('u-flex u-flex-items-baseline', {
                     'u-mt-1': index !== 0
                   })}
                 >

--- a/react/Contacts/AddModal/ContactForm/FieldInputLayout.jsx
+++ b/react/Contacts/AddModal/ContactForm/FieldInputLayout.jsx
@@ -10,7 +10,7 @@ import Icon from '../../../Icon'
 import { useI18n, useExtendI18n } from '../../../providers/I18n'
 
 const FieldInputLayout = ({
-  attributes: { isArray, icon, ...attributes }, // ⚠️ isArray and icon here are removed from attributes to avoid DOM propagration
+  attributes: { layout, icon, ...attributes }, // ⚠️ layout and icon here are removed from attributes to avoid DOM propagration
   contacts,
   formProps
 }) => {
@@ -24,15 +24,15 @@ const FieldInputLayout = ({
   return (
     <div
       className={cx('u-flex u-mt-1', {
-        'u-flex-items-center': !isArray,
-        'u-flex-items-baseline': isArray
+        'u-flex-items-center': layout !== 'array',
+        'u-flex-items-baseline': layout === 'array'
       })}
     >
       <div className="u-w-2-half">
         {icon && <Icon icon={icon} color="var(--iconTextColor)" />}
       </div>
       <div className="u-w-100">
-        {isArray ? (
+        {layout === 'array' ? (
           <FieldInputArray
             attributes={attributes}
             contacts={contacts}

--- a/react/Contacts/AddModal/ContactForm/FieldInputLayout.jsx
+++ b/react/Contacts/AddModal/ContactForm/FieldInputLayout.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import FieldInput from './FieldInput'
+import FieldInputAccordion from './FieldInputAccordion'
 import FieldInputArray from './FieldInputArray'
 import { fieldsRequired } from './helpers'
 import { locales } from './locales'
@@ -24,8 +25,8 @@ const FieldInputLayout = ({
   return (
     <div
       className={cx('u-flex u-mt-1', {
-        'u-flex-items-center': layout !== 'array',
-        'u-flex-items-baseline': layout === 'array'
+        'u-flex-items-center': !layout,
+        'u-flex-items-baseline': !!layout
       })}
     >
       <div className="u-w-2-half">
@@ -37,6 +38,13 @@ const FieldInputLayout = ({
             attributes={attributes}
             contacts={contacts}
             formProps={formProps}
+          />
+        ) : layout === 'accordion' ? (
+          <FieldInputAccordion
+            attributes={attributes}
+            contacts={contacts}
+            error={isError}
+            helperText={isError ? errors[name] : null}
           />
         ) : (
           <FieldInput

--- a/react/Contacts/AddModal/ContactForm/FieldInputLayout.jsx
+++ b/react/Contacts/AddModal/ContactForm/FieldInputLayout.jsx
@@ -11,8 +11,9 @@ import Icon from '../../../Icon'
 import { useI18n, useExtendI18n } from '../../../providers/I18n'
 
 const FieldInputLayout = ({
-  attributes: { layout, icon, ...attributes }, // ⚠️ layout and icon here are removed from attributes to avoid DOM propagration
+  attributes: { layout, icon, isSecondary, ...attributes }, // ⚠️ `layout` `icon` `isSecondary` here are removed from attributes to avoid DOM propagration
   contacts,
+  showSecondaryFields,
   formProps
 }) => {
   useExtendI18n(locales)
@@ -26,7 +27,8 @@ const FieldInputLayout = ({
     <div
       className={cx('u-flex u-mt-1', {
         'u-flex-items-center': !layout,
-        'u-flex-items-baseline': !!layout
+        'u-flex-items-baseline': !!layout,
+        'u-dn': isSecondary && !showSecondaryFields
       })}
     >
       <div className="u-w-2-half">

--- a/react/Contacts/AddModal/ContactForm/contactToFormValues.js
+++ b/react/Contacts/AddModal/ContactForm/contactToFormValues.js
@@ -8,8 +8,8 @@ import { makeItemLabel, makeRelatedContact, movePrimaryToHead } from './helpers'
 const contactToFormValues = (contact, t) => {
   // initialize the form values, required so that array fields start with at least one editable field
   const initialFieldValues = fields.reduce(
-    (initialValues, { name, isArray }) => {
-      initialValues[name] = isArray ? [undefined] : undefined
+    (initialValues, { name, layout }) => {
+      initialValues[name] = layout === 'array' ? [undefined] : undefined
       return initialValues
     },
     {}

--- a/react/Contacts/AddModal/ContactForm/fieldsConfig.jsx
+++ b/react/Contacts/AddModal/ContactForm/fieldsConfig.jsx
@@ -66,6 +66,7 @@ export const fields = [
     name: 'phone',
     icon: TelephoneIcon,
     type: 'tel',
+    layout: 'array',
     label: {
       name: 'phoneLabel',
       select: true,
@@ -103,13 +104,13 @@ export const fields = [
           label: 'Contacts.AddModal.ContactForm.label.phone.fax-work'
         }
       ]
-    },
-    isArray: true
+    }
   },
   {
     name: 'email',
     icon: EmailIcon,
     type: 'email',
+    layout: 'array',
     label: {
       name: 'emailLabel',
       select: true,
@@ -131,13 +132,13 @@ export const fields = [
           label: 'Contacts.AddModal.ContactForm.label.work'
         }
       ]
-    },
-    isArray: true
+    }
   },
   {
     name: 'address',
     icon: LocationIcon,
     type: 'text',
+    layout: 'array',
     InputProps: {
       readOnly: true
     },
@@ -224,8 +225,7 @@ export const fields = [
           label: 'Contacts.AddModal.ContactForm.label.address.work'
         }
       ]
-    },
-    isArray: true
+    }
   },
   {
     name: 'cozy',
@@ -268,6 +268,7 @@ export const fields = [
   {
     name: 'relatedContact',
     icon: RelationshipIcon,
+    layout: 'array',
     InputProps: {
       readOnly: true,
       endAdornment: (
@@ -329,8 +330,7 @@ export const fields = [
           label: 'Contacts.AddModal.ContactForm.label.relationship.recipient'
         }
       ]
-    },
-    isArray: true
+    }
   },
   {
     name: 'note',

--- a/react/Contacts/AddModal/ContactForm/fieldsConfig.jsx
+++ b/react/Contacts/AddModal/ContactForm/fieldsConfig.jsx
@@ -234,9 +234,16 @@ export const fields = [
     }
   },
   {
+    name: 'note',
+    icon: CommentIcon,
+    type: 'text',
+    multiline: true
+  },
+  {
     name: 'cozy',
     icon: CloudIcon,
     type: 'url',
+    isSecondary: true,
     label: {
       name: 'cozyLabel',
       select: true,
@@ -264,17 +271,20 @@ export const fields = [
     name: 'birthday',
     icon: CalendarIcon,
     type: 'date',
+    isSecondary: true,
     InputLabelProps: { shrink: true }
   },
   {
     name: 'birthplace',
     icon: null,
-    type: 'text'
+    type: 'text',
+    isSecondary: true
   },
   {
     name: 'relatedContact',
     icon: RelationshipIcon,
     layout: 'array',
+    isSecondary: true,
     InputProps: {
       readOnly: true,
       endAdornment: (
@@ -337,11 +347,5 @@ export const fields = [
         }
       ]
     }
-  },
-  {
-    name: 'note',
-    icon: CommentIcon,
-    type: 'text',
-    multiline: true
   }
 ]

--- a/react/Contacts/AddModal/ContactForm/fieldsConfig.jsx
+++ b/react/Contacts/AddModal/ContactForm/fieldsConfig.jsx
@@ -35,12 +35,20 @@ export const fields = [
   {
     name: 'givenName',
     icon: null,
-    type: 'text'
-  },
-  {
-    name: 'additionalName',
-    icon: null,
-    type: 'text'
+    type: 'text',
+    layout: 'accordion',
+    subFields: [
+      {
+        name: 'additionalName',
+        icon: null,
+        type: 'text'
+      },
+      {
+        name: 'surname',
+        icon: null,
+        type: 'text'
+      }
+    ]
   },
   {
     name: 'familyName',
@@ -48,19 +56,17 @@ export const fields = [
     type: 'text'
   },
   {
-    name: 'surname',
-    icon: null,
-    type: 'text'
-  },
-  {
     name: 'company',
     icon: CompanyIcon,
-    type: 'text'
-  },
-  {
-    name: 'jobTitle',
-    icon: null,
-    type: 'text'
+    type: 'text',
+    layout: 'accordion',
+    subFields: [
+      {
+        name: 'jobTitle',
+        icon: null,
+        type: 'text'
+      }
+    ]
   },
   {
     name: 'phone',

--- a/react/Contacts/AddModal/ContactForm/index.jsx
+++ b/react/Contacts/AddModal/ContactForm/index.jsx
@@ -1,5 +1,5 @@
 import arrayMutators from 'final-form-arrays'
-import React from 'react'
+import React, { useState } from 'react'
 import { Form } from 'react-final-form'
 
 import { getHasManyItems } from 'cozy-client/dist/associations/HasMany'
@@ -10,6 +10,7 @@ import { fields } from './fieldsConfig'
 import formValuesToContact from './formValuesToContact'
 import { validateFields } from './helpers'
 import { locales } from './locales'
+import Button from '../../../Buttons'
 import { useI18n, useExtendI18n } from '../../../providers/I18n'
 // import { fullContactPropTypes } from '../../ContactPropTypes' // !!
 
@@ -36,6 +37,7 @@ export function getSubmitContactForm() {
  * @returns
  */
 const ContactForm = ({ contact, onSubmit, contacts }) => {
+  const [showSecondaryFields, setShowSecondaryFields] = useState(false)
   useExtendI18n(locales)
   const { t } = useI18n()
 
@@ -60,6 +62,7 @@ const ContactForm = ({ contact, onSubmit, contacts }) => {
                 key={index}
                 attributes={attributes}
                 contacts={contacts}
+                showSecondaryFields={showSecondaryFields}
                 formProps={{
                   valid,
                   submitFailed,
@@ -67,6 +70,16 @@ const ContactForm = ({ contact, onSubmit, contacts }) => {
                 }}
               />
             ))}
+            {!showSecondaryFields && (
+              <div>
+                <Button
+                  className="u-db u-ml-2 u-mt-1"
+                  variant="text"
+                  label={t('Contacts.AddModal.ContactForm.other-fields')}
+                  onClick={() => setShowSecondaryFields(true)}
+                />
+              </div>
+            )}
           </form>
         )
       }}

--- a/react/Contacts/AddModal/ContactForm/locales/en.json
+++ b/react/Contacts/AddModal/ContactForm/locales/en.json
@@ -6,6 +6,7 @@
           "man": "Man",
           "woman": "Woman"
         },
+        "other-fields": "Other fields",
         "fields": {
           "gender": "Civility",
           "givenName": "Firstname",

--- a/react/Contacts/AddModal/ContactForm/locales/fr.json
+++ b/react/Contacts/AddModal/ContactForm/locales/fr.json
@@ -6,6 +6,7 @@
           "man": "Homme",
           "woman": "Femme"
         },
+        "other-fields": "Autres champs",
         "fields": {
           "gender": "Civilité",
           "givenName": "Prénom",

--- a/react/Contacts/AddModal/types.js
+++ b/react/Contacts/AddModal/types.js
@@ -22,7 +22,7 @@ export const fieldInputAttributesTypes = PropTypes.shape({
   icon: iconPropType,
   type: PropTypes.string,
   label: labelPropTypes,
-  isArray: PropTypes.bool,
+  layout: PropTypes.string,
   subFields: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,


### PR DESCRIPTION
We want to hide some "not so important" fields in the contact form.

One way is to add a sort of accordion in the main field (like Company) to show its subfields (like Job Title).
Other way is we added a new button at the bottom of the form to show secondary fields (Twake URL, Related contacts ...).

Small subtlety: the hidden fields are still in the DOM, we just not displaying them, to be more compliant with old way.

demo: https://jf-cozy.github.io/cozy-ui/react/#/Contacts/AddModal

**behavior validated by Swann** ✅ 