### PR TITLE
fix(Sidebar): Show scrollbar every time, not only on hover

### DIFF
--- a/stylus/objects/sidebar.styl
+++ b/stylus/objects/sidebar.styl
@@ -11,14 +11,11 @@
 $sidebar
     width rem(236)
     background-color var(--defaultBackgroundColor)
-    overflow-y hidden
+    overflow-y auto
     overflow-x hidden
     display flex
     flex-direction column
     flex 0 0 auto
-
-    &:hover
-        overflow-y auto
 
     &--border
         border-right rem(1) solid var(--dividerColor)


### PR DESCRIPTION
When the scrollbar appaers, it shift all content. Using
`scrollbar-gutter` doesn't help because the content will not be
centered