### PR TITLE
feat(AlertProvider): Add `noClickAway` and `noTimeOut` prop

### DIFF
--- a/react/providers/Alert/Readme.md
+++ b/react/providers/Alert/Readme.md
@@ -15,6 +15,8 @@ const initialVariants = [{
   square: false,
   standard: false,
   outlined: false,
+  noClickAway: false,
+  noTimeOut: false,
   close: true
 }]
 
@@ -23,7 +25,7 @@ const Component = ({ variant }) => {
 
   return (
     <Button
-      label="show alert"
+      label="Show alert"
       onClick={() =>
         showAlert({
           title: variant.title ? 'Alert title' : undefined,
@@ -42,6 +44,8 @@ const Component = ({ variant }) => {
             : variant.largeIcon
             ? <Icon icon={DeviceLaptopIcon} size={32} />
             : undefined,
+          noClickAway: variant.noClickAway,
+          noTimeOut: variant.noTimeOut,
           onClose: variant.close ? () => {} : undefined
         })
       }

--- a/react/providers/Alert/helpers.js
+++ b/react/providers/Alert/helpers.js
@@ -1,0 +1,13 @@
+export const handleClose = (state, setState) => (event, reason) => {
+  const { noClickAway, noTimeOut } = state
+
+  if (reason === 'clickaway' && noClickAway) {
+    return
+  }
+
+  if (reason === 'timeout' && noTimeOut) {
+    return
+  }
+
+  return setState({ ...state, open: false })
+}

--- a/react/providers/Alert/index.jsx
+++ b/react/providers/Alert/index.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useState, useContext, useMemo } from 'react'
 
+import { handleClose } from './helpers'
 import Alert from '../../Alert'
 import AlertTitle from '../../AlertTitle'
 import Snackbar from '../../Snackbar'
@@ -32,13 +33,19 @@ const defaultState = {
   duration: null,
   open: false
 }
-const handleClose = (state, setState) => () => {
-  return setState({ ...state, open: false })
-}
 
 const AlertProvider = ({ children }) => {
   const [state, setState] = useState(defaultState)
-  const { open, message, title, duration, ...alertProps } = state
+  // noTimeOut and noClickAway are destructured to not being passed to the DOM through ...alertProps
+  const {
+    open,
+    message,
+    title,
+    duration,
+    noTimeOut, // eslint-disable-line no-unused-vars
+    noClickAway, // eslint-disable-line no-unused-vars
+    ...alertProps
+  } = state
 
   const value = useMemo(
     () => ({
@@ -63,7 +70,7 @@ const AlertProvider = ({ children }) => {
         <Alert
           variant="filled"
           elevation={6}
-          onClose={handleClose(state, setState)}
+          onClose={ev => handleClose(state, setState)(ev, 'click')}
           {...alertProps}
         >
           {title && <AlertTitle>{title}</AlertTitle>}


### PR DESCRIPTION
to disable closing when clicking away or waiting the timeout. I moved the handleClose func in a helper file to avoid styleguide messing with func name