### PR TITLE
refactor(AlertProvider): clarify default duration handling

### DIFF
--- a/react/providers/Alert/Readme.md
+++ b/react/providers/Alert/Readme.md
@@ -17,6 +17,7 @@ const initialVariants = [{
   outlined: false,
   noClickAway: false,
   noTimeOut: false,
+  persistent: false,
   close: true
 }]
 
@@ -46,6 +47,7 @@ const Component = ({ variant }) => {
             : undefined,
           noClickAway: variant.noClickAway,
           noTimeOut: variant.noTimeOut,
+          duration: variant.persistent ? null : undefined,
           onClose: variant.close ? () => {} : undefined
         })
       }

--- a/react/providers/Alert/index.jsx
+++ b/react/providers/Alert/index.jsx
@@ -30,7 +30,6 @@ export const useAlert = () => {
 const defaultState = {
   title: '',
   message: '',
-  duration: null,
   open: false
 }
 
@@ -53,7 +52,7 @@ const AlertProvider = ({ children }) => {
        * @param {ShowAlertArgs} args
        */
       showAlert: args => {
-        setState({ open: true, ...args })
+        setState({ ...defaultState, ...args, open: true })
       }
     }),
     []

--- a/react/providers/Alert/index.spec.jsx
+++ b/react/providers/Alert/index.spec.jsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+
+import AlertProvider, { useAlert } from '.'
+import Alert from '../../Alert'
+import Snackbar from '../../Snackbar'
+
+jest.mock('../../Snackbar', () => ({
+  __esModule: true,
+  default: jest.fn(({ children }) => children)
+}))
+jest.mock('../../Alert', () => ({
+  __esModule: true,
+  default: jest.fn(() => null)
+}))
+
+const setup = () => {
+  const { result } = renderHook(() => useAlert(), { wrapper: AlertProvider })
+  const lastProps = mock => mock.mock.calls[mock.mock.calls.length - 1][0]
+  return {
+    showAlert: args => act(() => result.current.showAlert(args)),
+    lastSnackbarProps: () => lastProps(Snackbar),
+    lastAlertProps: () => lastProps(Alert)
+  }
+}
+
+describe('AlertProvider > showAlert', () => {
+  beforeEach(() => {
+    Snackbar.mockClear()
+    Alert.mockClear()
+  })
+
+  it('should leave autoHideDuration undefined when caller omits duration', () => {
+    const { showAlert, lastSnackbarProps } = setup()
+
+    showAlert({ message: 'An error' })
+
+    expect(lastSnackbarProps().open).toBe(true)
+    expect(lastSnackbarProps().autoHideDuration).toBeUndefined()
+  })
+
+  it('should forward a numeric duration to Snackbar', () => {
+    const { showAlert, lastSnackbarProps } = setup()
+
+    showAlert({ message: 'hi', duration: 3000 })
+
+    expect(lastSnackbarProps().autoHideDuration).toBe(3000)
+  })
+
+  it('should forward an explicit null duration to disable auto-hide', () => {
+    const { showAlert, lastSnackbarProps } = setup()
+
+    showAlert({ message: 'sticky', duration: null })
+
+    expect(lastSnackbarProps().autoHideDuration).toBeNull()
+  })
+
+  it('should not carry caller-provided fields over to a later call that omits them', () => {
+    const { showAlert, lastAlertProps } = setup()
+
+    showAlert({ message: 'first', severity: 'error' })
+    showAlert({ message: 'second' })
+
+    expect(lastAlertProps().severity).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Context

`AlertProvider`'s `defaultState` declared `duration: null`, which reads as "alerts are persistent by default". The actual default behavior is a 2s auto-dismiss — `null` was MUI plumbing (`Snackbar` treats it as "disabled"), never an API contract.

## Change

Drop the misleading default. The 2s auto-dismiss keeps applying as before; explicit `duration: null` remains the documented opt-out for persistent alerts. Tests pin the three duration paths.

No user-visible behavior change.