### PR TITLE
feat: Change overline style

### DIFF
--- a/react/MuiCozyTheme/makeTypography.js
+++ b/react/MuiCozyTheme/makeTypography.js
@@ -69,10 +69,10 @@ export const makeTypography = () => ({
     letterSpacing: '0.5px'
   },
   overline: {
-    fontSize: 11,
-    fontWeight: 500,
-    lineHeight: '16px',
-    letterSpacing: '0.5px',
+    fontSize: 10,
+    fontWeight: 700,
+    lineHeight: '13px',
+    letterSpacing: '0',
     textTransform: 'inherit'
   }
 })


### PR DESCRIPTION
This is part of the migration to the new sidebar.
It is hard to put this change in a new component or behind a flag but since the overline variant is only used in a small unnoticable part of drive application, I think it is quite safe to do it now.