### PR TITLE
Table: add double click

### DIFF
--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -15,7 +15,7 @@ const createData = (id, name, calories, fat, carbs, protein) => {
 
 const rows = [
   createData(0, 'Cupcake', 305, 3.7, 67, 4.3),
-  createData(1, 'Frozen yoghurt', 159, 6.0, 24, 4.0),
+  createData(1, 'Frozen yoghurt (unselectable)', 159, 6.0, 24, 4.0),
   createData(2, 'Donut', 452, 25.0, 51, 4.9),
   createData(3, 'Eclair', 262, 16.0, 24, 6.0),
   createData(4, 'Ice cream sandwich', 237, 9.0, 37, 4.3),
@@ -108,12 +108,20 @@ const ExampleTable = ({ variant, ...props }) => {
           componentsProps={{
             rowContent: {
               onClick: (row, column) => {
-                row.id !== 1 ? toggleSelectedItem(row.id) : undefined
+                row.id !== 1
+                  ? toggleSelectedItem(row.id)
+                  : undefined
               },
               onDoubleClick: (row, column) => {
-                console.info(`double click on cell. Row ${row['id']}, Column ${column['id']}`)
+                row.id !== 1
+                  ? console.info(`double click on cell. Row ${row['id']}, Column ${column['id']}`)
+                  : undefined
               },
-              onLongPress: (row, column) => { console.info(`long press on cell. Row ${row['id']}, Column ${column['id']}`) },
+              onLongPress: (row, column) => {
+                row.id !== 1
+                  ? console.info(`long press on cell. Row ${row['id']}, Column ${column['id']}`)
+                  : undefined
+              },
             },
           }}
         />

--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -95,7 +95,7 @@ const ExampleTable = ({ variant, ...props }) => {
         groups={variant.grouped ? makeGroups : undefined}
         selectedItems={selectedItemsId}
         isSelectedItem={row => isSelectedItem(row.id)}
-        onSelect={(row, event, index) => toggleSelectedItem(row.id)}
+        onSelect={(row, event, index) => row.id !== 1 ? toggleSelectedItem(row.id) : undefined}
         onSelectAll={rows => toggleSelectAllItems(rows.map(item => item.id !== 1 ? item.id : undefined))}
         onSortChange={onSortChange}
         withCheckbox={variant.withCheckbox}
@@ -104,7 +104,7 @@ const ExampleTable = ({ variant, ...props }) => {
             disableCheckbox: row => row.id === 1,
             onClick: (row, column) => {
               if (!variant.withCheckbox) {
-                return toggleSelectedItem(row.id)
+                return row.id !== 1 ? toggleSelectedItem(row.id) : undefined
               }
               console.info(`click on cell. Row ${row['id']}, Column ${column['id']}`)
             },

--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import VirtualizedTable from 'cozy-ui/transpiled/react/Table/Virtualized'
 import Variants from 'cozy-ui/docs/components/Variants'
 import Button from 'cozy-ui/transpiled/react/Buttons'
+import Stack from 'cozy-ui/transpiled/react/Stack'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import SelectionProvider, { useSelection } from 'cozy-ui/transpiled/react/providers/Selection'
 
@@ -125,7 +126,7 @@ const ExampleTable = ({ variant, ...props }) => {
   {variant => (
     <>
       <Typography variant="h4">Not sorted table</Typography>
-      <div className="u-mt-half" style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%" }}>
+      <div className="u-mt-half" style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%", marginBottom: "6rem" }}>
         <SelectionProvider>
           <ExampleTable variant={variant} />
         </SelectionProvider>

--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -140,3 +140,86 @@ const ExampleTable = ({ variant, ...props }) => {
   )}
 </Variants>
 ```
+
+### With Drag'n'Drop
+
+```jsx
+import { useState } from 'react'
+import VirtualizedTableDnd from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import SelectionProvider, { useSelection } from 'cozy-ui/transpiled/react/providers/Selection'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
+
+const createData = (_id, name, calories, fat, carbs, protein) => {
+  return { _id, name, calories, fat, carbs, protein }
+}
+
+const rows = [
+  createData(0, 'Cupcake', 305, 3.7, 67, 4.3),
+  createData(1, 'Frozen yoghurt', 159, 6.0, 24, 4.0),
+  createData(2, 'Donut', 452, 25.0, 51, 4.9),
+  createData(3, 'Eclair', 262, 16.0, 24, 6.0),
+  createData(4, 'Ice cream sandwich', 237, 9.0, 37, 4.3),
+  createData(5, 'Gingerbread', 356, 16.0, 49, 3.9),
+  createData(6, 'Honeycomb', 408, 3.2, 87, 6.5),
+  createData(7, 'Jelly Bean', 375, 0.0, 94, 0.0),
+  createData(8, 'KitKat', 518, 26.0, 65, 7.0),
+  createData(9, 'Oreo', 437, 18.0, 63, 4.0),
+]
+
+const columns = [
+  { id: 'name', disablePadding: false, label: 'Dessert' },
+  { id: 'calories', disablePadding: false, width: 80, label: 'Calories', textAlign: 'left' },
+  { id: 'fat', disablePadding: false, width: 85, label: 'Fat (g)', textAlign: 'right' },
+  { id: 'carbs', disablePadding: false, width: 115, label: 'Carbs (g)', textAlign: 'right' },
+  { id: 'protein', disablePadding: false, width: 115, label: 'Protein (g)', textAlign: 'right', disableClick: true }
+]
+
+const DndExample = () => {
+  const { selectedItemsId, isSelectedItem, toggleSelectedItem } = useSelection()
+
+  const dragProps = {
+    dragId: 'dessert-dnd',
+    onDrop: async (draggedItems, targetItem, selectedItems) => {
+      console.info('Dropped items:', draggedItems)
+      console.info('Target item:', targetItem)
+    },
+    canDrag: (item) => item.calories > 100,
+    canDrop: (item) => item.fat < 20,
+  }
+
+  return (
+    <div style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%" }}>
+      <VirtualizedTableDnd
+        rows={rows}
+        columns={columns}
+        dragProps={dragProps}
+        selectedItems={selectedItemsId}
+        isSelectedItem={row => isSelectedItem(row._id)}
+        componentsProps={{
+          rowContent: {
+            onClick: (row, column) => toggleSelectedItem(row._id),
+            onDoubleClick: (row, column) => {
+              console.info(`double click on cell. Row ${row['_id']}, Column ${column['id']}`)
+            },
+            onLongPress: (row, column) => { console.info(`long press on cell. Row ${row['_id']}, Column ${column['id']}`) },
+          },
+        }}
+      />
+    </div>
+  )
+}
+
+;
+
+<>
+  <div className="u-mt-half" style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%" }}>
+    <SelectionProvider>
+      <DndProvider backend={HTML5Backend}>
+        <DndExample />
+      </DndProvider>
+    </SelectionProvider>
+  </div>
+</>
+```

--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -108,6 +108,9 @@ const ExampleTable = ({ variant, ...props }) => {
               }
               console.info(`click on cell. Row ${row['id']}, Column ${column['id']}`)
             },
+            onDoubleClick: (row, column) => {
+              console.info(`double click on cell. Row ${row['id']}, Column ${column['id']}`)
+            },
             onLongPress: (row, column) => { console.info(`long press on cell. Row ${row['id']}, Column ${column['id']}`) },
           },
         }}

--- a/react/Table/Readme.md
+++ b/react/Table/Readme.md
@@ -4,6 +4,7 @@
 import { useState } from 'react'
 import VirtualizedTable from 'cozy-ui/transpiled/react/Table/Virtualized'
 import Variants from 'cozy-ui/docs/components/Variants'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import SelectionProvider, { useSelection } from 'cozy-ui/transpiled/react/providers/Selection'
 
@@ -38,7 +39,7 @@ const rows = [
 const columns = [
   {
     id: 'name',
-    disablePadding: true,
+    disablePadding: false,
     label: 'Dessert'
   },
   {
@@ -73,7 +74,7 @@ const columns = [
   }
 ]
 
-const initialVariants = [{ grouped: false, withCheckbox: true }, { grouped: false, withCheckbox: false }]
+const initialVariants = [{ grouped: false}]
 
 // Very basic usage only works when Dessert is sorted "asc"
 // Ideally you have to create a logic to create groups with sorted data
@@ -87,34 +88,35 @@ const ExampleTable = ({ variant, ...props }) => {
   }
 
   return (
-    <div style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%" }}>
-      <VirtualizedTable
-        {...props}
-        rows={rows}
-        columns={columns}
-        groups={variant.grouped ? makeGroups : undefined}
-        selectedItems={selectedItemsId}
-        isSelectedItem={row => isSelectedItem(row.id)}
-        onSelect={(row, event, index) => row.id !== 1 ? toggleSelectedItem(row.id) : undefined}
-        onSelectAll={rows => toggleSelectAllItems(rows.map(item => item.id !== 1 ? item.id : undefined))}
-        onSortChange={onSortChange}
-        withCheckbox={variant.withCheckbox}
-        componentsProps={{
-          rowContent: {
-            disableCheckbox: row => row.id === 1,
-            onClick: (row, column) => {
-              if (!variant.withCheckbox) {
-                return row.id !== 1 ? toggleSelectedItem(row.id) : undefined
-              }
-              console.info(`click on cell. Row ${row['id']}, Column ${column['id']}`)
-            },
-            onDoubleClick: (row, column) => {
-              console.info(`double click on cell. Row ${row['id']}, Column ${column['id']}`)
-            },
-            onLongPress: (row, column) => { console.info(`long press on cell. Row ${row['id']}, Column ${column['id']}`) },
-          },
-        }}
+    <div>
+      <Button
+        className="u-mt-1 u-mb-1"
+        variant="ghost"
+        label="Select all"
+        onClick={() => toggleSelectAllItems(rows.map(item => item.id !== 1 ? item.id : undefined))}
       />
+      <div style={{ border: "1px solid var(--borderMainColor)", height: 400, width: "100%" }}>
+        <VirtualizedTable
+          {...props}
+          rows={rows}
+          columns={columns}
+          groups={variant.grouped ? makeGroups : undefined}
+          selectedItems={selectedItemsId}
+          isSelectedItem={row => isSelectedItem(row.id)}
+          onSortChange={onSortChange}
+          componentsProps={{
+            rowContent: {
+              onClick: (row, column) => {
+                row.id !== 1 ? toggleSelectedItem(row.id) : undefined
+              },
+              onDoubleClick: (row, column) => {
+                console.info(`double click on cell. Row ${row['id']}, Column ${column['id']}`)
+              },
+              onLongPress: (row, column) => { console.info(`long press on cell. Row ${row['id']}, Column ${column['id']}`) },
+            },
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/react/Table/Virtualized/Cell.jsx
+++ b/react/Table/Virtualized/Cell.jsx
@@ -4,6 +4,7 @@ import { useOnLongPress } from 'rooks'
 
 import TableCell from '../../TableCell'
 import { makeStyles } from '../../styles'
+import { AddPropsToChildren } from '../../utils/react'
 
 const useStyles = makeStyles({
   root: {
@@ -51,16 +52,12 @@ const Cell = ({ row, columns, column, onClick, onLongPress, children }) => {
       onContextMenu={isLongPress ? ev => ev.preventDefault() : undefined}
     >
       {children
-        ? React.Children.map(children, child =>
-            React.isValidElement(child)
-              ? React.cloneElement(child, {
-                  row,
-                  columns,
-                  column,
-                  cell: cellContent
-                })
-              : null
-          )
+        ? AddPropsToChildren(children, () => ({
+            row,
+            columns,
+            column,
+            cell: cellContent
+          }))
         : cellContent}
     </TableCell>
   )

--- a/react/Table/Virtualized/Cell.jsx
+++ b/react/Table/Virtualized/Cell.jsx
@@ -6,6 +6,8 @@ import TableCell from '../../TableCell'
 import { makeStyles } from '../../styles'
 import { AddPropsToChildren } from '../../utils/react'
 
+const DOUBLECLICKDELAY = 400
+
 const useStyles = makeStyles({
   root: {
     cursor: ({ isClickable }) => (isClickable ? 'pointer' : undefined),
@@ -14,30 +16,49 @@ const useStyles = makeStyles({
   }
 })
 
-const Cell = ({ row, columns, column, onClick, onLongPress, children }) => {
+const Cell = ({
+  row,
+  columns,
+  column,
+  onClick,
+  onDoubleClick,
+  onLongPress,
+  children
+}) => {
   const [isLongPress, setIsLongPress] = useState(false) // onClick is triggered after a long press anyway, so we need this bool to avoid this behavior
+  const [lastClickTime, setLastClickTime] = useState(0)
 
   const classes = useStyles({ column, isClickable: !!onClick })
   const cellContent = get(row, column.id, '—')
 
-  const longPressRef = useOnLongPress(() => {
-    if (column.disableClick) {
-      return
-    }
+  const longPressRef = useOnLongPress(
+    () => {
+      if (column.disableClick) {
+        return
+      }
 
-    setIsLongPress(true)
-    onLongPress?.(row, column)
-  })
+      setIsLongPress(true)
+      onLongPress?.(row, column)
+    },
+    { duration: 300 }
+  )
 
   const handleClick = () => {
     if (column.disableClick) {
       return
     }
 
-    if (!isLongPress) {
-      onClick?.(row, column)
-    } else {
+    if (isLongPress) {
       setIsLongPress(false)
+      return
+    }
+
+    const currentTime = Date.now()
+    const isDoubleClick = currentTime - lastClickTime < DOUBLECLICKDELAY
+    setLastClickTime(currentTime)
+
+    if (!isDoubleClick) {
+      onClick?.(row, column)
     }
   }
 
@@ -49,6 +70,7 @@ const Cell = ({ row, columns, column, onClick, onLongPress, children }) => {
       align={column.textAlign ?? 'left'}
       padding={column.disablePadding ? 'none' : 'normal'}
       onClick={handleClick}
+      onDoubleClick={() => onDoubleClick?.(row, column)}
       onContextMenu={isLongPress ? ev => ev.preventDefault() : undefined}
     >
       {children

--- a/react/Table/Virtualized/FixedHeaderContent.jsx
+++ b/react/Table/Virtualized/FixedHeaderContent.jsx
@@ -1,9 +1,6 @@
-import cx from 'classnames'
 import React from 'react'
 
 import TableHeadCell from './HeadCell'
-import Checkbox from '../../Checkbox'
-import TableCell from '../../TableCell'
 import TableRow from '../../TableRow'
 import { makeStyles } from '../../styles'
 
@@ -21,34 +18,11 @@ const useStyles = makeStyles({
   }
 })
 
-const FixedHeaderContent = ({
-  columns,
-  orderDirection,
-  orderBy,
-  rowCount,
-  context,
-  onClick,
-  onSelectAllClick
-}) => {
+const FixedHeaderContent = ({ columns, orderDirection, orderBy, onClick }) => {
   const classes = useStyles()
-  const selectedCount = context.selectedItems.length
 
   return (
     <TableRow>
-      {context.withCheckbox && (
-        <TableCell align="center" padding="checkbox">
-          <Checkbox
-            className={cx('virtualizedCheckbox', {
-              checked: selectedCount > 0
-            })}
-            indeterminate={selectedCount > 0 && selectedCount < rowCount}
-            checked={rowCount > 0 && selectedCount === rowCount}
-            inputProps={{ 'aria-label': 'select all' }}
-            size="small"
-            onChange={onSelectAllClick}
-          />
-        </TableCell>
-      )}
       {columns.map(column => (
         <TableHeadCell
           key={column.id}

--- a/react/Table/Virtualized/RowContent.jsx
+++ b/react/Table/Virtualized/RowContent.jsx
@@ -1,43 +1,17 @@
-import cx from 'classnames'
 import React from 'react'
 
 import Cell from './Cell'
-import Checkbox from '../../Checkbox'
-import TableCell from '../../TableCell'
 
 const RowContent = ({
-  index,
   row,
   columns,
-  context,
   children,
-  disableCheckbox,
-  onSelectClick,
   onLongPress,
   onDoubleClick,
   onClick
 }) => {
-  const selectedCount = context.selectedItems.length
-
   return (
     <>
-      {context.withCheckbox && (
-        <TableCell align="center" padding="checkbox">
-          <Checkbox
-            className={cx('virtualizedCheckbox', {
-              visible: selectedCount > 0,
-              checked: context.isSelectedItem(row)
-            })}
-            disabled={disableCheckbox?.(row)}
-            checked={context.isSelectedItem(row)}
-            inputProps={{
-              'aria-labelledby': `enhanced-table-checkbox-${index}`
-            }}
-            size="small"
-            onClick={event => onSelectClick(row, event, index)}
-          />
-        </TableCell>
-      )}
       {columns.map(column => (
         <Cell
           key={column.id}

--- a/react/Table/Virtualized/RowContent.jsx
+++ b/react/Table/Virtualized/RowContent.jsx
@@ -14,6 +14,7 @@ const RowContent = ({
   disableCheckbox,
   onSelectClick,
   onLongPress,
+  onDoubleClick,
   onClick
 }) => {
   const selectedCount = context.selectedItems.length
@@ -44,6 +45,7 @@ const RowContent = ({
           columns={columns}
           column={column}
           onClick={onClick}
+          onDoubleClick={onDoubleClick}
           onLongPress={onLongPress}
         >
           {children}

--- a/react/Table/Virtualized/index.jsx
+++ b/react/Table/Virtualized/index.jsx
@@ -17,15 +17,12 @@ const VirtualizedTable = forwardRef(
       defaultOrder,
       secondarySort,
       selectedItems,
-      onSelect,
-      onSelectAll,
       isSelectedItem,
       componentsProps,
       context,
       components,
       onSortChange,
       isNewItem,
-      withCheckbox,
       ...props
     },
     ref
@@ -46,9 +43,7 @@ const VirtualizedTable = forwardRef(
       ...(isGroupedTable && { data }), // we use directly `data` prop if no groupCounts
       isSelectedItem,
       selectedItems,
-      isNewItem,
-      withCheckbox,
-      onSelect
+      isNewItem
     }
 
     const handleSort = property => {
@@ -57,14 +52,6 @@ const VirtualizedTable = forwardRef(
       setOrderDirection(newOrder)
       setOrderBy(property)
       onSortChange?.({ order: newOrder, orderBy: property })
-    }
-
-    const handleSelectAll = event => {
-      if (event?.target?.checked) {
-        onSelectAll(rows)
-        return
-      }
-      onSelectAll([])
     }
 
     const Component = isGroupedTable ? GroupedTableVirtuoso : TableVirtuoso
@@ -86,7 +73,6 @@ const VirtualizedTable = forwardRef(
             orderDirection={orderDirection}
             orderBy={orderBy}
             onClick={handleSort}
-            onSelectAllClick={handleSelectAll}
           />
         )}
         {...(isGroupedTable && {
@@ -103,7 +89,6 @@ const VirtualizedTable = forwardRef(
             row={data[index]}
             columns={columns}
             context={_context}
-            onSelectClick={onSelect}
           >
             {componentsProps?.rowContent?.children}
           </RowContent>
@@ -118,10 +103,7 @@ VirtualizedTable.displayName = 'VirtualizedTable'
 
 VirtualizedTable.defaultProps = {
   selectedItems: [],
-  isSelectedItem: () => {},
-  onSelect: () => {},
-  onSelectAll: () => {},
-  withCheckbox: true
+  isSelectedItem: () => {}
 }
 
 VirtualizedTable.propTypes = {
@@ -146,18 +128,12 @@ VirtualizedTable.propTypes = {
   secondarySort: PropTypes.func,
   /** Array of selected items */
   selectedItems: PropTypes.array,
-  /** Callback function when a row is selected */
-  onSelect: PropTypes.func,
-  /** Callback function when all rows are selected/deselected */
-  onSelectAll: PropTypes.func,
   /** Function to determine if a row is selected */
   isSelectedItem: PropTypes.func,
   /** Callback called after the sort */
   onSortChange: PropTypes.func,
   /** Function to determine if a row is new */
-  isNewItem: PropTypes.func,
-  /** Whether to show checkboxes. When false, rows become clickable for selection */
-  withCheckbox: PropTypes.bool
+  isNewItem: PropTypes.func
 }
 
 export default VirtualizedTable

--- a/skills/cozy-ui-reference/SKILL.md
+++ b/skills/cozy-ui-reference/SKILL.md
@@ -24,7 +24,7 @@ import 'cozy-ui/transpiled/react/stylesheet.css'
 
 ## What This Skill Provides
 
-- 88+ React components with examples and extracted props.
+- 89+ React components with examples and extracted props.
 - CSS utility classes for spacing, typography, colors, layout, and component-specific classes.
 - Cozy theming conventions built on Material-UI v4.
 - Import patterns for `cozy-ui/transpiled/react` and `cozy-ui/dist`.

--- a/skills/cozy-ui-reference/references/components.md
+++ b/skills/cozy-ui-reference/references/components.md
@@ -18,7 +18,7 @@ Generated reference for React components available in cozy-ui. Use this file to 
 - **Utils**: [DropdownText](#dropdowntext), [MuiCozyTheme](#muicozytheme)
 - **Hooks & Providers**: [Breakpoints (providers/Breakpoints)](#breakpoints-providers-breakpoints), [ConfirmDialog (providers/ConfirmDialog)](#confirmdialog-providers-confirmdialog), [CozyTheme (providers/CozyTheme)](#cozytheme-providers-cozytheme), [Selection (providers/Selection)](#selection-providers-selection), [useConfirmExit (hooks/useConfirmExit)](#useconfirmexit-hooks-useconfirmexit)
 - **Labs**: [IconGrid (Labs/IconGrid)](#icongrid-labs-icongrid), [Labs](#labs), [PasswordInput (Labs/PasswordInput)](#passwordinput-labs-passwordinput)
-- **Other**: [providers](#providers)
+- **Other**: [BottomSheet](#bottomsheet), [providers](#providers)
 
 ## Buttons
 
@@ -789,6 +789,7 @@ import ProgressionBanner from 'cozy-ui/transpiled/react/ProgressionBanner'
 | `icon` | React.node | - | Icon to be shown in the banner |
 | `button` | React.node | - | Button to use in the banner |
 | `progressBar` | boolean | `true` | Progression bar is hidden if set to false (defaults to true) |
+| `color` | string | `'var(--contrastBackgroundColor)'` | Background color of the banner, css color |
 
 
 ### Skeletons
@@ -1842,6 +1843,15 @@ import PasswordInput from 'cozy-ui/transpiled/react/Labs/PasswordInput'
 ---
 
 ## Other
+
+### BottomSheet
+
+Display content coming up from the bottom of the screen. The pane can be swiped to the top of the screen. Based on cozy / mui-bottom-sheet: API documentation is here. It uses Portal to have the same behavior as Dialogs / Modals (can be disabled with the disablePortal prop).
+
+```jsx
+import BottomSheet from 'cozy-ui/transpiled/react/BottomSheet'
+```
+
 
 ### providers
 


### PR DESCRIPTION
The browser fires click events before dblclick — there's no way to intercept or prevent the first click. The only alternative is delaying every click with a timer, which adds unwanted lag.
We accept this native behavior: double-click triggers click first, then double-click. Google does the same in Drive and Sheets — single-click selects, double-click opens.