### PR TITLE
ci: Upgrade GA to resolve Node.js version deprecation warnings

### DIFF
--- a/.github/actions/build_argos_desktop_cache/action.yml
+++ b/.github/actions/build_argos_desktop_cache/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Cache Argos desktop
       id: cache-argos-desktop
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-argos-desktop
       with:

--- a/.github/actions/build_argos_kss_cache/action.yml
+++ b/.github/actions/build_argos_kss_cache/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Cache Argos kss
       id: cache-argos-kss
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-argos-kss
       with:

--- a/.github/actions/build_argos_mobile_cache/action.yml
+++ b/.github/actions/build_argos_mobile_cache/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Cache Argos mobile
       id: cache-argos-mobile
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-argos-mobile
       with:

--- a/.github/actions/build_cache/action.yml
+++ b/.github/actions/build_cache/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Cache builds
       id: cache-builds
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-builds
       with:

--- a/.github/actions/build_cache_read/action.yml
+++ b/.github/actions/build_cache_read/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Read builds cache
       id: cache-builds-read
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       env:
         cache-name: cache-builds
       with:

--- a/.github/actions/setup_argos/action.yml
+++ b/.github/actions/setup_argos/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: ./.github/actions/setup_modules
     - name: Cache puppeteer
       id: cache-node-modules-puppeteer
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-node-modules-puppeteer
       with:

--- a/.github/actions/setup_modules/action.yml
+++ b/.github/actions/setup_modules/action.yml
@@ -3,12 +3,12 @@ name: "Setup modules"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
     - name: Cache node modules
       id: cache-node-modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-node-modules
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,19 +11,19 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_modules
   prepareArgos:
     needs: [install]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_argos
   build:
     needs: [install]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup_modules
@@ -44,7 +44,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_modules
       - uses: ./.github/actions/build_cache_read
       - name: BundleMon
@@ -56,7 +56,7 @@ jobs:
     needs: [prepareArgos, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_argos
       - uses: ./.github/actions/build_cache_read
       - uses: ./.github/actions/build_argos_desktop_cache
@@ -68,7 +68,7 @@ jobs:
     needs: [prepareArgos, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_argos
       - uses: ./.github/actions/build_cache_read
       - uses: ./.github/actions/build_argos_mobile_cache
@@ -80,7 +80,7 @@ jobs:
     needs: [prepareArgos, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_argos
       - uses: ./.github/actions/build_cache_read
       - uses: ./.github/actions/build_argos_kss_cache
@@ -92,7 +92,7 @@ jobs:
     needs: [argosDesktop, argosMobile, argosKss]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_argos
       - uses: ./.github/actions/build_argos_desktop_cache
       - uses: ./.github/actions/build_argos_mobile_cache
@@ -107,7 +107,7 @@ jobs:
     needs: [argosUpload, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup_modules


### PR DESCRIPTION
actions/checkout v4 -> v6
actions/setup-node v4 -> v6
actions/cache v4 -> v5