### PR TITLE
fix(Autocomplete): Small size is now the same as TextField component

### DIFF
--- a/react/Autocomplete/Readme.md
+++ b/react/Autocomplete/Readme.md
@@ -11,7 +11,13 @@ const options = ['one', 'two', 'three']
 <DemoProvider>
   <Autocomplete
     options={options}
-    renderInput={params => <TextField {...params} label="Basic" />}
+    renderInput={params => <TextField {...params} label="Basic" variant="outlined" />}
+  />
+  <Autocomplete
+    className="u-mt-1"
+    options={options}
+    size="small"
+    renderInput={params => <TextField {...params} label="Basic" variant="outlined" />}
   />
 </DemoProvider>
 ```

--- a/react/MuiCozyTheme/overrides/makeLightOverrides.js
+++ b/react/MuiCozyTheme/overrides/makeLightOverrides.js
@@ -959,6 +959,53 @@ export const makeLightOverrides = theme => ({
       padding: '8px 12px'
     }
   },
+  MuiAutocomplete: {
+    inputRoot: {
+      '&[class*="MuiInput-root"]': {
+        paddingBottom: undefined,
+        '& $input': {
+          padding: undefined
+        }
+      },
+      '&[class*="MuiInput-root"][class*="MuiInput-marginDense"]': {
+        '& $input': {
+          padding: undefined
+        },
+        '& $input:first-child': {
+          padding: undefined
+        }
+      },
+      '&[class*="MuiOutlinedInput-root"]': {
+        padding: undefined,
+        '& $input': {
+          padding: undefined
+        },
+        '& $input:first-child': {
+          paddingLeft: undefined
+        }
+      },
+      '&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-marginDense"]':
+        {
+          padding: undefined,
+          '& $input': {
+            padding: undefined
+          }
+        },
+      '&[class*="MuiFilledInput-root"]': {
+        paddingTop: undefined,
+        paddingLeft: undefined,
+        '& $input': {
+          padding: undefined
+        }
+      },
+      '&[class*="MuiFilledInput-root"][class*="MuiFilledInput-marginDense"]': {
+        paddingBottom: undefined,
+        '& $input': {
+          padding: undefined
+        }
+      }
+    }
+  },
   MuiIconButton: {
     root: {
       color: theme.palette.text.secondary,


### PR DESCRIPTION
Previously the small size of autocomplete was smaller than Textfield small.

demo: https://jf-cozy.github.io/cozy-ui/react/#/Autocomplete