### PR TITLE
fix: Force white for avatar color

### DIFF
--- a/react/Avatar/index.jsx
+++ b/react/Avatar/index.jsx
@@ -12,7 +12,7 @@ import {
 import { makeStyles } from '../styles'
 import { capitalize } from '../utils/index'
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
   root: {
     width: ({ size }) => size,
     height: ({ size }) => size,
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
   },
   colorDefault: {
     color: ({ color, textColor }) =>
-      textColor ? textColor : color ? theme.palette.primary.contrastText : '',
+      textColor ? textColor : color ? '#fff' : '', // We don't want avatar color to be theme responsive
     background: ({ color }) =>
       supportedColors.includes(color) ? colorMapping[color] : color
   }

--- a/react/MuiCozyTheme/helpers.js
+++ b/react/MuiCozyTheme/helpers.js
@@ -70,6 +70,9 @@ export const makeChipStyleByColor = (theme, color) => ({
           : alpha(theme.palette[color].main, theme.palette.action.hoverOpacity)
     }
   },
+  '& $avatar': {
+    color: '#fff' // We don't want avatar color to be theme responsive
+  },
   '& $icon': {
     color:
       color === 'primary' ? theme.palette.text.icon : theme.palette[color].main,


### PR DESCRIPTION
We don't want avatar color to be responsive. It is also what is done on stack side when we return an initial avatar from the stack.