### PR TITLE
fix(breakpoints)!: target the requesting iframe

### DIFF
--- a/react/providers/Breakpoints/index.jsx
+++ b/react/providers/Breakpoints/index.jsx
@@ -13,8 +13,8 @@ export const BreakpointsProvider = ({ parentBasedIframe, children }) => {
   const [breakpoints, setBreakpoints] = useState(
     getBreakpointsStatus(breakpointDefs)
   )
-  const { hasIframe } = useIframeConnection({ parentBasedIframe })
-  useIframeToSendWidth({ hasIframe })
+  const { iframeWindow } = useIframeConnection({ parentBasedIframe })
+  useIframeToSendWidth({ iframeWindow })
   const { parentBreakpoints } = useParentBreakpoints({ parentBasedIframe })
 
   useEffect(() => {

--- a/react/providers/Breakpoints/index.spec.jsx
+++ b/react/providers/Breakpoints/index.spec.jsx
@@ -1,0 +1,27 @@
+import { act, render } from '@testing-library/react'
+import React from 'react'
+
+import { BreakpointsProvider } from './index'
+
+it('sends parent breakpoints to the requesting iframe', () => {
+  const iframeWindow = { postMessage: jest.fn() }
+  const message = new MessageEvent('message', {
+    data: 'UI-breakpoints-needParentBreakpoints'
+  })
+  Object.defineProperty(message, 'source', { value: iframeWindow })
+
+  render(
+    <BreakpointsProvider>
+      <div />
+    </BreakpointsProvider>
+  )
+
+  act(() => {
+    window.dispatchEvent(message)
+  })
+
+  expect(iframeWindow.postMessage).toHaveBeenCalledWith(
+    `UI-breakpoints-value:${window.innerWidth}`,
+    '*'
+  )
+})

--- a/react/providers/Breakpoints/useIframeConnection.jsx
+++ b/react/providers/Breakpoints/useIframeConnection.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { isInsideIframe } from '../../helpers/breakpoints'
 
 export const useIframeConnection = ({ parentBasedIframe }) => {
-  const [hasIframe, setHasIframe] = useState(false)
+  const [iframeWindow, setIframeWindow] = useState(null)
 
   const isIframe = parentBasedIframe && isInsideIframe()
 
@@ -11,7 +11,7 @@ export const useIframeConnection = ({ parentBasedIframe }) => {
   useEffect(() => {
     const handleMessage = ev => {
       if (ev.data === 'UI-breakpoints-needParentBreakpoints') {
-        setHasIframe(true)
+        setIframeWindow(ev.source)
       }
     }
 
@@ -27,5 +27,5 @@ export const useIframeConnection = ({ parentBasedIframe }) => {
     }
   }, [isIframe])
 
-  return { hasIframe }
+  return { iframeWindow }
 }

--- a/react/providers/Breakpoints/useIframeToSendWidth.jsx
+++ b/react/providers/Breakpoints/useIframeToSendWidth.jsx
@@ -1,27 +1,19 @@
 import throttle from 'lodash/throttle'
 import { useEffect } from 'react'
 
-/**
- * To send window innerWidth to first iframe
- * @returns
- */
-const sendWidthToIframe = () =>
-  window.frames[1].postMessage(`UI-breakpoints-value:${window.innerWidth}`, '*')
+const sendWidthToIframe = iframeWindow =>
+  iframeWindow?.postMessage(`UI-breakpoints-value:${window.innerWidth}`, '*')
 
-export const useIframeToSendWidth = ({ hasIframe }) => {
+export const useIframeToSendWidth = ({ iframeWindow }) => {
   // parent window send its innerWidth
   useEffect(() => {
-    if (hasIframe) {
-      sendWidthToIframe()
-    }
-  }, [hasIframe])
+    sendWidthToIframe(iframeWindow)
+  }, [iframeWindow])
 
   // parent window send its innerWidth on resize
   useEffect(() => {
     const handleResize = throttle(() => {
-      if (hasIframe) {
-        sendWidthToIframe()
-      }
+      sendWidthToIframe(iframeWindow)
     }, 100)
 
     window.addEventListener('resize', handleResize)
@@ -29,5 +21,5 @@ export const useIframeToSendWidth = ({ hasIframe }) => {
     return () => {
       window.removeEventListener('resize', handleResize)
     }
-  }, [hasIframe])
+  }, [iframeWindow])
 }


### PR DESCRIPTION
## Summary

- Send parent breakpoint widths to the iframe that requested them instead of relying on a fixed frame index.
- **Breaking change:** replace the old hook usage with:

  ```js
  const { iframeWindow } = useIframeConnection({ parentBasedIframe })
  useIframeToSendWidth({ iframeWindow })
  ```

- Closes #2949.
